### PR TITLE
Add embedded library and IPC mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,18 @@ jobs:
         
     - name: Build
       run: make build-linux
+
+    - name: Build Linux loadable library
+      run: make build-lib-linux
       
     - name: Upload Linux artifact
       uses: actions/upload-artifact@v4
       with:
         name: patris-export-linux-amd64
-        path: build/patris-export-linux-amd64
+        path: |
+          build/patris-export-linux-amd64
+          build/libpatris-export.so
+          build/libpatris-export.h
 
   build-windows-mingw-cross:
     name: Build for Windows (MinGW cross-compile from Linux)
@@ -127,6 +133,14 @@ jobs:
         CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
           go build -ldflags "-X ${VERSION_PKG}.Version=1.0.0 -X ${VERSION_PKG}.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PKG}.Commit=${GITHUB_SHA::12}" \
           -o build/patris-export-windows-amd64.exe ./cmd/patris-export
+
+    - name: Build Windows loadable library
+      run: |
+        VERSION_PKG="github.com/atomicdeploy/patris-export/pkg/version"
+        CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
+          go build -buildmode=c-shared \
+          -ldflags "-X ${VERSION_PKG}.Version=1.0.0 -X ${VERSION_PKG}.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PKG}.Commit=${GITHUB_SHA::12}" \
+          -o build/patris-export.dll ./cmd/patris-export-lib
       
     - name: Copy pxlib DLL
       run: |
@@ -177,4 +191,6 @@ jobs:
         name: patris-export-windows-mingw-cross-amd64
         path: |
           build/patris-export-windows-amd64.exe
