### PR TITLE
Refresh GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,17 +20,18 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.23'
+        go-version: '1.24.11'
+        cache: false
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Install MSYS2 MinGW tools
       uses: msys2/setup-msys2@v2
@@ -183,7 +184,7 @@ jobs:
         }
     
     - name: Upload Windows artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: patris-export-windows-mingw-amd64
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,18 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.23'
+        go-version: '1.24.11'
+        cache: false
     
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         
     - name: Install dependencies and source pxlib
       run: |
@@ -58,7 +59,7 @@ jobs:
       run: make build-lib-linux
       
     - name: Upload Linux artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: patris-export-linux-amd64
         path: |
@@ -74,17 +75,18 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.23'
+        go-version: '1.24.11'
+        cache: false
     
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         
     - name: Install cross-compilation tools
       run: |
@@ -186,7 +188,7 @@ jobs:
         fi
         
     - name: Upload Windows artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: patris-export-windows-mingw-cross-amd64
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       
     - name: Wait for build workflows
       uses: actions/github-script@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,18 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.23'
+        go-version: '1.24.11'
+        cache: false
     
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
-        node-version: '20'
+        node-version: '24'
         
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- update first-party GitHub Actions to current Node 24-compatible releases:
  - `actions/checkout@v7.0.0`
  - `actions/setup-go@v6.5.0`
  - `actions/setup-node@v6.4.0`
  - `actions/upload-artifact@v7.0.1`
- run workflow Node setup with `node-version: '24'`
- disable `setup-go` implicit cache restore with `cache: false` to stop the `/usr/bin/tar` restore warning seen in the build logs
- update release workflow checkout to the same current checkout action

## Evidence
The referenced run completed successfully, but its Build jobs report Node 20 action deprecation warnings and `/usr/bin/tar` cache restore failures during setup. The action tags above were verified through the GitHub API before updating.

## Validation
- verified no remaining `checkout@v4`, `setup-go@v5`, `setup-node@v4`, `upload-artifact@v4`, or `node-version: '20'` entries in workflows
- verified updated action tags exist upstream
- `git diff --check`

Closes #56