### PR TITLE
Serve active source database file

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,21 @@ The executable endpoint uses the real file on disk and supports byte ranges, con
 
 If the remote update API is protected, set `PATRIS_UPDATE_TOKEN`; this is separate from `GITHUB_TOKEN` so GitHub credentials are not sent to arbitrary update hosts.
 
+### Source Database File API
+
+When the server is watching a local `.db` or has accepted an edge-uploaded
+snapshot, it can also publish that exact active source file:
+
+- `GET /api/source/manifest` returns file name, full active path, size, SHA-256, last modified timestamp, and `download_url`.
+- `GET /api/source/file` streams the active source file.
+- `HEAD /api/source/file` reports static headers without a body.
+
+The source-file endpoint supports byte ranges, conditional requests,
+`Content-Length`, `Last-Modified`, `ETag`, `X-Checksum-SHA256`, and
+`X-Source-*` metadata headers. Remote URL-backed sources cannot be re-served as
+a local static file until they have been materialized as an edge upload or local
+watched file.
+
 ## 🔧 API Reference
 
 ### REST Endpoints
@@ -426,6 +441,12 @@ Returns database schema information.
   "fields": [...]
 }
 ```
+
+#### `GET /api/source/manifest`
+Returns metadata for the currently active source file.
+
+#### `GET /api/source/file`
+Downloads the currently active source file with HEAD and range support.
 
 ### WebSocket
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,17 @@ type edgeUploadResponse struct {
 	Message  string `json:"message,omitempty"`
 }
 
+type sourceFileManifest struct {
+	Name         string    `json:"name"`
+	Filename     string    `json:"filename"`
+	Path         string    `json:"path"`
+	Size         int64     `json:"size"`
+	SHA256       string    `json:"sha256"`
+	LastModified time.Time `json:"last_modified"`
+	DownloadURL  string    `json:"download_url"`
+	GeneratedAt  time.Time `json:"generated_at"`
+}
+
 // NewServer creates a new server instance
 func NewServer(dbPath string, charMap converter.CharMapping, useTempFile ...bool) (*Server, error) {
 	return NewServerWithOptions(dbPath, charMap, Options{}, useTempFile...)
@@ -203,6 +214,8 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/status", s.handleGetStatus).Methods("GET")
 	s.router.HandleFunc("/api/toast", s.handlePostToast).Methods("POST")
 	s.router.HandleFunc("/api/edge/upload", s.handlePostEdgeUpload).Methods("POST")
+	s.router.HandleFunc("/api/source/manifest", s.handleGetSourceManifest).Methods("GET")
+	s.router.HandleFunc("/api/source/file", s.handleGetSourceFile).Methods("GET", "HEAD")
 	s.router.HandleFunc("/api/update/manifest", s.handleGetUpdateManifest).Methods("GET")
 	s.router.HandleFunc("/api/update/executable", s.handleGetExecutable).Methods("GET", "HEAD")
 	s.router.HandleFunc("/api/processes/patris81", s.handleGetPatris81Processes).Methods("GET")
@@ -598,6 +611,43 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, s.Status())
+}
+
+func (s *Server) handleGetSourceManifest(w http.ResponseWriter, r *http.Request) {
+	manifest, _, err := s.sourceFileManifest(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to inspect source file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, manifest)
+}
+
+func (s *Server) handleGetSourceFile(w http.ResponseWriter, r *http.Request) {
+	manifest, sourcePath, err := s.sourceFileManifest(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to inspect source file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	file, err := os.Open(sourcePath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to open source file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": manifest.Filename}))
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Date", time.Now().UTC().Format(http.TimeFormat))
+	w.Header().Set("ETag", fmt.Sprintf("\"sha256:%s\"", manifest.SHA256))
+	w.Header().Set("X-Checksum-SHA256", manifest.SHA256)
+	w.Header().Set("X-Source-File", manifest.Filename)
+	w.Header().Set("X-Source-Size", fmt.Sprintf("%d", manifest.Size))
+	w.Header().Set("X-Source-Modified", manifest.LastModified.UTC().Format(time.RFC3339))
+	http.ServeContent(w, r, manifest.Filename, manifest.LastModified, file)
 }
 
 func (s *Server) handleGetUpdateManifest(w http.ResponseWriter, r *http.Request) {
@@ -1097,6 +1147,38 @@ func (s *Server) executableManifestForPath(r *http.Request) (updater.ExecutableM
 		GeneratedAt:  time.Now().UTC(),
 	}
 	return manifest, exePath, nil
+}
+
+func (s *Server) sourceFileManifest(r *http.Request) (sourceFileManifest, string, error) {
+	sourcePath := s.currentDBPath()
+	if filecopy.IsURL(sourcePath) {
+		return sourceFileManifest{}, "", fmt.Errorf("current source is remote URL-backed and cannot be served as a local static file")
+	}
+	if resolved, err := filepath.EvalSymlinks(sourcePath); err == nil {
+		sourcePath = resolved
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return sourceFileManifest{}, "", err
+	}
+	if info.IsDir() {
+		return sourceFileManifest{}, "", fmt.Errorf("current source is a directory: %s", sourcePath)
+	}
+	hash, err := updater.FileSHA256(sourcePath)
+	if err != nil {
+		return sourceFileManifest{}, "", err
+	}
+	manifest := sourceFileManifest{
+		Name:         "Patris Export Source Database",
+		Filename:     filepath.Base(sourcePath),
+		Path:         sourcePath,
+		Size:         info.Size(),
+		SHA256:       hash,
+		LastModified: info.ModTime().UTC(),
+		DownloadURL:  absoluteURL(r, "/api/source/file"),
+		GeneratedAt:  time.Now().UTC(),
+	}
+	return manifest, sourcePath, nil
 }
 
 func absoluteURL(r *http.Request, path string) string {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -235,6 +235,74 @@ func TestServerJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("GET /api/source/manifest", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/source/manifest", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Expected Cache-Control no-store, got %s", cc)
+		}
+
+		var manifest map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&manifest); err != nil {
+			t.Fatalf("Failed to decode manifest: %v", err)
+		}
+		if manifest["filename"] != filepath.Base(jsonFile) {
+			t.Fatalf("Expected source filename %q, got %v", filepath.Base(jsonFile), manifest["filename"])
+		}
+		if manifest["sha256"] == "" {
+			t.Error("Expected source sha256")
+		}
+		if manifest["size"].(float64) <= 0 {
+			t.Error("Expected positive source size")
+		}
+		if !strings.Contains(manifest["download_url"].(string), "/api/source/file") {
+			t.Errorf("Expected source download URL, got %s", manifest["download_url"])
+		}
+	})
+
+	t.Run("HEAD /api/source/file has static headers", func(t *testing.T) {
+		req := httptest.NewRequest("HEAD", "/api/source/file", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", w.Code)
+		}
+		for _, header := range []string{"Content-Length", "Last-Modified", "Date", "ETag", "X-Checksum-SHA256", "X-Source-File", "X-Source-Size", "X-Source-Modified"} {
+			if got := w.Header().Get(header); got == "" {
+				t.Errorf("Expected %s header", header)
+			}
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/octet-stream" {
+			t.Errorf("Expected source file content type, got %s", ct)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("Expected empty HEAD body, got %d bytes", w.Body.Len())
+		}
+	})
+
+	t.Run("GET /api/source/file supports ranges", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/source/file", nil)
+		req.Header.Set("Range", "bytes=0-9")
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusPartialContent {
+			t.Fatalf("Expected status 206, got %d", w.Code)
+		}
+		if w.Body.Len() != 10 {
+			t.Errorf("Expected 10 response bytes, got %d", w.Body.Len())
+		}
+		if got := w.Header().Get("Content-Range"); !strings.HasPrefix(got, "bytes 0-9/") {
+			t.Errorf("Unexpected Content-Range: %s", got)
+		}
+	})
+
 	t.Run("POST /api/edge/upload switches active source", func(t *testing.T) {
 		var body bytes.Buffer
 		writer := multipart.NewWriter(&body)


### PR DESCRIPTION
﻿## What changed
- Added `GET /api/source/manifest` to expose metadata for the currently active source file.
- Added `GET`/`HEAD /api/source/file` to stream the active watched database/source file as a static downloadable file.
- The endpoint follows the same static-file behavior as the executable endpoint: `Content-Length`, `Last-Modified`, `ETag`, `X-Checksum-SHA256`, source metadata headers, HEAD support, and byte-range support through `http.ServeContent`.
- The source is resolved from the current active server source, so edge-uploaded snapshots are downloadable after they become active.
- Documented the new source file API in the README.

## Validation
- `go test ./pkg/server` with the local Windows CGO/pxlib environment.
- `go test ./...` with the local Windows CGO/pxlib environment.
- `git diff --check`.

Closes #62
