### PR TITLE
Add executable update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Update the installed executable from the latest successful GitHub Actions build 
 
 **Flags:**
 - `-b, --branch` - Branch to download from (default: main)
+- `--api-url` - Update from a running Patris Export API by fetching `/api/update/manifest`
+- `--manifest-url` - Update from an explicit executable manifest URL
 
 **Examples:**
 ```bash
@@ -327,11 +329,29 @@ patris-export update
 
 # Update from another branch
 patris-export update --branch develop
+
+# Update from another Patris Export instance/API
+patris-export update --api-url http://127.0.0.1:18080
+
+# Update from an explicit manifest endpoint
+patris-export update --manifest-url http://127.0.0.1:18080/api/update/manifest
 ```
 
 `GITHUB_TOKEN` is optional for public repositories, but recommended for higher API rate limits. Private repositories require a token that can read the repository and its Actions artifacts, such as a classic token with `repo` access.
 
 Repository lookup defaults to `atomicdeploy/patris-export`. Override it with `PATRIS_REPO_OWNER` and `PATRIS_REPO_NAME` when testing forks or custom deployments.
+
+### Executable Update API
+
+When the server is running, it can publish the exact executable that is serving the API:
+
+- `GET /api/update/manifest` returns version, platform, file name, size, SHA-256, last modified timestamp, and `download_url`.
+- `GET /api/update/executable` streams the executable.
+- `HEAD /api/update/executable` reports static headers without a body.
+
+The executable endpoint uses the real file on disk and supports byte ranges, conditional requests, `Content-Length`, `Last-Modified`, `ETag`, `X-Checksum-SHA256`, and `X-Executable-*` metadata headers. The API updater downloads by streaming to a temp file and only replaces the current executable after the manifest size and SHA-256 match the downloaded bytes.
+
+If the remote update API is protected, set `PATRIS_UPDATE_TOKEN`; this is separate from `GITHUB_TOKEN` so GitHub credentials are not sent to arbitrary update hosts.
 
 ## 🔧 API Reference
 

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -178,11 +178,15 @@ the current executable. Use --branch to update from a branch other than main.
 Examples:
   patris-export update
   patris-export update --branch develop