+          build/patris-export.dll
+          build/patris-export.h
           build/*.dll

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-linux build-windows build-all clean test run install install-linux uninstall-linux help deps build-web assets
+.PHONY: build build-linux build-windows build-all build-lib build-lib-linux build-lib-windows clean test run install install-linux uninstall-linux help deps build-web assets
 
 # Binary names
 BINARY_NAME=patris-export
@@ -31,11 +31,23 @@ build: build-web ## Build for current platform
 	CGO_ENABLED=1 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/patris-export
 	@echo "✅ Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
 
+build-lib: build-web ## Build loadable library for the current platform
+	@echo "Building patris-export loadable library..."
+	@mkdir -p $(BUILD_DIR)
+	CGO_ENABLED=1 go build -buildmode=c-shared $(LDFLAGS) -o $(BUILD_DIR)/patris-export-lib ./cmd/patris-export-lib
+	@echo "Build complete: $(BUILD_DIR)/patris-export-lib"
+
 build-linux: build-web ## Build for Linux
 	@echo "🐧 Building for Linux..."
 	@mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/patris-export
 	@echo "✅ Build complete: $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64"
+
+build-lib-linux: build-web ## Build Linux loadable library (.so)
+	@echo "Building Linux loadable library..."
+	@mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -buildmode=c-shared $(LDFLAGS) -o $(BUILD_DIR)/libpatris-export.so ./cmd/patris-export-lib
+	@echo "Build complete: $(BUILD_DIR)/libpatris-export.so"
 
 build-windows: assets build-web ## Build for Windows with CGO (builds pxlib from source)
 	@echo "🪟 Building for Windows with full Paradox support..."
@@ -63,6 +75,20 @@ build-windows: assets build-web ## Build for Windows with CGO (builds pxlib from
 		find /tmp/patris-pxlib-windows/bin -name "*.dll" -type f -exec cp {} $(BUILD_DIR)/ \; ; \
 	fi
 	@echo "✅ Build complete: $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe"
+
+build-lib-windows: assets build-web ## Build Windows loadable library (.dll)
+	@echo "Building Windows loadable library..."
+	@mkdir -p $(BUILD_DIR)
+	@if [ -n "$$PXLIB_ROOT" ]; then \
+		export CGO_CFLAGS="-I$$PXLIB_ROOT/include $${CGO_CFLAGS}"; \
+		export CGO_LDFLAGS="-L$$PXLIB_ROOT/lib $${CGO_LDFLAGS}"; \
+	fi; \
+	if command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then \
+		CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc go build -buildmode=c-shared $(LDFLAGS) -o $(BUILD_DIR)/patris-export.dll ./cmd/patris-export-lib; \
+	else \
+		CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -buildmode=c-shared $(LDFLAGS) -o $(BUILD_DIR)/patris-export.dll ./cmd/patris-export-lib; \
+	fi
+	@echo "Build complete: $(BUILD_DIR)/patris-export.dll"
 
 build-all: build-linux build-windows ## Build for all platforms
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ patris-export serve kala.db -a :8080
 ```
 
 Terminal WebSocket inspection with WebSocat is documented in [docs/examples/websocat.md](docs/examples/websocat.md).
+Embedding, loadable-library builds, and local IPC are documented in [docs/EMBEDDING.md](docs/EMBEDDING.md).
 
 Experimental RTL logical text conversion is available as an opt-in backend flag
 and web display setting. See [docs/RTL_CONVERSION.md](docs/RTL_CONVERSION.md).

--- a/cmd/patris-export-lib/main.go
+++ b/cmd/patris-export-lib/main.go
@@ -1,0 +1,170 @@
+package main
+
+/*
+#include <stdlib.h>
+#include <stdint.h>
+*/
+import "C"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/atomicdeploy/patris-export/pkg/embedded"
+	"github.com/atomicdeploy/patris-export/pkg/version"
+)
+
+var (
+	nextHandle uint64
+	handlesMu  sync.RWMutex
+	handles    = map[uint64]*embedded.Engine{}
+	lastErrMu  sync.Mutex
+	lastErr    string
+)
+
+func main() {}
+
+//export PatrisExportVersionJSON
+func PatrisExportVersionJSON() *C.char {
+	data, err := json.Marshal(version.Current())
+	if err != nil {
+		return C.CString(`{"error":"failed to encode version"}`)
+	}
+	return C.CString(string(data))
+}
+
+//export PatrisExportCreate
+func PatrisExportCreate(optionsJSON *C.char) C.uint64_t {
+	var options embedded.Options
+	if optionsJSON != nil {
+		raw := C.GoString(optionsJSON)
+		if raw != "" {
+			if err := json.Unmarshal([]byte(raw), &options); err != nil {
+				setLastError(fmt.Errorf("decode options: %w", err))
+				return 0
+			}
+		}
+	}
+	engine, err := embedded.New(options)
+	if err != nil {
+		setLastError(err)
+		return 0
+	}
+	handle := atomic.AddUint64(&nextHandle, 1)
+	handlesMu.Lock()
+	handles[handle] = engine
+	handlesMu.Unlock()
+	return C.uint64_t(handle)
+}
+
+//export PatrisExportClose
+func PatrisExportClose(handle C.uint64_t) C.int {
+	engine := takeHandle(uint64(handle))
+	if engine == nil {
+		setLastError(fmt.Errorf("invalid handle"))
+		return 0
+	}
+	if err := engine.Close(); err != nil {
+		setLastError(err)
+		return 0
+	}
+	return 1
+}
+
+//export PatrisExportCall
+func PatrisExportCall(handle C.uint64_t, requestJSON *C.char) *C.char {
+	engine := getHandle(uint64(handle))
+	if engine == nil {
+		setLastError(fmt.Errorf("invalid handle"))
+		return nil
+	}
+	if requestJSON == nil {
+		setLastError(fmt.Errorf("request JSON is required"))
+		return nil
+	}
+	response, err := engine.CallJSON(context.Background(), C.GoString(requestJSON))
+	if err != nil {
+		setLastError(err)
+		return nil
+	}
+	return C.CString(response)
+}
+
+//export PatrisExportStartHTTP
+func PatrisExportStartHTTP(handle C.uint64_t, addr *C.char) C.int {
+	engine := getHandle(uint64(handle))
+	if engine == nil {
+		setLastError(fmt.Errorf("invalid handle"))
+		return 0
+	}
+	value := ""
+	if addr != nil {
+		value = C.GoString(addr)
+	}
+	if err := engine.StartHTTP(value); err != nil {
+		setLastError(err)
+		return 0
+	}
+	return 1
+}
+
+//export PatrisExportStartIPC
+func PatrisExportStartIPC(handle C.uint64_t, path *C.char) *C.char {
+	engine := getHandle(uint64(handle))
+	if engine == nil {
+		setLastError(fmt.Errorf("invalid handle"))
+		return nil
+	}
+	value := ""
+	if path != nil {
+		value = C.GoString(path)
+	}
+	actualPath, err := engine.StartIPC(value)
+	if err != nil {
+		setLastError(err)
+		return nil
+	}
+	return C.CString(actualPath)
+}
+
+//export PatrisExportLastError
+func PatrisExportLastError() *C.char {
+	lastErrMu.Lock()
+	defer lastErrMu.Unlock()
+	return C.CString(lastErr)
+}
+
+//export PatrisExportFreeString
+func PatrisExportFreeString(value *C.char) {
+	if value != nil {
+		C.free(unsafe.Pointer(value))
+	}
+}
+
+func getHandle(handle uint64) *embedded.Engine {
+	handlesMu.RLock()
+	defer handlesMu.RUnlock()
+	return handles[handle]
+}
+
+func takeHandle(handle uint64) *embedded.Engine {
+	handlesMu.Lock()
+	defer handlesMu.Unlock()
+	engine := handles[handle]
+	delete(handles, handle)
+	return engine
+}
+
+func setLastError(err error) {
+	lastErrMu.Lock()
+	defer lastErrMu.Unlock()
+	if err == nil {
+		lastErr = ""
+		return
+	}
+	lastErr = err.Error()
+}

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -12,7 +16,9 @@ import (
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
 	"github.com/atomicdeploy/patris-export/pkg/converter"
+	"github.com/atomicdeploy/patris-export/pkg/embedded"
 	"github.com/atomicdeploy/patris-export/pkg/filecopy"
+	"github.com/atomicdeploy/patris-export/pkg/ipc"
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
 	"github.com/atomicdeploy/patris-export/pkg/server"
@@ -120,6 +126,17 @@ Supports Persian/Farsi encoding conversion and file watching.
 	serveCmd.Flags().Int("port", 0, "Port to listen on")
 	serveCmd.Flags().BoolP("watch", "w", true, "Watch file or URL for changes and broadcast updates")
 	serveCmd.Flags().String("debounce", "0s", "Debounce duration for local files; polling interval for URLs (e.g., 0s, 500ms, 1s, 5m)")
+	serveCmd.Flags().Bool("http", true, "Enable the HTTP REST/WebSocket/Web UI listener")
+	serveCmd.Flags().Bool("ipc", false, "Enable local IPC listener (Windows named pipe, Unix socket)")
+	serveCmd.Flags().String("ipc-path", "", "IPC path/name (default: platform-specific patris-export endpoint)")
+
+	ipcCmd := &cobra.Command{
+		Use:   "ipc [method] [json-params]",
+		Short: "Call a local patris-export IPC endpoint",
+		Args:  cobra.RangeArgs(1, 2),
+		Run:   runIPC,
+	}
+	ipcCmd.Flags().String("ipc-path", "", "IPC path/name (default: platform-specific patris-export endpoint)")
 
 	tuiCmd := &cobra.Command{
 		Use:   "tui [database-file]",
@@ -145,7 +162,7 @@ Set GITHUB_TOKEN for private repositories and higher API rate limits.`,
 	}
 	updateCmd.Flags().StringP("branch", "b", "main", "Branch to download from")
 
-	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, serveCmd, tuiCmd, updateCmd)
+	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, serveCmd, ipcCmd, tuiCmd, updateCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		errorColor.Fprintf(os.Stderr, "❌ Error: %v\n", err)
@@ -745,6 +762,46 @@ func sourceBaseName(path string) string {
 	return filepath.Base(path)
 }
 
+func runIPC(cmd *cobra.Command, args []string) {
+	path, _ := cmd.Flags().GetString("ipc-path")
+	conn, err := ipc.Dial(context.Background(), path)
+	if err != nil {
+		errorColor.Printf("Failed to connect to IPC endpoint: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	req := ipc.Request{
+		ID:     1,
+		Method: args[0],
+	}
+	if len(args) > 1 {
+		params := []byte(args[1])
+		if !json.Valid(params) {
+			errorColor.Println("IPC params must be valid JSON")
+			os.Exit(1)
+		}
+		req.Params = json.RawMessage(params)
+	}
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		errorColor.Printf("Failed to write IPC request: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+		if !strings.EqualFold(args[0], "subscribe") {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		errorColor.Printf("Failed to read IPC response: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 func init() {
 	// Set up logging
 	log.SetFlags(0)
@@ -766,6 +823,9 @@ func runServe(cmd *cobra.Command, args []string) {
 	debounceStr, _ := cmd.Flags().GetString("debounce")
 	host, _ := cmd.Flags().GetString("host")
 	port, _ := cmd.Flags().GetInt("port")
+	httpEnabled, _ := cmd.Flags().GetBool("http")
+	ipcEnabled, _ := cmd.Flags().GetBool("ipc")
+	ipcPath, _ := cmd.Flags().GetString("ipc-path")
 	if cmd.Flags().Changed("addr") && addr != "" {
 		appconfig.ApplyAddr(&cfg, addr)
 	}
@@ -780,6 +840,19 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 	if !cmd.Flags().Changed("debounce") {
 		debounceStr = cfg.Server.Debounce
+	}
+	if !cmd.Flags().Changed("http") {
+		httpEnabled = cfg.Server.HTTP
+	}
+	if cmd.Flags().Changed("ipc") {
+		cfg.Server.IPC.Enabled = ipcEnabled
+	}
+	if cmd.Flags().Changed("ipc-path") && ipcPath != "" {
+		cfg.Server.IPC.Path = ipcPath
+	}
+	if !httpEnabled && !cfg.Server.IPC.Enabled {
+		errorColor.Println("At least one transport must be enabled. Use --http=true or --ipc.")
+		os.Exit(1)
 	}
 	addr = cfg.Addr()
 
@@ -825,6 +898,27 @@ func runServe(cmd *cobra.Command, args []string) {
 			errorColor.Printf("❌ Failed to start file watching: %v\n", err)
 			os.Exit(1)
 		}
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	if cfg.Server.IPC.Enabled {
+		ipcServer := ipc.NewServer(cfg.Server.IPC.Path, embedded.NewServerHandler(srv))
+		go func() {
+			if err := ipcServer.Serve(ctx); err != nil {
+				errorColor.Printf("IPC server error: %v\n", err)
+				stop()
+			}
+		}()
+		successColor.Printf("IPC endpoint running at %s\n", ipcServer.Path())
+	}
+
+	if !httpEnabled {
+		infoColor.Printf("âš™ï¸ Config: %s\n", configManager.Path())
+		infoColor.Println("Press Ctrl+C to stop the IPC server")
+		<-ctx.Done()
+		return
 	}
 
 	// Start server

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,0 +1,152 @@
+# Embedding Patris Export
+
+Patris Export can run in three modes:
+
+- Standalone mode: the normal `patris-export serve ...` executable with Web UI, REST API, and WebSocket.
+- Embedded Go mode: import `github.com/atomicdeploy/patris-export/pkg/embedded` and call the engine directly from a host application.
+- Loadable library mode: build `patris-export.dll` on Windows or `libpatris-export.so` on Linux and call the C ABI from C#, Electron native modules, Python `ctypes`, or another host.
+
+The embedded and IPC APIs use the same backend as the standalone server, so records, config, process/file-lock status, notifications, and live update events stay consistent.
+
+## Build The Loadable Library
+
+Linux:
+
+```bash
+make build-lib-linux
+```
+
+Windows:
+
+```bash
+make build-lib-windows
+```
+
+Outputs:
+
+- Windows: `build/patris-export.dll` and `build/patris-export.h`
+- Linux: `build/libpatris-export.so` and `build/libpatris-export.h`
+
+The library still uses CGO and pxlib. Keep `pxlib.dll` beside the Windows host executable or make it available through `PATH`. On Linux, keep `libpx.so` in the system linker path or set `LD_LIBRARY_PATH`.
+
+## Go Embedded API
+
+```go
+engine, err := embedded.New(embedded.Options{
+    DatabasePath: `C:\Patris\data4\kala.db`,
+    Watch:        true,
+    WatchSet:     true,
+    Debounce:     "500ms",
+})
+if err != nil {
+    panic(err)
+}
+defer engine.Close()
+
+records, err := engine.Server().Records()
+status := engine.Server().Status()
+```
+
+To mount the existing REST/WebSocket/Web UI routes inside a larger Go server:
+
+```go
+http.Handle("/patris/", http.StripPrefix("/patris", engine.Server().Router()))
+```
+
+## C ABI
+
+The exported C functions are:
+
+- `PatrisExportVersionJSON() char*`
+- `PatrisExportCreate(char* options_json) uint64_t`
+- `PatrisExportClose(uint64_t handle) int`
+- `PatrisExportCall(uint64_t handle, char* request_json) char*`
+- `PatrisExportStartHTTP(uint64_t handle, char* addr) int`
+- `PatrisExportStartIPC(uint64_t handle, char* path) char*`
+- `PatrisExportLastError() char*`
+- `PatrisExportFreeString(char* value)`
+
+Every returned string must be released with `PatrisExportFreeString`.
+
+Example options JSON:
+
+```json
+{
+  "database_path": "C:\\Patris\\data4\\kala.db",
+  "watch": true,
+  "watch_set": true,
+  "debounce": "500ms"
+}
+```
+
+Example request JSON:
+
+```json
+{"id":1,"method":"records.list"}
+```
+
+## Local IPC
+
+IPC uses newline-delimited JSON requests and responses. It is useful when the host application does not want to expose a TCP/HTTP port.
+
+Default endpoints:
+
+- Windows named pipe: `\\.\pipe\patris-export`
+- Linux/macOS Unix socket: `/tmp/patris-export.sock`
+
+Start standalone with IPC only:
+
+```bash
+patris-export serve C:\Patris\data4\kala.db --ipc --http=false
+```
+
+Start standalone with both HTTP and IPC:
+
+```bash
+patris-export serve C:\Patris\data4\kala.db --addr 127.0.0.1:18080 --ipc
+```
+
+Call IPC from the bundled client:
+
+```bash
+patris-export ipc app.get
+patris-export ipc records.list
+patris-export ipc status.get
+patris-export ipc toast.show "{\"title\":\"Patris Export\",\"message\":\"Hello from IPC\",\"native\":true,\"broadcast\":true}"
+```
+
+Subscribe to live events:
+
+```bash
+patris-export ipc subscribe
+```
+
+Supported methods:
+
+- `app.get`
+- `records.list`
+- `info.get`
+- `status.get`
+- `config.get`
+- `config.set`
+- `toast.show`
+- `refresh`
+- `subscribe`
+
+Each request is one JSON object per line:
+
+```json
+{"id":1,"method":"status.get"}
+```
+
+A normal response looks like:
+
+```json
+{"id":1,"ok":true,"result":{...}}
+```
+
+After `subscribe`, the connection stays open and event messages look like:
+
+```json
+{"type":"event","event":{"type":"update","timestamp":"2026-07-10T12:00:00Z"}}
+```

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 git.sr.ht/~jackmordaunt/go-toast v1.1.2 h1:/yrfI55LRt1M7H1vkaw+NaH1+L1CDxrqDltwm5euVuE=
 git.sr.ht/~jackmordaunt/go-toast v1.1.2/go.mod h1:jA4OqHKTQ4AFBdwrSnwnskUIIS3HYzlJSgdzCKqfavo=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -39,10 +39,17 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Host     string `json:"host" yaml:"host" toml:"host"`
-	Port     int    `json:"port" yaml:"port" toml:"port"`
-	Watch    bool   `json:"watch" yaml:"watch" toml:"watch"`
-	Debounce string `json:"debounce" yaml:"debounce" toml:"debounce"`
+	Host     string    `json:"host" yaml:"host" toml:"host"`
+	Port     int       `json:"port" yaml:"port" toml:"port"`
+	Watch    bool      `json:"watch" yaml:"watch" toml:"watch"`
+	Debounce string    `json:"debounce" yaml:"debounce" toml:"debounce"`
+	HTTP     bool      `json:"http" yaml:"http" toml:"http"`
+	IPC      IPCConfig `json:"ipc" yaml:"ipc" toml:"ipc"`
+}
+
+type IPCConfig struct {
+	Enabled bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
+	Path    string `json:"path" yaml:"path" toml:"path"`
 }
 
 type DatabaseConfig struct {
@@ -101,6 +108,7 @@ func Default() Config {
 			Port:     8080,
 			Watch:    true,
 			Debounce: "0s",
+			HTTP:     true,
 		},
 		Database: DatabaseConfig{
 			DirectAccess: false,
@@ -474,6 +482,15 @@ func ApplyEnv(cfg *Config) {
 	if value := os.Getenv("PATRIS_WATCH"); strings.TrimSpace(value) != "" {
 		cfg.Server.Watch = parseBool(value, cfg.Server.Watch)
 	}
+	if value := os.Getenv("PATRIS_HTTP"); strings.TrimSpace(value) != "" {
+		cfg.Server.HTTP = parseBool(value, cfg.Server.HTTP)
+	}
+	if value := os.Getenv("PATRIS_IPC"); strings.TrimSpace(value) != "" {
+		cfg.Server.IPC.Enabled = parseBool(value, cfg.Server.IPC.Enabled)
+	}
+	if value := os.Getenv("PATRIS_IPC_PATH"); strings.TrimSpace(value) != "" {
+		cfg.Server.IPC.Path = strings.TrimSpace(value)
+	}
 	if value := os.Getenv("PATRIS_DIRECT_ACCESS"); strings.TrimSpace(value) != "" {
 		cfg.Database.DirectAccess = parseBool(value, cfg.Database.DirectAccess)
 	}
@@ -536,6 +553,9 @@ func normalize(cfg *Config) {
 	}
 	if cfg.Server.Debounce == "" {
 		cfg.Server.Debounce = "0s"
+	}
+	if !cfg.Server.HTTP && !cfg.Server.IPC.Enabled {
+		cfg.Server.HTTP = true
 	}
 	if cfg.Runtime.TempDir == "" {
 		cfg.Runtime.TempDir = "system"

--- a/pkg/embedded/engine.go
+++ b/pkg/embedded/engine.go
@@ -1,0 +1,297 @@
+package embedded
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/converter"
+	"github.com/atomicdeploy/patris-export/pkg/filecopy"
+	"github.com/atomicdeploy/patris-export/pkg/ipc"
+	"github.com/atomicdeploy/patris-export/pkg/server"
+	"github.com/atomicdeploy/patris-export/pkg/version"
+)
+
+type Options struct {
+	ConfigFiles     []string     `json:"config_files,omitempty"`
+	DatabasePath    string       `json:"database_path,omitempty"`
+	CharmapPath     string       `json:"charmap_path,omitempty"`
+	TempDir         string       `json:"temp_dir,omitempty"`
+	DirectAccess    bool         `json:"direct_access,omitempty"`
+	DirectAccessSet bool         `json:"direct_access_set,omitempty"`
+	Watch           bool         `json:"watch,omitempty"`
+	WatchSet        bool         `json:"watch_set,omitempty"`
+	Debounce        string       `json:"debounce,omitempty"`
+	Version         version.Info `json:"version,omitempty"`
+}
+
+type Engine struct {
+	mu      sync.Mutex
+	cfg     appconfig.Config
+	manager *appconfig.Manager
+	server  *server.Server
+	http    *http.Server
+	ipc     *ipc.Server
+	cancel  context.CancelFunc
+}
+
+func New(options Options) (*Engine, error) {
+	manager, err := appconfig.LoadFiles(options.ConfigFiles)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	cfg := manager.Get()
+	appconfig.ApplyEnv(&cfg)
+	if options.DatabasePath != "" {
+		cfg.Database.Path = options.DatabasePath
+	}
+	if options.CharmapPath != "" {
+		cfg.Database.Charmap = options.CharmapPath
+	}
+	if options.TempDir != "" {
+		cfg.Runtime.TempDir = options.TempDir
+	}
+	if options.DirectAccessSet {
+		cfg.Database.DirectAccess = options.DirectAccess
+	}
+	if options.WatchSet {
+		cfg.Server.Watch = options.Watch
+	}
+	if options.Debounce != "" {
+		cfg.Server.Debounce = options.Debounce
+	}
+	if strings.TrimSpace(cfg.Database.Path) == "" {
+		return nil, errors.New("database path is required")
+	}
+
+	filecopy.SetTempDir(appconfig.ResolveTempDir(cfg.Runtime.TempDir))
+	converter.SetRTLConversion(cfg.Database.RTLConversion)
+
+	var charMap converter.CharMapping
+	if cfg.Database.Charmap != "" {
+		charMap, err = converter.LoadCharMapping(cfg.Database.Charmap)
+		if err != nil {
+			return nil, fmt.Errorf("load charmap: %w", err)
+		}
+		converter.SetDefaultMapping(charMap)
+	}
+
+	info := options.Version
+	if info.Version == "" {
+		info = version.Current()
+	}
+	srv, err := server.NewServerWithOptions(cfg.Database.Path, charMap, server.Options{
+		Config:  manager,
+		Version: info,
+	}, !cfg.Database.DirectAccess)
+	if err != nil {
+		return nil, fmt.Errorf("create server: %w", err)
+	}
+
+	e := &Engine{
+		cfg:     cfg,
+		manager: manager,
+		server:  srv,
+	}
+	if cfg.Server.Watch {
+		if err := e.StartWatch(cfg.Server.Debounce); err != nil {
+			_ = e.Close()
+			return nil, err
+		}
+	}
+	return e, nil
+}
+
+func (e *Engine) Server() *server.Server {
+	return e.server
+}
+
+func (e *Engine) ConfigManager() *appconfig.Manager {
+	return e.manager
+}
+
+func (e *Engine) StartWatch(debounce string) error {
+	if strings.TrimSpace(debounce) == "" {
+		debounce = "0s"
+	}
+	duration, err := time.ParseDuration(debounce)
+	if err != nil {
+		return fmt.Errorf("invalid debounce duration %q: %w", debounce, err)
+	}
+	return e.server.StartWatching(duration)
+}
+
+func (e *Engine) StartHTTP(addr string) error {
+	if strings.TrimSpace(addr) == "" {
+		addr = e.cfg.Addr()
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.http != nil {
+		return errors.New("HTTP server already started")
+	}
+	e.http = &http.Server{Addr: addr, Handler: e.server.Router()}
+	go func() {
+		log.Printf("Embedded HTTP listening on %s", addr)
+		if err := e.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("Embedded HTTP server stopped with error: %v", err)
+		}
+	}()
+	return nil
+}
+
+func (e *Engine) StartIPC(path string) (string, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ipc != nil {
+		cancel()
+		return "", errors.New("IPC server already started")
+	}
+	e.cancel = cancel
+	e.ipc = ipc.NewServer(path, e)
+	go func() {
+		if err := e.ipc.Serve(ctx); err != nil {
+			log.Printf("IPC server stopped with error: %v", err)
+		}
+	}()
+	return e.ipc.Path(), nil
+}
+
+func (e *Engine) Close() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.cancel != nil {
+		e.cancel()
+		e.cancel = nil
+	}
+	var firstErr error
+	if e.http != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		if err := e.http.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		cancel()
+		e.http = nil
+	}
+	if e.server != nil {
+		if err := e.server.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	e.ipc = nil
+	return firstErr
+}
+
+func (e *Engine) CallJSON(ctx context.Context, raw string) (string, error) {
+	var req ipc.Request
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		return "", err
+	}
+	resp := e.Call(ctx, req)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (e *Engine) Call(ctx context.Context, req ipc.Request) ipc.Response {
+	return NewServerHandler(e.server).Call(ctx, req)
+}
+
+func (e *Engine) Subscribe(ctx context.Context, buffer int) (<-chan map[string]interface{}, func()) {
+	return e.server.SubscribeEvents(buffer)
+}
+
+type ServerHandler struct {
+	server *server.Server
+}
+
+func NewServerHandler(srv *server.Server) *ServerHandler {
+	return &ServerHandler{server: srv}
+}
+
+func (h *ServerHandler) Call(ctx context.Context, req ipc.Request) ipc.Response {
+	method := strings.ToLower(strings.TrimSpace(req.Method))
+	result, err := callServer(ctx, h.server, method, req.Params)
+	if err != nil {
+		return ipc.Response{ID: req.ID, OK: false, Error: err.Error()}
+	}
+	return ipc.Response{ID: req.ID, OK: true, Result: result}
+}
+
+func (h *ServerHandler) Subscribe(ctx context.Context, buffer int) (<-chan map[string]interface{}, func()) {
+	return h.server.SubscribeEvents(buffer)
+}
+
+func callServer(ctx context.Context, srv *server.Server, method string, params json.RawMessage) (interface{}, error) {
+	if srv == nil {
+		return nil, errors.New("server is not initialized")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	switch method {
+	case "app.get", "app":
+		return srv.AppMetadata(), nil
+	case "records.list", "records.get", "records":
+		return srv.Records()
+	case "info.get", "info":
+		return srv.Info()
+	case "status.get", "status":
+		return srv.Status(), nil
+	case "config.get", "config":
+		return srv.Config(), nil
+	case "config.set":
+		cfg, err := decodeConfigParams(params)
+		if err != nil {
+			return nil, err
+		}
+		return srv.ReplaceConfig(cfg)
+	case "toast.show", "toast":
+		var req server.ToastRequest
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, fmt.Errorf("decode toast params: %w", err)
+		}
+		req.Source = "ipc"
+		if err := srv.ShowToast(req); err != nil {
+			return map[string]interface{}{"native_error": err.Error()}, nil
+		}
+		return map[string]interface{}{"success": true}, nil
+	case "refresh":
+		srv.Refresh()
+		return map[string]interface{}{"refreshed": true}, nil
+	default:
+		return nil, fmt.Errorf("unknown method %q", method)
+	}
+}
+
+func decodeConfigParams(params json.RawMessage) (appconfig.Config, error) {
+	var cfg appconfig.Config
+	if len(params) == 0 || string(params) == "null" {
+		return cfg, errors.New("config params are required")
+	}
+	if err := json.Unmarshal(params, &cfg); err == nil && cfg.SchemaVersion != 0 {
+		return cfg, nil
+	}
+	var wrapped struct {
+		Config appconfig.Config `json:"config"`
+	}
+	if err := json.Unmarshal(params, &wrapped); err != nil {
+		return cfg, fmt.Errorf("decode config params: %w", err)
+	}
+	if wrapped.Config.SchemaVersion == 0 {
+		return cfg, errors.New("config params must contain a config object")
+	}
+	return wrapped.Config, nil
+}

--- a/pkg/embedded/engine_test.go
+++ b/pkg/embedded/engine_test.go
@@ -1,0 +1,25 @@
+package embedded
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestCallJSONRejectsUnknownMethod(t *testing.T) {
+	e := &Engine{}
+	raw, err := e.CallJSON(context.Background(), `{"id":1,"method":"missing"}`)
+	if err != nil {
+		t.Fatalf("CallJSON returned error: %v", err)
+	}
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if resp.OK || resp.Error == "" {
+		t.Fatalf("expected failed response, got %#v", resp)
+	}
+}

--- a/pkg/ipc/ipc_unix.go
+++ b/pkg/ipc/ipc_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package ipc
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+)
+
+func DefaultPath() string {
+	return "/tmp/patris-export.sock"
+}
+
+func NormalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return DefaultPath()
+	}
+	return path
+}
+
+func listenLocal(path string) (net.Listener, error) {
+	_ = os.Remove(path)
+	return net.Listen("unix", path)
+}
+
+func cleanupLocal(path string) {
+	_ = os.Remove(path)
+}
+
+func Dial(ctx context.Context, path string) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", NormalizePath(path))
+}

--- a/pkg/ipc/ipc_windows.go
+++ b/pkg/ipc/ipc_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package ipc
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func DefaultPath() string {
+	return `\\.\pipe\patris-export`
+}
+
+func NormalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return DefaultPath()
+	}
+	lower := strings.ToLower(path)
+	if strings.HasPrefix(lower, `\\.\pipe\`) || strings.HasPrefix(lower, `\\?\pipe\`) {
+		return path
+	}
+	path = strings.Trim(path, `\/`)
+	if path == "" {
+		path = "patris-export"
+	}
+	return `\\.\pipe\` + strings.ReplaceAll(path, `/`, `-`)
+}
+
+func listenLocal(path string) (net.Listener, error) {
+	return winio.ListenPipe(path, &winio.PipeConfig{
+		InputBufferSize:  16 * 1024 * 1024,
+		OutputBufferSize: 16 * 1024 * 1024,
+	})
+}
+
+func cleanupLocal(path string) {}
+
+func Dial(ctx context.Context, path string) (net.Conn, error) {
+	return winio.DialPipeContext(ctx, NormalizePath(path))
+}

--- a/pkg/ipc/protocol.go
+++ b/pkg/ipc/protocol.go
@@ -1,0 +1,146 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"sync"
+)
+
+// Request is a single JSON Lines IPC request.
+type Request struct {
+	ID     interface{}     `json:"id,omitempty"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a single JSON Lines IPC response.
+type Response struct {
+	ID     interface{} `json:"id,omitempty"`
+	OK     bool        `json:"ok"`
+	Result interface{} `json:"result,omitempty"`
+	Error  string      `json:"error,omitempty"`
+}
+
+// Handler executes IPC requests and optionally exposes the live event stream.
+type Handler interface {
+	Call(ctx context.Context, req Request) Response
+	Subscribe(ctx context.Context, buffer int) (<-chan map[string]interface{}, func())
+}
+
+// Server serves the patris-export IPC JSON Lines protocol on a local transport.
+type Server struct {
+	path    string
+	handler Handler
+}
+
+func NewServer(path string, handler Handler) *Server {
+	return &Server{
+		path:    NormalizePath(path),
+		handler: handler,
+	}
+}
+
+func (s *Server) Path() string {
+	return s.path
+}
+
+func (s *Server) Serve(ctx context.Context) error {
+	if s.handler == nil {
+		return errors.New("ipc handler is required")
+	}
+	ln, err := listenLocal(s.path)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+	defer cleanupLocal(s.path)
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+		cleanupLocal(s.path)
+	}()
+
+	log.Printf("IPC listening on %s", s.path)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil || isClosedListenerError(err) {
+				return nil
+			}
+			return err
+		}
+		go s.handleConn(ctx, conn)
+	}
+}
+
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var writerMu sync.Mutex
+	write := func(v interface{}) {
+		writerMu.Lock()
+		defer writerMu.Unlock()
+		if err := json.NewEncoder(conn).Encode(v); err != nil {
+			cancel()
+		}
+	}
+
+	scanner := bufio.NewScanner(conn)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			write(Response{OK: false, Error: fmt.Sprintf("invalid JSON request: %v", err)})
+			continue
+		}
+		if strings.EqualFold(req.Method, "subscribe") {
+			events, unsubscribe := s.handler.Subscribe(connCtx, 64)
+			defer unsubscribe()
+			write(Response{ID: req.ID, OK: true, Result: map[string]interface{}{"subscribed": true}})
+			go func() {
+				for {
+					select {
+					case <-connCtx.Done():
+						return
+					case event, ok := <-events:
+						if !ok {
+							return
+						}
+						write(map[string]interface{}{
+							"type":  "event",
+							"event": event,
+						})
+					}
+				}
+			}()
+			continue
+		}
+		write(s.handler.Call(connCtx, req))
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		log.Printf("IPC client error: %v", err)
+	}
+}
+
+func isClosedListenerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "use of closed network connection") ||
+		strings.Contains(text, "file has already been closed")
+}

