### PR TITLE
Add edge stub upload mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,47 @@ Embedding, loadable-library builds, and local IPC are documented in [docs/EMBEDD
 Experimental RTL logical text conversion is available as an opt-in backend flag
 and web display setting. See [docs/RTL_CONVERSION.md](docs/RTL_CONVERSION.md).
 
+### Edge Stub Upload Mode
+
+Run the full server on a central machine and let lightweight edge machines push
+raw `.db` snapshots whenever Patris updates the file:
+
+```bash
+# Central receiver
+PATRIS_EDGE_TOKEN=change-me patris-export serve received.db --addr 0.0.0.0:18080
+
+# Edge machine beside Patris81
+patris-export stub C:\Patris\data4\kala.db ^
+  --target-url http://central-server:18080 ^
+  --token change-me ^
+  --source-id branch-a ^
+  --debounce 750ms
+```
+
+The stub streams multipart uploads to `/api/edge/upload`; the receiver stores the
+snapshot, switches its active data source, transforms rows normally, and
+broadcasts updates through the existing WebSocket/API/UI paths.
+
+Config and environment equivalents:
+
+```yaml
+edge:
+  target_url: http://central-server:18080
+  token: change-me
+  source_id: branch-a
+  debounce: 750ms
+  max_upload_mb: 512
+  upload_dir: edge-uploads
+```
+
+```bash
+PATRIS_EDGE_TARGET_URL=http://central-server:18080
+PATRIS_EDGE_TOKEN=change-me
+PATRIS_EDGE_SOURCE_ID=branch-a
+PATRIS_EDGE_DEBOUNCE=750ms
+PATRIS_EDGE_MAX_UPLOAD_MB=512
+```
+
 ### One-shot Native Viewer
 
 Open a local snapshot viewer directly from a database file:

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
 	"github.com/atomicdeploy/patris-export/pkg/converter"
+	edgepkg "github.com/atomicdeploy/patris-export/pkg/edge"
 	"github.com/atomicdeploy/patris-export/pkg/embedded"
 	"github.com/atomicdeploy/patris-export/pkg/filecopy"
 	"github.com/atomicdeploy/patris-export/pkg/ipc"
@@ -35,21 +36,28 @@ import (
 
 var (
 	// Global flags
-	charMapFile  string
-	configFiles  []string
-	tempDir      string
-	tempStrategy string
-	tempLimitMB  int64
-	outputDir    string
-	outputFormat string
-	dbFileFlag   string
-	viewHTMLOut  string
-	viewNoOpen   bool
-	viewTitle    string
-	watchMode    bool
-	verbose      bool
-	directAccess bool
-	rtlMode      bool
+	charMapFile     string
+	configFiles     []string
+	tempDir         string
+	tempStrategy    string
+	tempLimitMB     int64
+	outputDir       string
+	outputFormat    string
+	dbFileFlag      string
+	viewHTMLOut     string
+	viewNoOpen      bool
+	viewTitle       string
+	watchMode       bool
+	verbose         bool
+	directAccess    bool
+	rtlMode         bool
+	edgeTargetURL   string
+	edgeToken       string
+	edgeSourceID    string
+	edgeDebounce    string
+	edgeOnce        bool
+	edgeInitial     bool
+	edgeMaxUploadMB int64
 
 	// Color definitions
 	successColor = color.New(color.FgGreen, color.Bold)
@@ -152,6 +160,27 @@ Supports Persian/Farsi encoding conversion and file watching.
 	serveCmd.Flags().Bool("ipc", false, "Enable local IPC listener (Windows named pipe, Unix socket)")
 	serveCmd.Flags().String("ipc-path", "", "IPC path/name (default: platform-specific patris-export endpoint)")
 
+	stubCmd := &cobra.Command{
+		Use:     "stub [database-file]",
+		Aliases: []string{"edge"},
+		Short:   "📡 Watch a local database and push snapshots to a remote patris-export server",
+		Long: `📡 Edge stub mode watches a local Patris .db file and uploads the raw file
+to a remote patris-export instance for conversion, transformation, REST, Web UI,
+WebSocket, IPC, and notification processing.
+
+This is intended for lightweight edge machines where Patris writes the database,
+while a stronger server does the expensive processing and serves clients.`,
+		Args: cobra.MaximumNArgs(1),
+		Run:  runStub,
+	}
+	stubCmd.Flags().StringVar(&edgeTargetURL, "target-url", "", "Remote patris-export base URL or /api/edge/upload endpoint")
+	stubCmd.Flags().StringVar(&edgeToken, "token", "", "Optional bearer token for the remote edge upload endpoint")
+	stubCmd.Flags().StringVar(&edgeSourceID, "source-id", "", "Stable edge/source identifier included with uploads")
+	stubCmd.Flags().StringVar(&edgeDebounce, "debounce", "", "Debounce duration before upload after local file changes")
+	stubCmd.Flags().BoolVar(&edgeOnce, "once", false, "Upload once and exit instead of watching")
+	stubCmd.Flags().BoolVar(&edgeInitial, "initial", true, "Upload the current file once before watching")
+	stubCmd.Flags().Int64Var(&edgeMaxUploadMB, "max-upload-mb", 0, "Maximum local file size to upload in MiB")
+
 	ipcCmd := &cobra.Command{
 		Use:   "ipc [method] [json-params]",
 		Short: "Call a local patris-export IPC endpoint",
@@ -188,7 +217,7 @@ Set GITHUB_TOKEN for private repositories and higher API rate limits.`,
 	updateCmd.Flags().String("api-url", "", "Update from a Patris Export API base URL using /api/update/manifest")
 	updateCmd.Flags().String("manifest-url", "", "Update from an explicit Patris Export executable manifest URL")
 
-	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, viewCmd, serveCmd, ipcCmd, tuiCmd, updateCmd)
+	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, viewCmd, serveCmd, stubCmd, ipcCmd, tuiCmd, updateCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		errorColor.Fprintf(os.Stderr, "❌ Error: %v\n", err)
@@ -971,6 +1000,110 @@ func isViewableSource(path string) bool {
 		}
 	}
 	return ext == ".db" || ext == ".json"
+}
+
+func runStub(cmd *cobra.Command, args []string) {
+	_, cfg := effectiveConfig(cmd)
+	dbFile := cfg.Database.Path
+	if strings.TrimSpace(dbFileFlag) != "" {
+		dbFile = strings.TrimSpace(dbFileFlag)
+	}
+	if len(args) > 0 {
+		dbFile = args[0]
+	}
+	if strings.TrimSpace(dbFile) == "" {
+		errorColor.Println("No database file specified. Pass one to stub, set --db, or set database.path in config.")
+		os.Exit(1)
+	}
+	if filecopy.IsURL(dbFile) {
+		errorColor.Println("Edge stub mode watches local files only. Use a local .db path.")
+		os.Exit(1)
+	}
+
+	targetURL := edgeTargetURL
+	if !cmd.Flags().Changed("target-url") {
+		targetURL = cfg.Edge.TargetURL
+	}
+	token := edgeToken
+	if !cmd.Flags().Changed("token") {
+		token = cfg.Edge.Token
+	}
+	sourceID := edgeSourceID
+	if !cmd.Flags().Changed("source-id") {
+		sourceID = cfg.Edge.SourceID
+	}
+	debounceStr := edgeDebounce
+	if !cmd.Flags().Changed("debounce") {
+		debounceStr = cfg.Edge.Debounce
+	}
+	maxUploadMB := edgeMaxUploadMB
+	if !cmd.Flags().Changed("max-upload-mb") {
+		maxUploadMB = cfg.Edge.MaxUploadMB
+	}
+	if maxUploadMB <= 0 {
+		maxUploadMB = 512
+	}
+	debounceDuration := parseDebounceDuration(debounceStr)
+
+	client := edgepkg.Client{
+		TargetURL: targetURL,
+		Token:     token,
+		SourceID:  sourceID,
+		MaxBytes:  maxUploadMB * 1024 * 1024,
+	}
+	if _, err := edgepkg.UploadURL(targetURL); err != nil {
+		errorColor.Printf("Invalid edge target URL: %v\n", err)
+		os.Exit(1)
+	}
+
+	displayFileStatus(dbFile)
+	checkProcessConflicts(dbFile)
+
+	upload := func(path string) bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		infoColor.Printf("📤 Uploading %s to %s\n", filepath.Base(path), targetURL)
+		result, err := client.UploadFile(ctx, path)
+		if err != nil {
+			errorColor.Printf("Edge upload failed: %v\n", err)
+			return false
+		}
+		successColor.Printf("✅ Edge upload accepted: %d records, %d bytes, hash=%s\n", result.Records, result.Size, result.Hash)
+		return true
+	}
+
+	if edgeInitial || edgeOnce {
+		if ok := upload(dbFile); !ok && edgeOnce {
+			os.Exit(1)
+		}
+	}
+	if edgeOnce {
+		return
+	}
+
+	fw, err := watcher.NewFileWatcher()
+	if err != nil {
+		errorColor.Printf("Failed to create file watcher: %v\n", err)
+		os.Exit(1)
+	}
+	defer fw.Close()
+
+	if err := fw.Watch(dbFile, func(path string) {
+		infoColor.Printf("🔄 Local database changed: %s\n", filepath.Base(path))
+		upload(path)
+	}, debounceDuration); err != nil {
+		errorColor.Printf("Failed to watch database file: %v\n", err)
+		os.Exit(1)
+	}
+	fw.Start()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	successColor.Printf("📡 Edge stub watching %s\n", filepath.Base(dbFile))
+	infoColor.Printf("🎯 Remote target: %s\n", targetURL)
+	infoColor.Printf("⏱️ Debounce: %s | Max upload: %d MiB\n", debounceDuration, maxUploadMB)
+	infoColor.Println("Press Ctrl+C to stop the edge stub")
+	<-ctx.Done()
 }
 
 func runIPC(cmd *cobra.Command, args []string) {

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Database      DatabaseConfig         `json:"database" yaml:"database" toml:"database"`
 	Runtime       RuntimeConfig          `json:"runtime" yaml:"runtime" toml:"runtime"`
 	Convert       ConvertConfig          `json:"convert" yaml:"convert" toml:"convert"`
+	Edge          EdgeConfig             `json:"edge" yaml:"edge" toml:"edge"`
 	Notifications NotificationsConfig    `json:"notifications" yaml:"notifications" toml:"notifications"`
 	UI            UIConfig               `json:"ui" yaml:"ui" toml:"ui"`
 	ColumnLabels  map[string]string      `json:"column_labels" yaml:"column_labels" toml:"column_labels"`
@@ -71,6 +72,16 @@ type ConvertConfig struct {
 	Format   string `json:"format" yaml:"format" toml:"format"`
 	Watch    bool   `json:"watch" yaml:"watch" toml:"watch"`
 	Debounce string `json:"debounce" yaml:"debounce" toml:"debounce"`
+}
+
+type EdgeConfig struct {
+	Enabled     bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
+	TargetURL   string `json:"target_url" yaml:"target_url" toml:"target_url"`
+	Token       string `json:"token,omitempty" yaml:"token,omitempty" toml:"token,omitempty"`
+	SourceID    string `json:"source_id" yaml:"source_id" toml:"source_id"`
+	Debounce    string `json:"debounce" yaml:"debounce" toml:"debounce"`
+	MaxUploadMB int64  `json:"max_upload_mb" yaml:"max_upload_mb" toml:"max_upload_mb"`
+	UploadDir   string `json:"upload_dir" yaml:"upload_dir" toml:"upload_dir"`
 }
 
 type NotificationsConfig struct {
@@ -125,6 +136,11 @@ func Default() Config {
 			Output:   ".",
 			Format:   "json",
 			Debounce: "1s",
+		},
+		Edge: EdgeConfig{
+			Debounce:    "1s",
+			MaxUploadMB: 512,
+			UploadDir:   "edge-uploads",
 		},
 		Notifications: NotificationsConfig{
 			Native:  true,
@@ -541,6 +557,29 @@ func ApplyEnv(cfg *Config) {
 	if value := os.Getenv("PATRIS_CONVERT_DEBOUNCE"); strings.TrimSpace(value) != "" {
 		cfg.Convert.Debounce = strings.TrimSpace(value)
 	}
+	if value := os.Getenv("PATRIS_EDGE_ENABLED"); strings.TrimSpace(value) != "" {
+		cfg.Edge.Enabled = parseBool(value, cfg.Edge.Enabled)
+	}
+	if value := os.Getenv("PATRIS_EDGE_TARGET_URL"); strings.TrimSpace(value) != "" {
+		cfg.Edge.TargetURL = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EDGE_TOKEN"); strings.TrimSpace(value) != "" {
+		cfg.Edge.Token = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EDGE_SOURCE_ID"); strings.TrimSpace(value) != "" {
+		cfg.Edge.SourceID = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EDGE_DEBOUNCE"); strings.TrimSpace(value) != "" {
+		cfg.Edge.Debounce = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EDGE_MAX_UPLOAD_MB"); strings.TrimSpace(value) != "" {
+		if maxMB, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+			cfg.Edge.MaxUploadMB = maxMB
+		}
+	}
+	if value := os.Getenv("PATRIS_EDGE_UPLOAD_DIR"); strings.TrimSpace(value) != "" {
+		cfg.Edge.UploadDir = strings.TrimSpace(value)
+	}
 	applyBoolEnv := func(key string, dst *bool) {
 		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
 			*dst = parseBool(value, *dst)
@@ -612,6 +651,18 @@ func normalize(cfg *Config) {
 	}
 	if cfg.Convert.Debounce == "" {
 		cfg.Convert.Debounce = "1s"
+	}
+	cfg.Edge.TargetURL = strings.TrimRight(strings.TrimSpace(cfg.Edge.TargetURL), "/")
+	cfg.Edge.Token = strings.TrimSpace(cfg.Edge.Token)
+	cfg.Edge.SourceID = strings.TrimSpace(cfg.Edge.SourceID)
+	if cfg.Edge.Debounce == "" {
+		cfg.Edge.Debounce = "1s"
+	}
+	if cfg.Edge.MaxUploadMB <= 0 {
+		cfg.Edge.MaxUploadMB = 512
+	}
+	if cfg.Edge.UploadDir == "" {
+		cfg.Edge.UploadDir = "edge-uploads"
 	}
 	if !cfg.Notifications.Native && !cfg.Notifications.InApp {
 		cfg.Notifications.Native = true

--- a/pkg/edge/client.go
+++ b/pkg/edge/client.go
@@ -1,0 +1,182 @@
+package edge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/filecopy"
+)
+
+const uploadEndpoint = "/api/edge/upload"
+
+type Client struct {
+	TargetURL string
+	Token     string
+	SourceID  string
+	MaxBytes  int64
+	Client    *http.Client
+}
+
+type UploadResult struct {
+	Success  bool   `json:"success"`
+	File     string `json:"file"`
+	Path     string `json:"path"`
+	SourceID string `json:"source_id"`
+	Hash     string `json:"hash"`
+	Size     int64  `json:"size"`
+	Records  int    `json:"records"`
+	Message  string `json:"message"`
+}
+
+func (c Client) UploadFile(ctx context.Context, path string) (*UploadResult, error) {
+	target, err := UploadURL(c.TargetURL)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat source file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("source is a directory: %s", path)
+	}
+	if c.MaxBytes > 0 && info.Size() > c.MaxBytes {
+		return nil, fmt.Errorf("source file is %d bytes, above max upload size %d", info.Size(), c.MaxBytes)
+	}
+	hash, err := filecopy.CalculateHash(path)
+	if err != nil {
+		return nil, fmt.Errorf("hash source file: %w", err)
+	}
+
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, pr)
+	if err != nil {
+		_ = pr.Close()
+		_ = pw.Close()
+		return nil, err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("User-Agent", "patris-export-edge-stub")
+	req.Header.Set("X-Patris-Source-ID", defaultSourceID(c.SourceID))
+	req.Header.Set("X-Patris-File-Name", filepath.Base(path))
+	req.Header.Set("X-Patris-File-Size", fmt.Sprintf("%d", info.Size()))
+	req.Header.Set("X-Patris-File-CRC32", hash)
+	if token := strings.TrimSpace(c.Token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	writeErr := make(chan error, 1)
+	go func() {
+		defer close(writeErr)
+		defer pw.Close()
+
+		fields := map[string]string{
+			"source_id":   defaultSourceID(c.SourceID),
+			"source_path": path,
+			"file_name":   filepath.Base(path),
+			"size":        fmt.Sprintf("%d", info.Size()),
+			"mod_time":    info.ModTime().UTC().Format(time.RFC3339Nano),
+			"crc32":       hash,
+		}
+		for key, value := range fields {
+			if err := mw.WriteField(key, value); err != nil {
+				writeErr <- err
+				_ = mw.Close()
+				return
+			}
+		}
+
+		part, err := mw.CreateFormFile("file", filepath.Base(path))
+		if err != nil {
+			writeErr <- err
+			_ = mw.Close()
+			return
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			writeErr <- err
+			_ = mw.Close()
+			return
+		}
+		defer file.Close()
+		if _, err := io.CopyBuffer(part, file, make([]byte, filecopy.ChunkSize)); err != nil {
+			writeErr <- err
+			_ = mw.Close()
+			return
+		}
+		writeErr <- mw.Close()
+	}()
+
+	httpClient := c.Client
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Minute}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		_ = pw.CloseWithError(err)
+		<-writeErr
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := <-writeErr; err != nil {
+		return nil, fmt.Errorf("stream upload body: %w", err)
+	}
+
+	var result UploadResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode upload response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if result.Message != "" {
+			return &result, fmt.Errorf("upload failed: HTTP %d: %s", resp.StatusCode, result.Message)
+		}
+		return &result, fmt.Errorf("upload failed: HTTP %d", resp.StatusCode)
+	}
+	return &result, nil
+}
+
+func UploadURL(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", fmt.Errorf("edge target URL is required")
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("parse edge target URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("edge target URL must use http or https")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("edge target URL must include a host")
+	}
+	if strings.TrimRight(u.Path, "/") == uploadEndpoint {
+		return u.String(), nil
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + uploadEndpoint
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func defaultSourceID(value string) string {
+	if value = strings.TrimSpace(value); value != "" {
+		return value
+	}
+	if host, err := os.Hostname(); err == nil && strings.TrimSpace(host) != "" {
+		return host
+	}
+	return "edge"
+}

--- a/pkg/edge/client_test.go
+++ b/pkg/edge/client_test.go
@@ -1,0 +1,67 @@
+package edge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUploadURL(t *testing.T) {
+	tests := map[string]string{
+		"http://127.0.0.1:18080":                 "http://127.0.0.1:18080/api/edge/upload",
+		"http://127.0.0.1:18080/":                "http://127.0.0.1:18080/api/edge/upload",
+		"http://127.0.0.1:18080/api/edge/upload": "http://127.0.0.1:18080/api/edge/upload",
+	}
+	for input, want := range tests {
+		got, err := UploadURL(input)
+		if err != nil {
+			t.Fatalf("UploadURL(%q) returned error: %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("UploadURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestClientUploadFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	source := filepath.Join(tmpDir, "kala.json")
+	if err := os.WriteFile(source, []byte(`{"101":{"Code":"101","Name":"Edge"}}`), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/edge/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("unexpected authorization header: %q", got)
+		}
+		if err := r.ParseMultipartForm(1024 * 1024); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("source_id"); got != "edge-a" {
+			t.Fatalf("source_id = %q, want edge-a", got)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("missing file part: %v", err)
+		}
+		file.Close()
+		_ = json.NewEncoder(w).Encode(UploadResult{Success: true, Records: 1, Size: 36, Hash: "abcd1234"})
+	}))
+	defer server.Close()
+
+	client := Client{TargetURL: server.URL, Token: "secret", SourceID: "edge-a", MaxBytes: 1024 * 1024}
+	result, err := client.UploadFile(context.Background(), source)
+	if err != nil {
+		t.Fatalf("UploadFile returned error: %v", err)
+	}
+	if result.Records != 1 {
+		t.Fatalf("records = %d, want 1", result.Records)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"log"
 	"mime"
@@ -12,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -38,6 +41,7 @@ type Server struct {
 	dbPath             string
 	charMap            converter.CharMapping
 	dataSource         datasource.DataSource
+	dataSourceMu       sync.RWMutex
 	watcher            *watcher.FileWatcher
 	wsClients          map[*websocket.Conn]*sync.Mutex
 	wsClientsMu        sync.RWMutex
@@ -97,6 +101,17 @@ type ToastRequest struct {
 type charmapPreviewRequest struct {
 	Content string `json:"content"`
 	Path    string `json:"path"`
+}
+
+type edgeUploadResponse struct {
+	Success  bool   `json:"success"`
+	File     string `json:"file,omitempty"`
+	Path     string `json:"path,omitempty"`
+	SourceID string `json:"source_id,omitempty"`
+	Hash     string `json:"hash,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	Records  int    `json:"records,omitempty"`
+	Message  string `json:"message,omitempty"`
 }
 
 // NewServer creates a new server instance
@@ -187,6 +202,7 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/config", s.handlePutConfig).Methods("PUT")
 	s.router.HandleFunc("/api/status", s.handleGetStatus).Methods("GET")
 	s.router.HandleFunc("/api/toast", s.handlePostToast).Methods("POST")
+	s.router.HandleFunc("/api/edge/upload", s.handlePostEdgeUpload).Methods("POST")
 	s.router.HandleFunc("/api/update/manifest", s.handleGetUpdateManifest).Methods("GET")
 	s.router.HandleFunc("/api/update/executable", s.handleGetExecutable).Methods("GET", "HEAD")
 	s.router.HandleFunc("/api/processes/patris81", s.handleGetPatris81Processes).Methods("GET")
@@ -206,7 +222,7 @@ func (s *Server) Router() http.Handler {
 // Records returns the current records using the same transformed shape served
 // by GET /api/records.
 func (s *Server) Records() (map[string]interface{}, error) {
-	records, err := s.dataSource.GetRecords()
+	records, err := s.recordsRaw()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read records: %w", err)
 	}
@@ -230,8 +246,8 @@ func (s *Server) Info() (map[string]interface{}, error) {
 
 	return map[string]interface{}{
 		"success":     true,
-		"file":        sourceBaseName(s.dbPath),
-		"path":        s.dbPath,
+		"file":        sourceBaseName(s.currentDBPath()),
+		"path":        s.currentDBPath(),
 		"version":     s.version,
 		"num_records": db.GetNumRecords(),
 		"num_fields":  db.GetNumFields(),
@@ -251,6 +267,50 @@ func (s *Server) Config() appconfig.Config {
 		return appconfig.Default()
 	}
 	return s.config.Get()
+}
+
+func (s *Server) currentDBPath() string {
+	s.dataSourceMu.RLock()
+	defer s.dataSourceMu.RUnlock()
+	return s.dbPath
+}
+
+func (s *Server) recordsRaw() ([]map[string]interface{}, error) {
+	s.dataSourceMu.RLock()
+	defer s.dataSourceMu.RUnlock()
+	if s.dataSource == nil {
+		return nil, fmt.Errorf("data source is not initialized")
+	}
+	return s.dataSource.GetRecords()
+}
+
+func (s *Server) replaceDataSource(path string, records []map[string]interface{}) error {
+	ds, err := datasource.NewDataSource(path, s.charMap, false)
+	if err != nil {
+		return err
+	}
+	if records == nil {
+		records, err = ds.GetRecords()
+		if err != nil {
+			ds.Close()
+			return err
+		}
+	}
+
+	s.dataSourceMu.Lock()
+	old := s.dataSource
+	s.dataSource = ds
+	s.dbPath = path
+	s.useTempFile = false
+	s.dataSourceMu.Unlock()
+
+	if old != nil {
+		_ = old.Close()
+	}
+	s.lastSourceHashMu.Lock()
+	s.lastSourceHash = ""
+	s.lastSourceHashMu.Unlock()
+	return nil
 }
 
 // ReplaceConfig persists and broadcasts a new configuration snapshot.
@@ -306,10 +366,15 @@ func (s *Server) SubscribeEvents(buffer int) (<-chan map[string]interface{}, fun
 }
 
 func (s *Server) openDatabase() (*paradox.Database, func(), error) {
-	pathToOpen := s.dbPath
+	s.dataSourceMu.RLock()
+	dbPath := s.dbPath
+	useTempFile := s.useTempFile
+	s.dataSourceMu.RUnlock()
+
+	pathToOpen := dbPath
 	cleanup := func() {}
-	if filecopy.IsURL(s.dbPath) {
-		tempFileInfo, err := filecopy.DownloadToTemp(s.dbPath)
+	if filecopy.IsURL(dbPath) {
+		tempFileInfo, err := filecopy.DownloadToTemp(dbPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to download database to temp: %w", err)
 		}
@@ -317,8 +382,8 @@ func (s *Server) openDatabase() (*paradox.Database, func(), error) {
 		cleanup = func() {
 			filecopy.CleanupTemp(tempFileInfo.TempPath)
 		}
-	} else if s.useTempFile && strings.EqualFold(filepath.Ext(s.dbPath), ".db") {
-		tempFileInfo, err := filecopy.CopyToTemp(s.dbPath)
+	} else if useTempFile && strings.EqualFold(filepath.Ext(dbPath), ".db") {
+		tempFileInfo, err := filecopy.CopyToTemp(dbPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to copy database to temp: %w", err)
 		}
@@ -589,6 +654,129 @@ func (s *Server) handlePostToast(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handlePostEdgeUpload(w http.ResponseWriter, r *http.Request) {
+	if !s.edgeUploadAuthorized(r) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="patris-export-edge"`)
+		writeJSONStatus(w, http.StatusUnauthorized, edgeUploadResponse{Success: false, Message: "edge upload token is required or invalid"})
+		return
+	}
+
+	cfg := s.Config()
+	maxBytes := cfg.Edge.MaxUploadMB * 1024 * 1024
+	if maxBytes <= 0 {
+		maxBytes = 512 * 1024 * 1024
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes+1024*1024)
+	if err := r.ParseMultipartForm(32 * 1024 * 1024); err != nil {
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to parse upload: %v", err)})
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: "multipart field 'file' is required"})
+		return
+	}
+	defer file.Close()
+
+	originalName := firstNonEmpty(r.FormValue("file_name"), header.Filename, "edge-upload.db")
+	ext := strings.ToLower(filepath.Ext(originalName))
+	if ext != ".db" && ext != ".json" {
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: "uploaded file must be .db or .json"})
+		return
+	}
+
+	uploadDir := appconfig.ResolveTempDir(cfg.Edge.UploadDir)
+	if strings.TrimSpace(cfg.Edge.UploadDir) == "" || strings.EqualFold(cfg.Edge.UploadDir, "edge-uploads") {
+		uploadDir = filepath.Join(filecopy.TempRootForSize(header.Size), "edge-uploads")
+	}
+	if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		writeJSONStatus(w, http.StatusInternalServerError, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to create upload directory: %v", err)})
+		return
+	}
+
+	sourceID := firstNonEmpty(r.FormValue("source_id"), r.Header.Get("X-Patris-Source-ID"), "edge")
+	filename := fmt.Sprintf("%s-%s-%d%s", sanitizeFilename(sourceID), sanitizeFilename(strings.TrimSuffix(filepath.Base(originalName), ext)), time.Now().UTC().UnixNano(), ext)
+	destPath := filepath.Join(uploadDir, filename)
+	dest, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		writeJSONStatus(w, http.StatusInternalServerError, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to create upload file: %v", err)})
+		return
+	}
+
+	hash := crc32.NewIEEE()
+	written, copyErr := io.CopyBuffer(io.MultiWriter(dest, hash), file, make([]byte, filecopy.ChunkSize))
+	closeErr := dest.Close()
+	if copyErr != nil {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusInternalServerError, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to save upload: %v", copyErr)})
+		return
+	}
+	if closeErr != nil {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusInternalServerError, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to close upload file: %v", closeErr)})
+		return
+	}
+	if written > maxBytes {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusRequestEntityTooLarge, edgeUploadResponse{Success: false, Message: "uploaded file exceeds configured edge.max_upload_mb"})
+		return
+	}
+	if expectedSize := firstNonEmpty(r.FormValue("size"), r.Header.Get("X-Patris-File-Size")); expectedSize != "" {
+		if parsed, err := strconv.ParseInt(expectedSize, 10, 64); err == nil && parsed != written {
+			_ = os.Remove(destPath)
+			writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: fmt.Sprintf("upload size mismatch: expected %d got %d", parsed, written)})
+			return
+		}
+	}
+
+	gotHash := fmt.Sprintf("%08x", hash.Sum32())
+	expectedHash := firstNonEmpty(r.FormValue("crc32"), r.Header.Get("X-Patris-File-CRC32"))
+	if expectedHash != "" && !strings.EqualFold(expectedHash, gotHash) {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: fmt.Sprintf("upload checksum mismatch: expected %s got %s", expectedHash, gotHash)})
+		return
+	}
+	if modTime, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(r.FormValue("mod_time"))); err == nil {
+		_ = os.Chtimes(destPath, time.Now(), modTime)
+	}
+
+	ds, err := datasource.NewDataSource(destPath, s.charMap, false)
+	if err != nil {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to open uploaded source: %v", err)})
+		return
+	}
+	records, err := ds.GetRecords()
+	if err != nil {
+		_ = ds.Close()
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusBadRequest, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to read uploaded source: %v", err)})
+		return
+	}
+	_ = ds.Close()
+	if err := s.replaceDataSource(destPath, records); err != nil {
+		_ = os.Remove(destPath)
+		writeJSONStatus(w, http.StatusInternalServerError, edgeUploadResponse{Success: false, Message: fmt.Sprintf("failed to activate uploaded source: %v", err)})
+		return
+	}
+
+	log.Printf("📥 Edge upload accepted from %s: %s (%d bytes, %d records, crc32=%s)", sourceID, filepath.Base(destPath), written, len(records), gotHash)
+	s.notifyConfigured("file_updated", "Patris edge upload received", fmt.Sprintf("%s uploaded %s (%d records)", sourceID, filepath.Base(originalName), len(records)))
+	s.broadcastUpdate()
+
+	writeJSON(w, edgeUploadResponse{
+		Success:  true,
+		File:     filepath.Base(originalName),
+		Path:     destPath,
+		SourceID: sourceID,
+		Hash:     gotHash,
+		Size:     written,
+		Records:  len(records),
+		Message:  "edge upload accepted",
+	})
+}
+
 // handleGetPatris81Processes returns information about running patris81.exe processes.
 func (s *Server) handleGetPatris81Processes(w http.ResponseWriter, r *http.Request) {
 	processes, err := processmon.FindProcessByName("patris81.exe")
@@ -607,12 +795,13 @@ func (s *Server) handleGetPatris81Processes(w http.ResponseWriter, r *http.Reque
 
 // handleGetFileProcesses returns information about processes accessing the database file.
 func (s *Server) handleGetFileProcesses(w http.ResponseWriter, r *http.Request) {
-	if filecopy.IsURL(s.dbPath) {
+	dbPath := s.currentDBPath()
+	if filecopy.IsURL(dbPath) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success":   true,
-			"file":      sourceBaseName(s.dbPath),
-			"path":      s.dbPath,
+			"file":      sourceBaseName(dbPath),
+			"path":      dbPath,
 			"remote":    true,
 			"count":     0,
 			"in_use":    false,
@@ -621,7 +810,7 @@ func (s *Server) handleGetFileProcesses(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	fileInfo, err := processmon.FindProcessesWithFile(s.dbPath)
+	fileInfo, err := processmon.FindProcessesWithFile(dbPath)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to find processes with file: %v", err), http.StatusInternalServerError)
 		return
@@ -630,7 +819,7 @@ func (s *Server) handleGetFileProcesses(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"success":   true,
-		"file":      sourceBaseName(s.dbPath),
+		"file":      sourceBaseName(dbPath),
 		"path":      fileInfo.FilePath,
 		"count":     len(fileInfo.Processes),
 		"in_use":    len(fileInfo.Processes) > 0,
@@ -715,11 +904,12 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // sendRecordsToClient sends current database records to a WebSocket client
 func (s *Server) sendRecordsToClient(conn *websocket.Conn, connMu *sync.Mutex) {
-	records, err := s.dataSource.GetRecords()
+	records, err := s.recordsRaw()
 	if err != nil {
 		log.Printf("Failed to read records: %v", err)
 		return
 	}
+	dbPath := s.currentDBPath()
 
 	// Send as initial load (all records are "added")
 	message := map[string]interface{}{
@@ -727,8 +917,8 @@ func (s *Server) sendRecordsToClient(conn *websocket.Conn, connMu *sync.Mutex) {
 		"timestamp":   time.Now().Format(time.RFC3339),
 		"added":       records,
 		"total_count": len(records),
-		"file_name":   sourceBaseName(s.dbPath),
-		"file_path":   s.dbPath,
+		"file_name":   sourceBaseName(dbPath),
+		"file_path":   dbPath,
 		"version":     s.version,
 		"resources":   web.Resources(),
 	}
@@ -768,7 +958,7 @@ func (s *Server) broadcastUpdate() {
 	log.Printf("📡 Broadcasting update to %d clients", clientCount)
 
 	// Get current records
-	records, err := s.dataSource.GetRecords()
+	records, err := s.recordsRaw()
 	if err != nil {
 		log.Printf("Failed to read records: %v", err)
 		return
@@ -1006,10 +1196,11 @@ func boolPtr(value bool) *bool {
 }
 
 func (s *Server) updateSourceHash() (oldHash, newHash string) {
-	if filecopy.IsURL(s.dbPath) {
+	dbPath := s.currentDBPath()
+	if filecopy.IsURL(dbPath) {
 		return "", ""
 	}
-	hash, err := filecopy.CalculateHash(s.dbPath)
+	hash, err := filecopy.CalculateHash(dbPath)
 	if err != nil {
 		log.Printf("Failed to calculate source hash: %v", err)
 		return "", ""
@@ -1083,12 +1274,79 @@ func writeJSON(w http.ResponseWriter, payload interface{}) {
 	}
 }
 
+func writeJSONStatus(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *Server) edgeUploadAuthorized(r *http.Request) bool {
+	token := ""
+	if s.config != nil {
+		token = s.config.Get().Edge.Token
+	}
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv("PATRIS_EDGE_TOKEN"))
+	}
+	if token == "" {
+		return true
+	}
+	got := strings.TrimSpace(r.Header.Get("X-Patris-Edge-Token"))
+	if got == "" {
+		auth := strings.TrimSpace(r.Header.Get("Authorization"))
+		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+			got = strings.TrimSpace(auth[len("Bearer "):])
+		}
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sanitizeFilename(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "edge"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	cleaned := strings.Trim(b.String(), ".-")
+	if cleaned == "" {
+		return "edge"
+	}
+	if len(cleaned) > 80 {
+		cleaned = cleaned[:80]
+	}
+	return cleaned
+}
+
 func (s *Server) processStatus() map[string]interface{} {
 	patris81Processes, patrisErr := findPatrisProcessesWithTimeout(1500 * time.Millisecond)
 	var fileInfo *processmon.FileAccessInfo
 	var fileErr error
-	if !filecopy.IsURL(s.dbPath) {
-		fileInfo, fileErr = findFileProcessesWithTimeout(s.dbPath, 1500*time.Millisecond)
+	dbPath := s.currentDBPath()
+	if !filecopy.IsURL(dbPath) {
+		fileInfo, fileErr = findFileProcessesWithTimeout(dbPath, 1500*time.Millisecond)
 	}
 
 	status := map[string]interface{}{
@@ -1099,9 +1357,9 @@ func (s *Server) processStatus() map[string]interface{} {
 			"processes": patris81Processes,
 		},
 		"file_access": map[string]interface{}{
-			"file":      sourceBaseName(s.dbPath),
-			"path":      s.dbPath,
-			"remote":    filecopy.IsURL(s.dbPath),
+			"file":      sourceBaseName(dbPath),
+			"path":      dbPath,
+			"remote":    filecopy.IsURL(dbPath),
 			"in_use":    fileInfo != nil && len(fileInfo.Processes) > 0,
 			"count":     0,
 			"processes": []processmon.ProcessInfo{},
@@ -1346,7 +1604,8 @@ func (s *Server) logDetailedChanges(added []map[string]interface{}, deleted []st
 	lastModTime := s.lastModTime
 	s.lastModTimeMu.Unlock()
 
-	fileInfo, err := os.Stat(s.dbPath)
+	dbPath := s.currentDBPath()
+	fileInfo, err := os.Stat(dbPath)
 	var currentModTime time.Time
 	if err == nil {
 		currentModTime = fileInfo.ModTime()
@@ -1357,7 +1616,7 @@ func (s *Server) logDetailedChanges(added []map[string]interface{}, deleted []st
 
 	// Log file timestamps
 	log.Println(strings.Repeat("━", 80))
-	log.Printf("📁 File: %s", filepath.Base(s.dbPath))
+	log.Printf("📁 File: %s", filepath.Base(dbPath))
 	if !lastModTime.IsZero() {
 		timeDiff := currentModTime.Sub(lastModTime)
 		log.Printf("⏰ Last modified: %s (%s)", lastModTime.Format("2006-01-02 15:04:05"), formatDuration(timeDiff))
@@ -1556,24 +1815,25 @@ func (s *Server) StartWatching(debounceDuration time.Duration) error {
 
 	s.watcher = fw
 	s.updateSourceHash()
+	dbPath := s.currentDBPath()
 
-	if filecopy.IsURL(s.dbPath) {
+	if filecopy.IsURL(dbPath) {
 		pollInterval := debounceDuration
 		if pollInterval <= 0 {
 			pollInterval = 5 * time.Minute
 		}
-		if err := fw.Poll(s.dbPath, func(path string) {
+		if err := fw.Poll(dbPath, func(path string) {
 			log.Printf("🔄 Remote source changed: %s", path)
 			s.notifyFileUpdated(path)
 			s.broadcastUpdate()
 		}, pollInterval); err != nil {
 			return fmt.Errorf("failed to poll URL: %w", err)
 		}
-		log.Printf("👀 Polling remote source: %s (interval: %v)", s.dbPath, pollInterval)
+		log.Printf("👀 Polling remote source: %s (interval: %v)", dbPath, pollInterval)
 		return nil
 	}
 
-	if err := fw.Watch(s.dbPath, func(path string) {
+	if err := fw.Watch(dbPath, func(path string) {
 		log.Printf("🔄 File changed: %s", filepath.Base(path))
 		s.notifyFileUpdated(path)
 		s.broadcastUpdate()
@@ -1582,12 +1842,12 @@ func (s *Server) StartWatching(debounceDuration time.Duration) error {
 	}
 
 	fw.Start()
-	ext := filepath.Ext(s.dbPath)
+	ext := filepath.Ext(dbPath)
 	fileType := "database"
 	if ext == ".json" {
 		fileType = "JSON"
 	}
-	log.Printf("👀 Watching %s file: %s", fileType, filepath.Base(s.dbPath))
+	log.Printf("👀 Watching %s file: %s", fileType, filepath.Base(dbPath))
 
 	return nil
 }
@@ -1605,8 +1865,12 @@ func (s *Server) Close() error {
 			firstErr = err
 		}
 	}
-	if s.dataSource != nil {
-		if err := s.dataSource.Close(); err != nil && firstErr == nil {
+	s.dataSourceMu.Lock()
+	ds := s.dataSource
+	s.dataSource = nil
+	s.dataSourceMu.Unlock()
+	if ds != nil {
+		if err := ds.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -1616,11 +1880,12 @@ func (s *Server) Close() error {
 // Start starts the HTTP server
 func (s *Server) Start(addr string) error {
 	log.Printf("🚀 Starting server on %s", addr)
-	log.Printf("📊 Serving file: %s", filepath.Base(s.dbPath))
+	dbPath := s.currentDBPath()
+	log.Printf("📊 Serving file: %s", filepath.Base(dbPath))
 
-	if !filecopy.IsURL(s.dbPath) {
-		if _, err := os.Stat(s.dbPath); os.IsNotExist(err) {
-			return fmt.Errorf("file does not exist: %s", s.dbPath)
+	if !filecopy.IsURL(dbPath) {
+		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+			return fmt.Errorf("file does not exist: %s", dbPath)
 		}
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -230,6 +232,60 @@ func TestServerJSON(t *testing.T) {
 		}
 		if got := w.Header().Get("Content-Range"); !strings.HasPrefix(got, "bytes 0-15/") {
 			t.Errorf("Unexpected Content-Range: %s", got)
+		}
+	})
+
+	t.Run("POST /api/edge/upload switches active source", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		if err := writer.WriteField("source_id", "test-edge"); err != nil {
+			t.Fatalf("write source_id: %v", err)
+		}
+		if err := writer.WriteField("file_name", "edge.json"); err != nil {
+			t.Fatalf("write file_name: %v", err)
+		}
+		part, err := writer.CreateFormFile("file", "edge.json")
+		if err != nil {
+			t.Fatalf("create file part: %v", err)
+		}
+		if _, err := part.Write([]byte(`{"777":{"Code":"777","Name":"Uploaded Edge Record"}}`)); err != nil {
+			t.Fatalf("write file part: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close multipart writer: %v", err)
+		}
+
+		req := httptest.NewRequest("POST", "/api/edge/upload", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var response map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+			t.Fatalf("decode upload response: %v", err)
+		}
+		if response["success"] != true {
+			t.Fatalf("Expected success=true, got %v", response["success"])
+		}
+		if response["records"].(float64) != 1 {
+			t.Fatalf("Expected records=1, got %v", response["records"])
+		}
+
+		req = httptest.NewRequest("GET", "/api/records", nil)
+		w = httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected records status 200, got %d", w.Code)
+		}
+		var records map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&records); err != nil {
+			t.Fatalf("decode records: %v", err)
+		}
+		if _, ok := records["777"]; !ok {
+			t.Fatalf("Expected uploaded record 777, got keys %+v", records)
 		}
 	})
 }


### PR DESCRIPTION
﻿## What changed
- Added `patris-export stub` (alias `edge`) to watch a local `.db` file and stream snapshots to a remote Patris Export server.
- Added `pkg/edge` streaming multipart client with upload URL normalization, source metadata, CRC32 metadata, optional bearer auth, and max-size checks.
- Added remote `POST /api/edge/upload` receiver that stores uploads, validates extension/size/checksum, switches the active server data source, transforms rows through the normal backend, and broadcasts updates to existing WebSocket/API/UI clients.
- Added persistent config and environment support under `edge.*` / `PATRIS_EDGE_*`.
- Documented central receiver plus edge machine usage in the README.

## Validation
- `go test ./...` with the local Windows CGO/pxlib environment active.
- `git diff --check`.

Closes #60
