### PR TITLE
Prefer /dev/shm for small temp copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,34 @@ Generate the snapshot without opening a window:
 patris-export view kala.db --no-open --html-output output/kala-viewer.html
 ```
 
+### Temporary Storage Policy
+
+When no explicit temp directory is configured, Linux builds use `auto` temp storage selection. In that mode Patris Export prefers `/dev/shm/patris-export` for known-size temp copies up to 100 MiB when the tmpfs mount exists and has enough free space, then falls back to the normal system temp directory for larger files, unknown-size downloads, or unsupported platforms.
+
+Explicit temp directories always win:
+
+```bash
+patris-export serve kala.db --temp-dir /var/tmp/patris-export
+PATRIS_TEMP_DIR=/var/tmp/patris-export patris-export convert kala.db
+```
+
+The policy can also be configured:
+
+```bash
+patris-export convert kala.db --temp-strategy system
+patris-export convert kala.db --temp-strategy auto --temp-memory-limit-mb 128
+PATRIS_TEMP_STRATEGY=memory PATRIS_TEMP_MEMORY_LIMIT_MB=64 patris-export serve kala.db
+```
+
+Config file equivalent:
+
+```yaml
+runtime:
+  temp_dir: system
+  temp_strategy: auto
+  temp_memory_limit_mb: 100
+```
+
 Then access:
 - Web interface: http://localhost:8080
 - API records: http://localhost:8080/api/records
@@ -245,6 +273,9 @@ go test -v ./...
 
 - `-c, --charmap` - Optional path to a custom character mapping file. If omitted, the embedded Patris81 mapping is used.
 - `-o, --output` - Output directory for converted files, or `-` for stdout (default: current directory)
+- `--temp-dir` - Explicit temp directory for copied/downloaded database files. Overrides automatic temp storage selection.
+- `--temp-strategy` - Temp storage strategy: `auto`, `system`, or `memory`.
+- `--temp-memory-limit-mb` - Maximum known file size for memory-backed temp copies when the strategy allows it.
 - `-v, --verbose` - Enable verbose logging
 - `-r, --rtl` - Opt in to experimental RTL logical text conversion for mixed Persian/Latin output
 

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -38,6 +38,8 @@ var (
 	charMapFile  string
 	configFiles  []string
 	tempDir      string
+	tempStrategy string
+	tempLimitMB  int64
 	outputDir    string
 	outputFormat string
 	dbFileFlag   string
@@ -89,6 +91,8 @@ Supports Persian/Farsi encoding conversion and file watching.
 	rootCmd.PersistentFlags().StringVarP(&charMapFile, "charmap", "c", "", "Optional custom character mapping file; embedded Patris81 mapping is used by default")
 	rootCmd.PersistentFlags().StringVarP(&outputDir, "output", "o", ".", "Output directory for converted files (use '-' for stdout)")
 	rootCmd.PersistentFlags().StringVar(&tempDir, "temp-dir", "", "Temp directory for copied/downloaded database files (default: system temp)")
+	rootCmd.PersistentFlags().StringVar(&tempStrategy, "temp-strategy", "", "Temp storage strategy: auto, system, or memory (auto prefers /dev/shm on Linux for small files)")
+	rootCmd.PersistentFlags().Int64Var(&tempLimitMB, "temp-memory-limit-mb", 0, "Maximum file size in MiB for /dev/shm temp copies when temp strategy allows memory")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&directAccess, "direct-access", "d", false, "Access database file directly without temp copy (may conflict with BDE writes)")
 	rootCmd.PersistentFlags().BoolVarP(&rtlMode, "rtl", "r", false, "Opt in to RTL logical text conversion for mixed Persian/Latin output")
@@ -370,7 +374,14 @@ func effectiveConfig(cmd *cobra.Command) (*appconfig.Manager, appconfig.Config) 
 	if !rootFlags.Changed("temp-dir") {
 		tempDir = cfg.Runtime.TempDir
 	}
+	if !rootFlags.Changed("temp-strategy") {
+		tempStrategy = cfg.Runtime.TempStrategy
+	}
+	if !rootFlags.Changed("temp-memory-limit-mb") {
+		tempLimitMB = cfg.Runtime.TempMemoryLimitMB
+	}
 	filecopy.SetTempDir(appconfig.ResolveTempDir(tempDir))
+	filecopy.SetTempPolicy(tempStrategy, appconfig.TempMemoryLimitBytes(tempLimitMB))
 	converter.SetRTLConversion(rtlMode)
 	return mgr, cfg
 }

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -60,8 +60,10 @@ type DatabaseConfig struct {
 }
 
 type RuntimeConfig struct {
-	TempDir string `json:"temp_dir" yaml:"temp_dir" toml:"temp_dir"`
-	Debug   bool   `json:"debug" yaml:"debug" toml:"debug"`
+	TempDir           string `json:"temp_dir" yaml:"temp_dir" toml:"temp_dir"`
+	TempStrategy      string `json:"temp_strategy" yaml:"temp_strategy" toml:"temp_strategy"`
+	TempMemoryLimitMB int64  `json:"temp_memory_limit_mb" yaml:"temp_memory_limit_mb" toml:"temp_memory_limit_mb"`
+	Debug             bool   `json:"debug" yaml:"debug" toml:"debug"`
 }
 
 type ConvertConfig struct {
@@ -115,7 +117,9 @@ func Default() Config {
 			DirectAccess: false,
 		},
 		Runtime: RuntimeConfig{
-			TempDir: "system",
+			TempDir:           "system",
+			TempStrategy:      "auto",
+			TempMemoryLimitMB: 100,
 		},
 		Convert: ConvertConfig{
 			Output:   ".",
@@ -213,6 +217,13 @@ func ResolveTempDir(value string) string {
 		return filepath.Join(cwd, value)
 	}
 	return value
+}
+
+func TempMemoryLimitBytes(limitMB int64) int64 {
+	if limitMB <= 0 {
+		limitMB = 100
+	}
+	return limitMB * 1024 * 1024
 }
 
 func cleanPathList(paths []string) []string {
@@ -504,6 +515,17 @@ func ApplyEnv(cfg *Config) {
 			break
 		}
 	}
+	if value := os.Getenv("PATRIS_TEMP_STRATEGY"); strings.TrimSpace(value) != "" {
+		cfg.Runtime.TempStrategy = strings.TrimSpace(value)
+	}
+	for _, key := range []string{"PATRIS_TEMP_MEMORY_LIMIT_MB", "PATRIS_TMPFS_LIMIT_MB"} {
+		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
+			if limit, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+				cfg.Runtime.TempMemoryLimitMB = limit
+			}
+			break
+		}
+	}
 	if value := os.Getenv("PATRIS_DEBUG"); strings.TrimSpace(value) != "" {
 		cfg.Runtime.Debug = parseBool(value, cfg.Runtime.Debug)
 	}
@@ -563,6 +585,20 @@ func normalize(cfg *Config) {
 	}
 	if cfg.Runtime.TempDir == "" {
 		cfg.Runtime.TempDir = "system"
+	}
+	cfg.Runtime.TempStrategy = strings.ToLower(strings.TrimSpace(cfg.Runtime.TempStrategy))
+	switch cfg.Runtime.TempStrategy {
+	case "", "auto":
+		cfg.Runtime.TempStrategy = "auto"
+	case "system", "disk", "tmp":
+		cfg.Runtime.TempStrategy = "system"
+	case "memory", "shm", "tmpfs", "ram":
+		cfg.Runtime.TempStrategy = "memory"
+	default:
+		cfg.Runtime.TempStrategy = "auto"
+	}
+	if cfg.Runtime.TempMemoryLimitMB <= 0 {
+		cfg.Runtime.TempMemoryLimitMB = 100
 	}
 	if cfg.Convert.Output == "" {
 		cfg.Convert.Output = "."

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -16,7 +16,7 @@ func TestLoadFilesLayersJSONYAMLTOML(t *testing.T) {
 	if err := os.WriteFile(jsonPath, []byte(`{"server":{"host":"127.0.0.1","port":18080},"database":{"path":"base.db"},"convert":{"format":"csv"}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(yamlPath, []byte("server:\n  port: 19090\nruntime:\n  temp_dir: tmp/patris\n"), 0644); err != nil {
+	if err := os.WriteFile(yamlPath, []byte("server:\n  port: 19090\nruntime:\n  temp_dir: tmp/patris\n  temp_strategy: memory\n  temp_memory_limit_mb: 64\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(tomlPath, []byte("[ui]\npage_size = 250\nrtl_text_direction = true\n"), 0644); err != nil {
@@ -39,6 +39,9 @@ func TestLoadFilesLayersJSONYAMLTOML(t *testing.T) {
 	}
 	if cfg.Runtime.TempDir != "tmp/patris" {
 		t.Fatalf("temp dir = %q", cfg.Runtime.TempDir)
+	}
+	if cfg.Runtime.TempStrategy != "memory" || cfg.Runtime.TempMemoryLimitMB != 64 {
+		t.Fatalf("runtime temp policy was not layered correctly: %+v", cfg.Runtime)
 	}
 	if cfg.UI.PageSize != 250 || !cfg.UI.RTLTextDirection {
 		t.Fatalf("ui config was not layered correctly: %+v", cfg.UI)
@@ -86,6 +89,23 @@ func TestApplyEnvNotificationOptions(t *testing.T) {
 	}
 	if !cfg.Notifications.IncludeRowValues || cfg.Notifications.MaxRows != 7 {
 		t.Fatalf("notification details were not applied: %+v", cfg.Notifications)
+	}
+}
+
+func TestApplyEnvRuntimeTempPolicy(t *testing.T) {
+	t.Setenv("PATRIS_TEMP_STRATEGY", "tmpfs")
+	t.Setenv("PATRIS_TEMP_MEMORY_LIMIT_MB", "42")
+
+	cfg := Default()
+	ApplyEnv(&cfg)
+	if cfg.Runtime.TempStrategy != "memory" {
+		t.Fatalf("temp strategy = %q", cfg.Runtime.TempStrategy)
+	}
+	if cfg.Runtime.TempMemoryLimitMB != 42 {
+		t.Fatalf("temp memory limit = %d", cfg.Runtime.TempMemoryLimitMB)
+	}
+	if TempMemoryLimitBytes(cfg.Runtime.TempMemoryLimitMB) != 42*1024*1024 {
+		t.Fatalf("unexpected temp memory limit bytes")
 	}
 }
 

--- a/pkg/embedded/engine.go
+++ b/pkg/embedded/engine.go
@@ -72,6 +72,7 @@ func New(options Options) (*Engine, error) {
 	}
 
 	filecopy.SetTempDir(appconfig.ResolveTempDir(cfg.Runtime.TempDir))
+	filecopy.SetTempPolicy(cfg.Runtime.TempStrategy, appconfig.TempMemoryLimitBytes(cfg.Runtime.TempMemoryLimitMB))
 	converter.SetRTLConversion(cfg.Database.RTLConversion)
 
 	var charMap converter.CharMapping

--- a/pkg/filecopy/filecopy.go
+++ b/pkg/filecopy/filecopy.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -16,12 +17,22 @@ import (
 const (
 	// ChunkSize defines the size of chunks for file copying (10MB)
 	ChunkSize = 10 * 1024 * 1024
+
+	// DefaultMemoryTempLimitBytes is the default cap for tmpfs-backed copies.
+	DefaultMemoryTempLimitBytes = 100 * 1024 * 1024
+
+	TempStrategyAuto   = "auto"
+	TempStrategySystem = "system"
+	TempStrategyMemory = "memory"
 )
 
 var (
-	httpClient      = &http.Client{Timeout: 2 * time.Minute}
-	tempDirOverride string
-	tempDirMu       sync.RWMutex
+	httpClient               = &http.Client{Timeout: 2 * time.Minute}
+	tempDirOverride          string
+	tempStrategy                   = TempStrategyAuto
+	tempMemoryLimitBytes     int64 = DefaultMemoryTempLimitBytes
+	tempDirMu                sync.RWMutex
+	memoryTempFreeSpaceSlack int64 = 8 * 1024 * 1024
 )
 
 // SetTempDir configures the base temp directory used by copy/download helpers.
@@ -32,14 +43,94 @@ func SetTempDir(path string) {
 	tempDirMu.Unlock()
 }
 
-func tempRoot() string {
+// SetTempPolicy configures automatic temp storage selection. The system
+// strategy always uses os.TempDir, memory tries /dev/shm when safe, and auto
+// prefers memory only for small known-size files on supported platforms.
+func SetTempPolicy(strategy string, memoryLimitBytes int64) {
+	tempDirMu.Lock()
+	tempStrategy = normalizeTempStrategy(strategy)
+	if memoryLimitBytes > 0 {
+		tempMemoryLimitBytes = memoryLimitBytes
+	} else {
+		tempMemoryLimitBytes = DefaultMemoryTempLimitBytes
+	}
+	tempDirMu.Unlock()
+}
+
+// TempRootForSize returns the directory used for temporary files of sizeHint.
+// Explicit SetTempDir overrides always win. A negative size means unknown.
+func TempRootForSize(sizeHint int64) string {
 	tempDirMu.RLock()
 	override := tempDirOverride
+	strategy := tempStrategy
+	limit := tempMemoryLimitBytes
 	tempDirMu.RUnlock()
+
 	if override != "" {
 		return override
 	}
+	if shouldUseMemoryTemp(strategy, sizeHint, limit) {
+		return filepath.Join(memoryTempBaseDir(), "patris-export")
+	}
+	return systemTempRoot()
+}
+
+func tempRootForSize(sizeHint int64) string {
+	return TempRootForSize(sizeHint)
+}
+
+func tempRoot() string {
+	return tempRootForSize(-1)
+}
+
+func systemTempRoot() string {
 	return filepath.Join(os.TempDir(), "patris-export")
+}
+
+func normalizeTempStrategy(strategy string) string {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", TempStrategyAuto:
+		return TempStrategyAuto
+	case TempStrategySystem, "disk", "tmp":
+		return TempStrategySystem
+	case TempStrategyMemory, "shm", "tmpfs", "ram":
+		return TempStrategyMemory
+	default:
+		return TempStrategyAuto
+	}
+}
+
+func shouldUseMemoryTemp(strategy string, sizeHint int64, limit int64) bool {
+	strategy = normalizeTempStrategy(strategy)
+	if strategy == TempStrategySystem {
+		return false
+	}
+	if sizeHint < 0 || limit <= 0 || sizeHint > limit {
+		return false
+	}
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	base := memoryTempBaseDir()
+	info, err := os.Stat(base)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	if available, ok := availableBytes(base); ok {
+		required := uint64(sizeHint)
+		if memoryTempFreeSpaceSlack > 0 {
+			required += uint64(memoryTempFreeSpaceSlack)
+		}
+		if available < required {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryTempBaseDir() string {
+	return "/dev/shm"
 }
 
 // FileInfo contains information about a file copy operation
@@ -86,10 +177,10 @@ func CopyToTemp(sourcePath string) (*FileInfo, error) {
 	}
 	defer source.Close()
 
-	// Create temp file in system temp directory
-	// Use a subdirectory to avoid conflicts with source files that might be in /tmp
+	// Create temp file in the selected temp directory. Use a subdirectory to
+	// avoid conflicts with source files that might already be in temp storage.
 	// Include a hash of the absolute path to handle multiple files with same name
-	tempDir := tempRoot()
+	tempDir := tempRootForSize(sourceInfo.Size())
 	if err := os.MkdirAll(tempDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
 	}
@@ -203,13 +294,7 @@ func DownloadToTemp(sourceURL string) (*FileInfo, error) {
 		baseName = "download.db"
 	}
 
-	tempDir := tempRoot()
-	if err := os.MkdirAll(tempDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-
 	urlHash := crc32.ChecksumIEEE([]byte(sourceURL))
-	tempPath := filepath.Join(tempDir, fmt.Sprintf("%s.%08x", baseName, urlHash))
 
 	req, err := http.NewRequest(http.MethodGet, sourceURL, nil)
 	if err != nil {
@@ -226,6 +311,12 @@ func DownloadToTemp(sourceURL string) (*FileInfo, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("failed to download URL: HTTP %d %s", resp.StatusCode, resp.Status)
 	}
+
+	tempDir := tempRootForSize(resp.ContentLength)
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	tempPath := filepath.Join(tempDir, fmt.Sprintf("%s.%08x", baseName, urlHash))
 
 	dest, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {

--- a/pkg/filecopy/filecopy_test.go
+++ b/pkg/filecopy/filecopy_test.go
@@ -243,8 +243,8 @@ func TestCopyToTempBasename(t *testing.T) {
 		t.Errorf("Expected basename to start with 'test-database.db.', got '%s'", baseName)
 	}
 
-	// Verify temp file is in system temp directory under patris-export subdirectory
-	expectedDir := filepath.Join(os.TempDir(), "patris-export")
+	// Verify temp file is in the selected patris-export temp directory.
+	expectedDir := TempRootForSize(4)
 	actualDir := filepath.Dir(fileInfo.TempPath)
 	if actualDir != expectedDir {
 		t.Errorf("Expected temp dir %s, got %s", expectedDir, actualDir)
@@ -259,6 +259,43 @@ func TestCopyToTempBasename(t *testing.T) {
 
 	if fileInfo.TempPath != fileInfo2.TempPath {
 		t.Errorf("Expected same temp path for same source file, got %s and %s", fileInfo.TempPath, fileInfo2.TempPath)
+	}
+}
+
+func TestTempRootExplicitOverrideWins(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "override")
+	SetTempDir(override)
+	SetTempPolicy(TempStrategyMemory, DefaultMemoryTempLimitBytes)
+	defer SetTempDir("")
+	defer SetTempPolicy(TempStrategyAuto, DefaultMemoryTempLimitBytes)
+
+	if got := TempRootForSize(1); got != override {
+		t.Fatalf("explicit temp dir should win: got %s want %s", got, override)
+	}
+}
+
+func TestTempRootSystemStrategy(t *testing.T) {
+	SetTempDir("")
+	SetTempPolicy(TempStrategySystem, DefaultMemoryTempLimitBytes)
+	defer SetTempPolicy(TempStrategyAuto, DefaultMemoryTempLimitBytes)
+
+	expected := filepath.Join(os.TempDir(), "patris-export")
+	if got := TempRootForSize(1); got != expected {
+		t.Fatalf("system strategy temp root = %s, want %s", got, expected)
+	}
+}
+
+func TestTempRootLargeOrUnknownUsesSystem(t *testing.T) {
+	SetTempDir("")
+	SetTempPolicy(TempStrategyAuto, 10)
+	defer SetTempPolicy(TempStrategyAuto, DefaultMemoryTempLimitBytes)
+
+	expected := filepath.Join(os.TempDir(), "patris-export")
+	if got := TempRootForSize(-1); got != expected {
+		t.Fatalf("unknown size temp root = %s, want %s", got, expected)
+	}
+	if got := TempRootForSize(11); got != expected {
+		t.Fatalf("oversized temp root = %s, want %s", got, expected)
 	}
 }
 

--- a/pkg/filecopy/space_linux.go
+++ b/pkg/filecopy/space_linux.go
@@ -1,0 +1,11 @@
+package filecopy
+
+import "syscall"
+
+func availableBytes(path string) (uint64, bool) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, false
+	}
+	return stat.Bavail * uint64(stat.Bsize), true
+}

--- a/pkg/filecopy/space_other.go
+++ b/pkg/filecopy/space_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package filecopy
+
+func availableBytes(_ string) (uint64, bool) {
+	return 0, false
+}

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -657,6 +657,8 @@ function applyConfigToSettingsForm() {
     setChecked('notifyIncludeRowValues', cfg.notifications?.include_row_values);
     setValue('notifyMaxRows', cfg.notifications?.max_rows || 3);
     setValue('runtimeTempDir', cfg.runtime?.temp_dir || 'system');
+    setValue('runtimeTempStrategy', cfg.runtime?.temp_strategy || 'auto');
+    setValue('runtimeTempMemoryLimitMB', cfg.runtime?.temp_memory_limit_mb || 100);
     setChecked('runtimeDebug', cfg.runtime?.debug);
     const pathEl = document.getElementById('settingsConfigPath');
     if (pathEl) {
@@ -683,6 +685,8 @@ function updateConfigFromSettingsForm() {
     state.config.runtime = {
         ...(state.config.runtime || {}),
         temp_dir: document.getElementById('runtimeTempDir')?.value.trim() || 'system',
+        temp_strategy: document.getElementById('runtimeTempStrategy')?.value || 'auto',
+        temp_memory_limit_mb: parseInt(document.getElementById('runtimeTempMemoryLimitMB')?.value || '100', 10) || 100,
         debug: !!document.getElementById('runtimeDebug')?.checked
     };
     state.config.notifications = {
@@ -2458,6 +2462,8 @@ function init() {
         'notifyIncludeRowValues',
         'notifyMaxRows',
         'runtimeTempDir',
+        'runtimeTempStrategy',
+        'runtimeTempMemoryLimitMB',
         'runtimeDebug'
     ]
         .forEach(id => bindConfigField(id));

--- a/web/src/viewer.html
+++ b/web/src/viewer.html
@@ -190,9 +190,19 @@
                         <label class="field-label wide">Temp directory
                             <input id="runtimeTempDir" class="text-input" type="text" placeholder="system">
                         </label>
+                        <label class="field-label">Temp strategy
+                            <select id="runtimeTempStrategy" class="text-input">
+                                <option value="auto">Auto</option>
+                                <option value="system">System temp</option>
+                                <option value="memory">Memory temp</option>
+                            </select>
+                        </label>
+                        <label class="field-label">Memory temp limit (MiB)
+                            <input id="runtimeTempMemoryLimitMB" class="text-input" type="number" min="1" max="4096" step="1" placeholder="100">
+                        </label>
                     </div>
                     <label class="checkbox-label"><input type="checkbox" id="runtimeDebug"><span>Enable debug tools and custom charmap previews</span></label>
-                    <p class="settings-help">Use <code>system</code> for the operating system temp directory. Relative paths resolve under the application directory.</p>
+                    <p class="settings-help">Use <code>system</code> for the operating system temp directory. Auto prefers <code>/dev/shm</code> on Linux for known-size files within the memory limit.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a temp storage policy that prefers `/dev/shm/patris-export` on Linux for known-size temp copies within a configurable cap
- keep explicit temp directory overrides as the highest priority, with safe fallback to the ordinary system temp directory
- expose the policy through config, env vars, CLI flags, and the web settings pane

## Why this is useful
Patris temp copies are usually short-lived and small. Keeping those copies in tmpfs reduces disk churn, avoids persisting sensitive transient database copies, and can make polling/one-shot reads a little snappier. The implementation only does this when the file size is known, below the configured limit, and `/dev/shm` has enough free space.

## Validation
- npm.cmd run build in web
- go test ./pkg/filecopy ./pkg/appconfig
- go test ./pkg/filecopy ./pkg/appconfig ./pkg/datasource ./pkg/server ./pkg/embedded ./pkg/oneshot ./cmd/patris-export
- go test ./...

Closes #52