--- a/pkg/processmon/processmon.go
+++ b/pkg/processmon/processmon.go
@@ -52,7 +52,7 @@ func FindProcessByName(name string) ([]ProcessInfo, error) {
 		}
 
 		if processNameMatches(pName, name) {
-			found = append(found, collectProcessInfo(p, pName, nil, true))
+			found = append(found, collectProcessInfo(p, pName, nil, false))
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,6 +52,8 @@ type Server struct {
 	processStatusAt    time.Time
 	lastSourceHash     string
 	lastSourceHashMu   sync.Mutex
+	eventSubscribers   map[chan map[string]interface{}]struct{}
+	eventSubscribersMu sync.RWMutex
 }
 
 type Options struct {
@@ -110,14 +112,15 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 	}
 
 	s := &Server{
-		router:      mux.NewRouter(),
-		dbPath:      dbPath,
-		charMap:     charMap,
-		dataSource:  ds,
-		wsClients:   make(map[*websocket.Conn]*sync.Mutex),
-		useTempFile: copyBeforeRead,
-		config:      options.Config,
-		version:     options.Version,
+		router:           mux.NewRouter(),
+		dbPath:           dbPath,
+		charMap:          charMap,
+		dataSource:       ds,
+		wsClients:        make(map[*websocket.Conn]*sync.Mutex),
+		eventSubscribers: make(map[chan map[string]interface{}]struct{}),
+		useTempFile:      copyBeforeRead,
+		config:           options.Config,
+		version:          options.Version,
 		upgrader: websocket.Upgrader{
 			// Security: Configure origin checking for production use
 			// Default allows localhost only
@@ -181,6 +184,114 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/ws", s.handleWebSocket)
 }
 
+// Router returns the HTTP router used by the standalone server. Embedded hosts
+// can mount it in their own HTTP stack instead of opening a patris-export port.
+func (s *Server) Router() http.Handler {
+	return s.router
+}
+
+// Records returns the current records using the same transformed shape served
+// by GET /api/records.
+func (s *Server) Records() (map[string]interface{}, error) {
+	records, err := s.dataSource.GetRecords()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read records: %w", err)
+	}
+	exporter := converter.NewExporter(nil)
+	return exporter.TransformRecordsMap(records), nil
+}
+
+// Info returns database schema and metadata using the same shape served by
+// GET /api/info.
+func (s *Server) Info() (map[string]interface{}, error) {
+	db, cleanup, err := s.openDatabase()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+	defer cleanup()
+
+	fields, err := db.GetFields()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fields: %w", err)
+	}
+
+	return map[string]interface{}{
+		"success":     true,
+		"file":        sourceBaseName(s.dbPath),
+		"path":        s.dbPath,
+		"version":     s.version,
+		"num_records": db.GetNumRecords(),
+		"num_fields":  db.GetNumFields(),
+		"fields":      fields,
+	}, nil
+}
+
+// AppMetadata returns version/resource/config metadata for embedded and IPC
+// clients.
+func (s *Server) AppMetadata() map[string]interface{} {
+	return s.appMetadata()
+}
+
+// Config returns the active configuration snapshot.
+func (s *Server) Config() appconfig.Config {
+	if s.config == nil {
+		return appconfig.Default()
+	}
+	return s.config.Get()
+}
+
+// ReplaceConfig persists and broadcasts a new configuration snapshot.
+func (s *Server) ReplaceConfig(cfg appconfig.Config) (appconfig.Config, error) {
+	if s.config == nil {
+		return appconfig.Default(), fmt.Errorf("configuration storage is not enabled")
+	}
+	if err := s.config.Replace(cfg); err != nil {
+		return appconfig.Config{}, err
+	}
+	cfg = s.config.Get()
+	s.broadcastConfig(cfg)
+	return cfg, nil
+}
+
+// Status returns process and database lock status using the same shape served
+// by GET /api/status.
+func (s *Server) Status() map[string]interface{} {
+	return s.processStatus()
+}
+
+// ShowToast displays a native notification and/or broadcasts it to connected
+// browser, IPC, and embedded subscribers.
+func (s *Server) ShowToast(req ToastRequest) error {
+	return s.processToastRequest(req)
+}
+
+// Refresh forces a data refresh broadcast to browser, IPC, and embedded
+// subscribers.
+func (s *Server) Refresh() {
+	s.broadcastUpdate()
+}
+
+// SubscribeEvents subscribes to the same event stream used by the WebSocket
+// broadcaster. The returned unsubscribe function must be called by the host.
+func (s *Server) SubscribeEvents(buffer int) (<-chan map[string]interface{}, func()) {
+	if buffer < 1 {
+		buffer = 1
+	}
+	ch := make(chan map[string]interface{}, buffer)
+	s.eventSubscribersMu.Lock()
+	s.eventSubscribers[ch] = struct{}{}
+	s.eventSubscribersMu.Unlock()
+	unsubscribe := func() {
+		s.eventSubscribersMu.Lock()
+		if _, ok := s.eventSubscribers[ch]; ok {
+			delete(s.eventSubscribers, ch)
+			close(ch)
+		}
+		s.eventSubscribersMu.Unlock()
+	}
+	return ch, unsubscribe
+}
+
 func (s *Server) openDatabase() (*paradox.Database, func(), error) {
 	pathToOpen := s.dbPath
 	cleanup := func() {}
@@ -232,15 +343,11 @@ func (s *Server) handleViewer(w http.ResponseWriter, r *http.Request) {
 
 // handleGetRecords returns all database records as JSON
 func (s *Server) handleGetRecords(w http.ResponseWriter, r *http.Request) {
-	records, err := s.dataSource.GetRecords()
+	transformed, err := s.Records()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to read records: %v", err), http.StatusInternalServerError)
 		return
 	}
-
-	// Transform records to use Code as key (same format as convert command)
-	exporter := converter.NewExporter(nil)
-	transformed := exporter.TransformRecordsMap(records)
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if err := json.NewEncoder(w).Encode(transformed); err != nil {
@@ -250,29 +357,14 @@ func (s *Server) handleGetRecords(w http.ResponseWriter, r *http.Request) {
 
 // handleGetInfo returns database schema information
 func (s *Server) handleGetInfo(w http.ResponseWriter, r *http.Request) {
-	db, cleanup, err := s.openDatabase()
+	info, err := s.Info()
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to open database: %v", err), http.StatusInternalServerError)
-		return
-	}
-	defer cleanup()
-
-	fields, err := db.GetFields()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get fields: %v", err), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"success":     true,
-		"file":        sourceBaseName(s.dbPath),
-		"path":        s.dbPath,
-		"version":     s.version,
-		"num_records": db.GetNumRecords(),
-		"num_fields":  db.GetNumFields(),
-		"fields":      fields,
-	})
+	json.NewEncoder(w).Encode(info)
 }
 
 func (s *Server) handleGetApp(w http.ResponseWriter, r *http.Request) {
@@ -312,19 +404,19 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to decode config: %v", err), http.StatusBadRequest)
 		return
 	}
-	if err := s.config.Replace(cfg); err != nil {
+	cfg, err := s.ReplaceConfig(cfg)
+	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)
 		return
 	}