+  patris-export update --api-url http://127.0.0.1:18080
+  patris-export update --manifest-url http://127.0.0.1:18080/api/update/manifest
 
 Set GITHUB_TOKEN for private repositories and higher API rate limits.`,
 		Run: runUpdate,
 	}
 	updateCmd.Flags().StringP("branch", "b", "main", "Branch to download from")
+	updateCmd.Flags().String("api-url", "", "Update from a Patris Export API base URL using /api/update/manifest")
+	updateCmd.Flags().String("manifest-url", "", "Update from an explicit Patris Export executable manifest URL")
 
 	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, viewCmd, serveCmd, ipcCmd, tuiCmd, updateCmd)
 
@@ -218,6 +222,21 @@ func runRoot(cmd *cobra.Command, args []string) {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) {
+	apiURL, err := cmd.Flags().GetString("api-url")
+	if err != nil {
+		errorColor.Printf("❌ Failed to read 'api-url' flag: %v\n", err)
+		os.Exit(1)
+	}
+	manifestURL, err := cmd.Flags().GetString("manifest-url")
+	if err != nil {
+		errorColor.Printf("❌ Failed to read 'manifest-url' flag: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(apiURL) != "" || strings.TrimSpace(manifestURL) != "" {
+		runAPIUpdate(apiURL, manifestURL)
+		return
+	}
+
 	branch, err := cmd.Flags().GetString("branch")
 	if err != nil {
 		errorColor.Printf("❌ Failed to read 'branch' flag: %v\n", err)
@@ -332,6 +351,79 @@ func runUpdate(cmd *cobra.Command, args []string) {
 	infoColor.Printf("📅 Build date: %s\n", run.CreatedAt.Format("2006-01-02 15:04:05"))
 	infoColor.Println("💡 Run 'patris-export --version' to verify the update")
 	fmt.Println()
+}
+
+func runAPIUpdate(apiURL, manifestURL string) {
+	fmt.Println()
+	successColor.Println("🚀 Patris Export API Update")
+	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	fmt.Println()
+
+	manifestURL = strings.TrimSpace(manifestURL)
+	if manifestURL == "" {
+		var err error
+		manifestURL, err = updater.ManifestURLFromAPIBase(apiURL)
+		if err != nil {
+			errorColor.Printf("❌ Invalid API URL: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	infoColor.Printf("🔎 Manifest: %s\n", manifestURL)
+	u := updater.NewAPIUpdater()
+
+	manifest, err := u.FetchExecutableManifest(manifestURL)
+	if err != nil {
+		errorColor.Printf("❌ Failed to fetch manifest: %v\n", err)
+		os.Exit(1)
+	}
+	successColor.Printf("✅ Remote version: %s (commit %s)\n", manifest.Version.Version, shortCLIHash(manifest.Version.Commit))
+	infoColor.Printf("💻 Platform: %s\n", manifest.Platform)
+	infoColor.Printf("📦 File: %s (%.2f MB)\n", manifest.Filename, float64(manifest.Size)/(1024*1024))
+	infoColor.Printf("🔐 SHA-256: %s\n", shortCLIHash(manifest.SHA256))
+	infoColor.Printf("🕒 Modified: %s\n", manifest.LastModified.Local().Format("2006-01-02 15:04:05"))
+	fmt.Println()
+
+	tempDir, err := os.MkdirTemp("", "patris-api-update-*")
+	if err != nil {
+		errorColor.Printf("❌ Failed to create temp directory: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tempDir)
+
+	infoColor.Println("⬇️  Downloading and verifying executable...")
+	exePath, err := u.DownloadExecutableFromManifest(manifest, tempDir)
+	if err != nil {
+		errorColor.Printf("❌ Failed to download executable: %v\n", err)
+		os.Exit(1)
+	}
+	successColor.Printf("✅ Verified download: %s\n", filepath.Base(exePath))
+	fmt.Println()
+
+	infoColor.Println("🔄 Replacing current executable...")
+	if err := u.ReplaceCurrentExecutable(exePath); err != nil {
+		errorColor.Printf("❌ Failed to replace executable: %v\n", err)
+		errorColor.Println("💡 You may need elevated permissions to update the executable")
+		os.Exit(1)
+	}
+
+	fmt.Println()
+	successColor.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	successColor.Println("✨ API update completed successfully! ✨")
+	successColor.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	infoColor.Println("💡 Restart patris-export, then run 'patris-export --version' to verify.")
+	fmt.Println()
+}
+
+func shortCLIHash(value string) string {
+	value = strings.TrimPrefix(strings.TrimSpace(value), "sha256:")
+	if value == "" {
+		return "unknown"
+	}
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
 }
 
 func cliIntro() string {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/notifier"
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
+	"github.com/atomicdeploy/patris-export/pkg/updater"
 	"github.com/atomicdeploy/patris-export/pkg/version"
 	"github.com/atomicdeploy/patris-export/pkg/watcher"
 	"github.com/atomicdeploy/patris-export/web"
@@ -185,6 +187,8 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/config", s.handlePutConfig).Methods("PUT")
 	s.router.HandleFunc("/api/status", s.handleGetStatus).Methods("GET")
 	s.router.HandleFunc("/api/toast", s.handlePostToast).Methods("POST")
+	s.router.HandleFunc("/api/update/manifest", s.handleGetUpdateManifest).Methods("GET")
+	s.router.HandleFunc("/api/update/executable", s.handleGetExecutable).Methods("GET", "HEAD")
 	s.router.HandleFunc("/api/processes/patris81", s.handleGetPatris81Processes).Methods("GET")
 	s.router.HandleFunc("/api/processes/file", s.handleGetFileProcesses).Methods("GET")
 	s.router.HandleFunc("/static/notification.ogg", s.handleNotificationAudio).Methods("GET", "HEAD")
@@ -531,6 +535,42 @@ func (s *Server) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, s.Status())
 }
 
+func (s *Server) handleGetUpdateManifest(w http.ResponseWriter, r *http.Request) {
+	manifest, err := s.executableManifest(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to inspect executable: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, manifest)
+}
+
+func (s *Server) handleGetExecutable(w http.ResponseWriter, r *http.Request) {
+	manifest, exePath, err := s.executableManifestForPath(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to inspect executable: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	file, err := os.Open(exePath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to open executable: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": manifest.Filename}))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Date", time.Now().UTC().Format(http.TimeFormat))
+	w.Header().Set("ETag", fmt.Sprintf("\"sha256:%s\"", manifest.SHA256))
+	w.Header().Set("X-Checksum-SHA256", manifest.SHA256)
+	w.Header().Set("X-Executable-Size", fmt.Sprintf("%d", manifest.Size))
+	w.Header().Set("X-Executable-Modified", manifest.LastModified.UTC().Format(time.RFC3339))
+	http.ServeContent(w, r, manifest.Filename, manifest.LastModified, file)
+}
+
 // handlePostToast displays a native notification and broadcasts it to web clients.
 func (s *Server) handlePostToast(w http.ResponseWriter, r *http.Request) {
 	var req ToastRequest
@@ -822,6 +862,67 @@ func (s *Server) notifyConfigured(event, title, message string) {
 	if err := s.processToastRequest(req); err != nil {
 		log.Printf("Configured notification failed: %v", err)
 	}
+}
+
+func (s *Server) executableManifest(r *http.Request) (updater.ExecutableManifest, error) {
+	manifest, _, err := s.executableManifestForPath(r)
+	return manifest, err
+}
+
+func (s *Server) executableManifestForPath(r *http.Request) (updater.ExecutableManifest, string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return updater.ExecutableManifest{}, "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+	info, err := os.Stat(exePath)
+	if err != nil {
+		return updater.ExecutableManifest{}, "", err
+	}
+	hash, err := updater.FileSHA256(exePath)
+	if err != nil {
+		return updater.ExecutableManifest{}, "", err
+	}
+	v := s.version
+	if v.Version == "" {
+		v = version.Current()
+	}
+	manifest := updater.ExecutableManifest{
+		Name:     "Patris Export",
+		Filename: filepath.Base(exePath),
+		Version: updater.VersionShape{
+			Version:   v.Version,
+			BuildDate: v.BuildDate,
+			Commit:    v.Commit,
+			GoVersion: v.GoVersion,
+			Platform:  v.Platform,
+		},
+		Platform:     updater.CurrentPlatform(),
+		Size:         info.Size(),
+		SHA256:       hash,
+		LastModified: info.ModTime().UTC(),
+		DownloadURL:  absoluteURL(r, "/api/update/executable"),
+		GeneratedAt:  time.Now().UTC(),
+	}
+	return manifest, exePath, nil
+}
+
+func absoluteURL(r *http.Request, path string) string {
+	scheme := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = r.Host
+	}
+	return (&url.URL{Scheme: scheme, Host: host, Path: path}).String()
 }
 
 func notificationEventEnabled(cfg appconfig.NotificationsConfig, event string) bool {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -158,6 +159,77 @@ func TestServerJSON(t *testing.T) {
 
 		if w.Body.Len() == 0 {
 			t.Error("Expected non-empty favicon")
+		}
+	})
+
+	t.Run("GET /api/update/manifest", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/update/manifest", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", w.Code)
+		}
+		if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Expected Cache-Control no-store, got %s", cc)
+		}
+
+		var manifest map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&manifest); err != nil {
+			t.Fatalf("Failed to decode manifest: %v", err)
+		}
+		if manifest["filename"] == "" {
+			t.Error("Expected manifest filename")
+		}
+		if manifest["sha256"] == "" {
+			t.Error("Expected manifest sha256")
+		}
+		if manifest["size"].(float64) <= 0 {
+			t.Error("Expected positive manifest size")
+		}
+		if !strings.Contains(manifest["download_url"].(string), "/api/update/executable") {
+			t.Errorf("Expected manifest download URL to point at executable endpoint, got %s", manifest["download_url"])
+		}
+		if _, err := time.Parse(time.RFC3339, manifest["last_modified"].(string)); err != nil {
+			t.Fatalf("Expected RFC3339 last_modified, got %v", manifest["last_modified"])
+		}
+	})
+
+	t.Run("HEAD /api/update/executable has static headers", func(t *testing.T) {
+		req := httptest.NewRequest("HEAD", "/api/update/executable", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", w.Code)
+		}
+		for _, header := range []string{"Content-Length", "Last-Modified", "Date", "ETag", "X-Checksum-SHA256", "X-Executable-Size", "X-Executable-Modified"} {
+			if got := w.Header().Get(header); got == "" {
+				t.Errorf("Expected %s header", header)
+			}
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/octet-stream" {
+			t.Errorf("Expected executable content type, got %s", ct)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("Expected empty HEAD body, got %d bytes", w.Body.Len())
+		}
+	})
+
+	t.Run("GET /api/update/executable supports ranges", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/update/executable", nil)
+		req.Header.Set("Range", "bytes=0-15")
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusPartialContent {
+			t.Fatalf("Expected status 206, got %d", w.Code)
+		}
+		if w.Body.Len() != 16 {
+			t.Errorf("Expected 16 response bytes, got %d", w.Body.Len())
+		}
+		if got := w.Header().Get("Content-Range"); !strings.HasPrefix(got, "bytes 0-15/") {
+			t.Errorf("Unexpected Content-Range: %s", got)
 		}
 	})
 }

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -67,6 +68,30 @@ type ArtifactsResponse struct {
 	Artifacts  []Artifact `json:"artifacts"`
 }
 
+// ExecutableManifest describes a directly downloadable patris-export binary.
+// It is served by the app itself and consumed by API-based self-updates.
+type ExecutableManifest struct {
+	Name         string       `json:"name"`
+	Filename     string       `json:"filename"`
+	Version      VersionShape `json:"version"`
+	Platform     string       `json:"platform"`
+	Size         int64        `json:"size"`
+	SHA256       string       `json:"sha256"`
+	LastModified time.Time    `json:"last_modified"`
+	DownloadURL  string       `json:"download_url"`
+	GeneratedAt  time.Time    `json:"generated_at"`
+}
+
+// VersionShape mirrors pkg/version.Info without making update metadata depend
+// on that package.
+type VersionShape struct {
+	Version   string `json:"version"`
+	BuildDate string `json:"build_date"`
+	Commit    string `json:"commit"`
+	GoVersion string `json:"go_version"`
+	Platform  string `json:"platform"`
+}
+
 // NewUpdater creates a new updater instance
 func NewUpdater(repoOwner, repoName string) *Updater {
 	// Derive binary name from the current executable
@@ -82,6 +107,36 @@ func NewUpdater(repoOwner, repoName string) *Updater {
 			Timeout: defaultHTTPTimeout,
 		},
 	}
+}
+
+// NewAPIUpdater creates an updater for manifest-based HTTP APIs. It
+// intentionally does not reuse GITHUB_TOKEN so repository credentials are not
+// sent to arbitrary update servers. Set PATRIS_UPDATE_TOKEN when the remote
+// manifest/executable endpoints require bearer authentication.
+func NewAPIUpdater() *Updater {
+	u := NewUpdater("", "patris-export")
+	u.apiToken = strings.TrimSpace(os.Getenv("PATRIS_UPDATE_TOKEN"))
+	return u
+}
+
+// CurrentPlatform returns the runtime platform string used in manifests.
+func CurrentPlatform() string {
+	return runtime.GOOS + "/" + runtime.GOARCH
+}
+
+// FileSHA256 calculates a hex-encoded SHA-256 digest for path.
+func FileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file for sha256: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("failed to calculate sha256: %w", err)
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // deriveBinaryName derives the base binary name from the current executable
@@ -297,6 +352,182 @@ func verifyArtifactDigest(expected string, actual []byte) error {
 	}
 
 	return nil
+}
+
+// ManifestURLFromAPIBase returns the standard manifest endpoint for a Patris
+// Export API base URL.
+func ManifestURLFromAPIBase(apiBase string) (string, error) {
+	base, err := url.Parse(strings.TrimSpace(apiBase))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse API URL: %w", err)
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("API URL must include scheme and host")
+	}
+	return base.JoinPath("api", "update", "manifest").String(), nil
+}
+
+// FetchExecutableManifest downloads and validates a remote executable manifest.
+func (u *Updater) FetchExecutableManifest(manifestURL string) (*ExecutableManifest, error) {
+	manifestURL = strings.TrimSpace(manifestURL)
+	if manifestURL == "" {
+		return nil, fmt.Errorf("manifest URL is required")
+	}
+	req, err := http.NewRequest(http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manifest request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if u.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+u.apiToken)
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("manifest request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("manifest request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var manifest ExecutableManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("failed to decode manifest: %w", err)
+	}
+	if err := validateManifest(&manifest); err != nil {
+		return nil, err
+	}
+
+	downloadURL, err := resolveManifestURL(manifestURL, manifest.DownloadURL)
+	if err != nil {
+		return nil, err
+	}
+	manifest.DownloadURL = downloadURL
+	return &manifest, nil
+}
+
+func validateManifest(manifest *ExecutableManifest) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is nil")
+	}
+	if strings.TrimSpace(manifest.Filename) == "" {
+		return fmt.Errorf("manifest filename is required")
+	}
+	if strings.TrimSpace(manifest.Platform) == "" {
+		return fmt.Errorf("manifest platform is required")
+	}
+	if manifest.Platform != CurrentPlatform() {
+		return fmt.Errorf("manifest platform %q does not match current platform %q", manifest.Platform, CurrentPlatform())
+	}
+	if manifest.Size <= 0 {
+		return fmt.Errorf("manifest size must be positive")
+	}
+	if _, err := decodeSHA256(manifest.SHA256); err != nil {
+		return fmt.Errorf("manifest sha256 is invalid: %w", err)
+	}
+	if strings.TrimSpace(manifest.DownloadURL) == "" {
+		return fmt.Errorf("manifest download_url is required")
+	}
+	return nil
+}
+
+func decodeSHA256(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "sha256:")
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(decoded) != sha256.Size {
+		return nil, fmt.Errorf("expected %d bytes, got %d", sha256.Size, len(decoded))
+	}
+	return decoded, nil
+}
+
+func resolveManifestURL(manifestURL, rawDownloadURL string) (string, error) {
+	base, err := url.Parse(manifestURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse manifest URL: %w", err)
+	}
+	ref, err := url.Parse(strings.TrimSpace(rawDownloadURL))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse download URL: %w", err)
+	}
+	return base.ResolveReference(ref).String(), nil
+}
+
+// DownloadExecutableFromManifest streams the manifest executable to destDir and
+// verifies the downloaded size and SHA-256 digest before returning the path.
+func (u *Updater) DownloadExecutableFromManifest(manifest *ExecutableManifest, destDir string) (destPath string, err error) {
+	if err := validateManifest(manifest); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	destPath = filepath.Join(destDir, filepath.Base(manifest.Filename))
+	tmpPath := destPath + ".download"
+	out, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return "", fmt.Errorf("failed to create downloaded executable: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	req, err := http.NewRequest(http.MethodGet, manifest.DownloadURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create executable request: %w", err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	if u.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+u.apiToken)
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("executable download failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("executable download failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if resp.ContentLength >= 0 && resp.ContentLength != manifest.Size {
+		return "", fmt.Errorf("download content length mismatch: manifest=%d response=%d", manifest.Size, resp.ContentLength)
+	}
+	if headerHash := strings.TrimSpace(resp.Header.Get("X-Checksum-SHA256")); headerHash != "" && !strings.EqualFold(strings.TrimPrefix(headerHash, "sha256:"), strings.TrimPrefix(manifest.SHA256, "sha256:")) {
+		return "", fmt.Errorf("download checksum header mismatch: manifest=%s response=%s", manifest.SHA256, headerHash)
+	}
+
+	hash := sha256.New()
+	written, err := io.CopyBuffer(io.MultiWriter(out, hash), resp.Body, make([]byte, 1024*1024))
+	if err != nil {
+		return "", fmt.Errorf("failed to write downloaded executable: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return "", fmt.Errorf("failed to close downloaded executable: %w", err)
+	}
+	if written != manifest.Size {
+		return "", fmt.Errorf("download size mismatch: manifest=%d downloaded=%d", manifest.Size, written)
+	}
+	actualHex := hex.EncodeToString(hash.Sum(nil))
+	if !strings.EqualFold(strings.TrimPrefix(manifest.SHA256, "sha256:"), actualHex) {
+		return "", fmt.Errorf("download sha256 mismatch: manifest=%s downloaded=sha256:%s", manifest.SHA256, actualHex)
+	}
+	if !manifest.LastModified.IsZero() {
+		_ = os.Chtimes(tmpPath, time.Now(), manifest.LastModified)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return "", fmt.Errorf("failed to finalize downloaded executable: %w", err)
+	}
+	return destPath, nil
 }
 
 // ExtractExecutable extracts the executable from a ZIP file

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetCurrentPlatformArtifactName(t *testing.T) {
@@ -66,6 +67,16 @@ func TestNewUpdater(t *testing.T) {
 
 	if u.repoName != "testrepo" {
 		t.Errorf("Expected repoName to be 'testrepo', got '%s'", u.repoName)
+	}
+}
+
+func TestNewAPIUpdaterUsesSeparateToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "github-secret")
+	t.Setenv("PATRIS_UPDATE_TOKEN", "update-secret")
+
+	u := NewAPIUpdater()
+	if u.apiToken != "update-secret" {
+		t.Fatalf("API updater token = %q", u.apiToken)
 	}
 }
 
@@ -361,6 +372,83 @@ func TestDownloadArtifactRejectsDigestMismatch(t *testing.T) {
 
 	if _, err := u.DownloadArtifact(artifact, t.TempDir()); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("expected digest mismatch error, got %v", err)
+	}
+}
+
+func TestManifestURLFromAPIBase(t *testing.T) {
+	got, err := ManifestURLFromAPIBase("http://127.0.0.1:18080/")
+	if err != nil {
+		t.Fatalf("ManifestURLFromAPIBase returned error: %v", err)
+	}
+	if got != "http://127.0.0.1:18080/api/update/manifest" {
+		t.Fatalf("manifest URL = %q", got)
+	}
+}
+
+func TestFetchAndDownloadExecutableFromManifest(t *testing.T) {
+	payload := []byte("new executable bytes")
+	sum := sha256.Sum256(payload)
+	modTime := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/update/manifest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"name":"Patris Export","filename":"patris-export-test","version":{"version":"9.9.9","commit":"abcdef123456","build_date":"2026-07-10T12:00:00Z","go_version":"go1.test","platform":%q},"platform":%q,"size":%d,"sha256":"%x","last_modified":%q,"download_url":"/api/update/executable","generated_at":%q}`,
+				CurrentPlatform(), CurrentPlatform(), len(payload), sum, modTime.Format(time.RFC3339), modTime.Format(time.RFC3339))
+		case "/api/update/executable":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			w.Header().Set("X-Checksum-SHA256", fmt.Sprintf("%x", sum))
+			w.Write(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	u := NewUpdater("testowner", "testrepo")
+	u.client = server.Client()
+	manifest, err := u.FetchExecutableManifest(server.URL + "/api/update/manifest")
+	if err != nil {
+		t.Fatalf("FetchExecutableManifest returned error: %v", err)
+	}
+	if manifest.DownloadURL != server.URL+"/api/update/executable" {
+		t.Fatalf("download URL = %q", manifest.DownloadURL)
+	}
+
+	exePath, err := u.DownloadExecutableFromManifest(manifest, t.TempDir())
+	if err != nil {
+		t.Fatalf("DownloadExecutableFromManifest returned error: %v", err)
+	}
+	got, err := os.ReadFile(exePath)
+	if err != nil {
+		t.Fatalf("failed to read downloaded executable: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("downloaded payload = %q", got)
+	}
+}
+
+func TestDownloadExecutableFromManifestRejectsHashMismatch(t *testing.T) {
+	payload := []byte("different executable bytes")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.Write(payload)
+	}))
+	defer server.Close()
+
+	u := NewUpdater("testowner", "testrepo")
+	u.client = server.Client()
+	manifest := &ExecutableManifest{
+		Filename:    "patris-export-test",
+		Platform:    CurrentPlatform(),
+		Size:        int64(len(payload)),
+		SHA256:      strings.Repeat("0", 64),
+		DownloadURL: server.URL,
+	}
+	if _, err := u.DownloadExecutableFromManifest(manifest, t.TempDir()); err == nil || !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Fatalf("expected sha256 mismatch, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `/api/update/manifest` with executable metadata: version, platform, file name, size, SHA-256, last modified time, and download URL
- add `/api/update/executable` to serve the running executable with HEAD/range/static-file headers
- add `patris-export update --api-url ...` and `--manifest-url ...` for manifest-based self-update from a remote Patris Export API
- keep the existing GitHub Actions artifact updater as the default update mode

## Safety and correctness
- executable downloads are streamed to a temp file and verified against manifest size and SHA-256 before replacement
- update manifests must declare the current runtime platform
- API updates use `PATRIS_UPDATE_TOKEN`, not `GITHUB_TOKEN`, so GitHub credentials are not sent to arbitrary update hosts
- executable serving uses the real file on disk through `http.ServeContent` for correct `HEAD`, range, `Content-Length`, and `Last-Modified` behavior

## Validation
- go test ./pkg/updater ./pkg/server ./cmd/patris-export
- go test ./...

Closes #54