-	s.broadcastConfig(s.config.Get())
 	writeJSON(w, map[string]interface{}{
 		"success": true,
-		"config":  s.config.Get(),
+		"config":  cfg,
 	})
 }
 
 func (s *Server) handleGetStatus(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, s.processStatus())
+	writeJSON(w, s.Status())
 }
 
 // handlePostToast displays a native notification and broadcasts it to web clients.
@@ -336,7 +428,7 @@ func (s *Server) handlePostToast(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Source = "api"
-	nativeErr := s.processToastRequest(req)
+	nativeErr := s.ShowToast(req)
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -779,11 +871,11 @@ func writeJSON(w http.ResponseWriter, payload interface{}) {
 }
 
 func (s *Server) processStatus() map[string]interface{} {
-	patris81Processes, patrisErr := processmon.FindProcessByName("patris81.exe")
+	patris81Processes, patrisErr := findPatrisProcessesWithTimeout(1500 * time.Millisecond)
 	var fileInfo *processmon.FileAccessInfo
 	var fileErr error
 	if !filecopy.IsURL(s.dbPath) {
-		fileInfo, fileErr = processmon.FindProcessesWithFile(s.dbPath)
+		fileInfo, fileErr = findFileProcessesWithTimeout(s.dbPath, 1500*time.Millisecond)
 	}
 
 	status := map[string]interface{}{
@@ -815,6 +907,45 @@ func (s *Server) processStatus() map[string]interface{} {
 	return status
 }
 
+func findPatrisProcessesWithTimeout(timeout time.Duration) ([]processmon.ProcessInfo, error) {
+	type result struct {
+		processes []processmon.ProcessInfo
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		processes, err := processmon.FindProcessByName("patris81.exe")
+		ch <- result{processes: processes, err: err}
+	}()
+	select {
+	case res := <-ch:
+		return res.processes, res.err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("timed out inspecting patris81.exe processes")
+	}
+}
+
+func findFileProcessesWithTimeout(path string, timeout time.Duration) (*processmon.FileAccessInfo, error) {
+	type result struct {
+		info *processmon.FileAccessInfo
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		info, err := processmon.FindProcessesWithFile(path)
+		ch <- result{info: info, err: err}
+	}()
+	select {
+	case res := <-ch:
+		return res.info, res.err
+	case <-time.After(timeout):
+		return &processmon.FileAccessInfo{
+			FilePath:  path,
+			Processes: []processmon.ProcessInfo{},
+		}, fmt.Errorf("timed out inspecting file access")
+	}
+}
+
 func (s *Server) broadcastConfig(cfg appconfig.Config) {
 	message := map[string]interface{}{
 		"type":      "config_update",
@@ -825,6 +956,15 @@ func (s *Server) broadcastConfig(cfg appconfig.Config) {
 }
 
 func (s *Server) broadcastMessage(message map[string]interface{}) {
+	s.eventSubscribersMu.RLock()
+	for ch := range s.eventSubscribers {
+		select {
+		case ch <- cloneMap(message):
+		default:
+		}
+	}
+	s.eventSubscribersMu.RUnlock()
+
 	s.wsClientsMu.RLock()
 	defer s.wsClientsMu.RUnlock()
 	for conn, connMu := range s.wsClients {
@@ -837,6 +977,14 @@ func (s *Server) broadcastMessage(message map[string]interface{}) {
 			}
 		}(conn, connMu)
 	}
+}
+
+func cloneMap(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func (s *Server) broadcastProcessInfo() {


### PR DESCRIPTION
﻿## Summary
- add `pkg/embedded` for in-process Go hosts and `cmd/patris-export-lib` for C ABI `.dll`/`.so` builds
- add local JSON Lines IPC over Windows named pipes and Unix sockets, with CLI `patris-export ipc` client
- allow `serve` to run HTTP, IPC, or both via config/env/CLI flags
- add CI artifact builds for Linux `.so` and Windows `.dll`
- bound process-status collection so status events/endpoints do not hang embedded or IPC callers
- document embedding, C ABI, and IPC usage

Closes #46

## Validation
- `go test ./pkg/ipc ./pkg/embedded ./pkg/server ./pkg/processmon ./cmd/patris-export` with CGO, pxlib, and MinGW runtime DLLs on PATH
- `scripts/windows/Build-LocalWindows.ps1 -SkipPxlibBuild -PatrisDb C:\Patris\data4\kala.db`
- built `C:\Users\Mahdi\Desktop\AtomicDeploy\deploy\patris-export.dll` and generated `patris-export.h`
- live service restarted on `127.0.0.1:18080` with `--ipc`
- IPC-only smoke: `serve testdata\kala.db --ipc --ipc-path patris-export-test --http=false --watch=false` then `ipc --ipc-path patris-export-test info.get`
