### PR TITLE
Complete Bubble Tea terminal dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ patris-export company company.inf
 patris-export serve kala.db -a :8080
 ```
 
+### Terminal Dashboard
+
+Run the Bubble Tea terminal dashboard when you want a keyboard-first view of the
+same operational state exposed by the web UI and API:
+
+```bash
+patris-export tui kala.db
+```
+
+The dashboard refreshes live and includes data/source status, field discovery,
+Patris81 process and file-lock visibility, the embedded/default character map,
+API shortcuts, and a WebSocat launcher. Use `tab` or the arrow keys to switch
+views, `1` through `7` to jump to a tab, `r` to refresh, `o` to open the web
+viewer, and `w` to inspect WebSocket updates through WebSocat.
+
+![Patris Export TUI dashboard](docs/screenshots/issue-3-tui-dashboard.svg)
+
 Terminal WebSocket inspection with WebSocat is documented in [docs/examples/websocat.md](docs/examples/websocat.md).
 Embedding, loadable-library builds, and local IPC are documented in [docs/EMBEDDING.md](docs/EMBEDDING.md).
 

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -1259,7 +1259,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	}
 
 	if !httpEnabled {
-		infoColor.Printf("âš™ï¸ Config: %s\n", configManager.Path())
+		infoColor.Printf("⚙️ Config: %s\n", configManager.Path())
 		infoColor.Println("Press Ctrl+C to stop the IPC server")
 		<-ctx.Done()
 		return

--- a/docs/screenshots/issue-3-tui-dashboard.svg
+++ b/docs/screenshots/issue-3-tui-dashboard.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="732" viewBox="0 0 1400 732">
+<defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#10131b"/><stop offset="1" stop-color="#1e2433"/></linearGradient></defs>
+<rect width="100%" height="100%" rx="18" fill="url(#bg)"/>
+<rect x="24" y="24" width="1352" height="42" rx="10" fill="#262d3d"/>
+<circle cx="49" cy="45" r="7" fill="#ff5f57"/><circle cx="73" cy="45" r="7" fill="#ffbd2e"/><circle cx="97" cy="45" r="7" fill="#28c840"/>
+<text x="122" y="51" font-family="Cascadia Mono, Consolas, monospace" font-size="14" fill="#cbd5e1">patris-export tui C:\Patris\data4\kala.db</text>
+<text x="36" y="92" font-family="Cascadia Mono, Consolas, monospace" font-size="15" fill="#e6edf3">
+<tspan x="36" dy="0"> Patris Export  Terminal operations dashboard                                                                         </tspan>
+<tspan x="36" dy="22">┌──────────────┐ ┌───────────────┐ ┌─────────────────────┐ ┌──────────────────┐                                       </tspan>
+<tspan x="36" dy="22">│ File kala.db │ │ Data 994 rows │ │ Patris81 running: 2 │ │ Updated 03:06:48 │                                       </tspan>
+<tspan x="36" dy="22">└──────────────┘ └───────────────┘ └─────────────────────┘ └──────────────────┘                                       </tspan>
+<tspan x="36" dy="22"> 1 Dashboard   2 Data   3 Config   4 Charmap   5 Processes   6 Tools   7 About                                        </tspan>
+<tspan x="36" dy="22">╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮</tspan>
+<tspan x="36" dy="22">│                                                                                                                    │</tspan>
+<tspan x="36" dy="22">│  ┌────────────────────────────────────────────────────┐ ┌──────────────────────────────────────┐                   │</tspan>
+<tspan x="36" dy="22">│  │ Source                                             │ │ Live Data                            │                   │</tspan>
+<tspan x="36" dy="22">│  │ Path: C:\Patris\data4\kala.db                      │ │ Records: 994                         │                   │</tspan>
+<tspan x="36" dy="22">│  │ Exists: yes                                        │ │ Fields: 15                           │                   │</tspan>
+<tspan x="36" dy="22">│  │ Remote: no                                         │ │ Groups: 27                           │                   │</tspan>
+<tspan x="36" dy="22">│  │ Size: 582.00 KiB                                   │ │ Subgroups: 180                       │                   │</tspan>
+<tspan x="36" dy="22">│  │ Modified: 2026-07-11 00:37:17                      │ │ Items: 787                           │                   │</tspan>
+<tspan x="36" dy="22">│  └────────────────────────────────────────────────────┘ │ Positive stock: 716                  │                   │</tspan>
+<tspan x="36" dy="22">│                                                         │ Zero stock: 278                      │                   │</tspan>
+<tspan x="36" dy="22">│                                                         └──────────────────────────────────────┘                   │</tspan>
+<tspan x="36" dy="22">│                                                                                                                    │</tspan>
+<tspan x="36" dy="22">│  ┌──────────────────────────────────────────────────────────────────────────────────────────────┐                  │</tspan>
+<tspan x="36" dy="22">│  │ API Shortcuts                                                                                │                  │</tspan>
+<tspan x="36" dy="22">│  │ Web UI: http://127.0.0.1:18080                                                               │                  │</tspan>
+<tspan x="36" dy="22">│  │ Viewer: http://127.0.0.1:18080/viewer                                                        │                  │</tspan>
+<tspan x="36" dy="22">│  │ WebSocket: ws://127.0.0.1:18080/ws                                                           │                  │</tspan>
+<tspan x="36" dy="22">│  │ Source manifest: http://127.0.0.1:18080/api/source/manifest                                  │                  │</tspan>
+<tspan x="36" dy="22">│  │ Source file: http://127.0.0.1:18080/api/source/file                                          │                  │</tspan>
+<tspan x="36" dy="22">│  └──────────────────────────────────────────────────────────────────────────────────────────────┘                  │</tspan>
+<tspan x="36" dy="22">│                                                                                                                    │</tspan>
+<tspan x="36" dy="22">╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</tspan>
+<tspan x="36" dy="22">tab/←/→ navigate  1-7 jump  ↑/↓ scroll  r refresh  o viewer  w WebSocat  q quit                                       </tspan>
+</text>
+</svg>

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2,13 +2,21 @@ package tui
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
 	"github.com/atomicdeploy/patris-export/pkg/converter"
+	"github.com/atomicdeploy/patris-export/pkg/datasource"
+	"github.com/atomicdeploy/patris-export/pkg/filecopy"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
 	"github.com/atomicdeploy/patris-export/pkg/version"
 	tea "github.com/charmbracelet/bubbletea"
@@ -16,15 +24,53 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
+const refreshInterval = 3 * time.Second
+
 var (
-	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("229")).Background(lipgloss.Color("57")).Padding(0, 1)
-	tabStyle   = lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("245"))
-	activeTab  = tabStyle.Copy().Bold(true).Foreground(lipgloss.Color("86")).Underline(true)
-	boxStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(1, 2)
-	mutedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	okStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
-	warnStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	appTitleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("229")).
+			Background(lipgloss.Color("57")).
+			Padding(0, 1)
+	subtitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
+	tabStyle      = lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("245"))
+	activeTab     = tabStyle.Copy().Bold(true).Foreground(lipgloss.Color("86")).Underline(true)
+	panelStyle    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(1, 2)
+	cardStyle     = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("238")).Padding(0, 1)
+	mutedStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	okStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
+	warnStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	badStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Bold(true)
+	accentStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("86")).Bold(true)
+	keyStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("238")).Padding(0, 1)
 )
+
+type tabID int
+
+const (
+	tabDashboard tabID = iota
+	tabData
+	tabConfig
+	tabCharmap
+	tabProcesses
+	tabTools
+	tabAbout
+)
+
+type tabDef struct {
+	ID    tabID
+	Label string
+}
+
+var tabs = []tabDef{
+	{tabDashboard, "Dashboard"},
+	{tabData, "Data"},
+	{tabConfig, "Config"},
+	{tabCharmap, "Charmap"},
+	{tabProcesses, "Processes"},
+	{tabTools, "Tools"},
+	{tabAbout, "About"},
+}
 
 type model struct {
 	cfg     appconfig.Config
@@ -33,15 +79,68 @@ type model struct {
 	tab     int
 	width   int
 	height  int
+	scroll  int
+	state   dashboardState
+	message string
 }
 
+type dashboardState struct {
+	SourcePath        string
+	SourceName        string
+	SourceExists      bool
+	SourceRemote      bool
+	SourceSize        int64
+	SourceModified    time.Time
+	RecordCount       int
+	FieldCount        int
+	Fields            []string
+	GroupRows         int
+	SubgroupRows      int
+	ItemRows          int
+	PositiveStock     int
+	ZeroStock         int
+	PatrisProcesses   []processmon.ProcessInfo
+	FileAccess        *processmon.FileAccessInfo
+	FileAccessErr     error
+	LoadErr           error
+	LastRefresh       time.Time
+	CharmapCount      int
+	CharmapIssues     int
+	CharmapSource     string
+	WebURL            string
+	ViewerURL         string
+	WebSocketURL      string
+	SourceFileURL     string
+	SourceManifestURL string
+}
+
+type refreshMsg dashboardState
+
+type tickMsg time.Time
+
 func Run(cfg appconfig.Config, configPath string, build version.Info) error {
-	_, err := tea.NewProgram(model{cfg: cfg, path: configPath, version: build}, tea.WithAltScreen()).Run()
+	_, err := tea.NewProgram(newModel(cfg, configPath, build), tea.WithAltScreen()).Run()
 	return err
 }
 
+func newModel(cfg appconfig.Config, configPath string, build version.Info) model {
+	return model{
+		cfg:     cfg,
+		path:    configPath,
+		version: build,
+		state:   collectState(cfg),
+	}
+}
+
+func Preview(cfg appconfig.Config, configPath string, build version.Info, width, height int) string {
+	m := newModel(cfg, configPath, build)
+	m.width = width
+	m.height = height
+	return m.View()
+}
+
 func (m model) Init() tea.Cmd {
-	return nil
+	return tea.Batch(refreshCmd(m.cfg), tickCmd())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -49,83 +148,241 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case refreshMsg:
+		m.state = dashboardState(msg)
+		m.message = "Refreshed " + m.state.LastRefresh.Format("15:04:05")
+	case tickMsg:
+		return m, tea.Batch(refreshCmd(m.cfg), tickCmd())
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
 			return m, tea.Quit
 		case "tab", "right", "l":
-			m.tab = (m.tab + 1) % 5
+			m.tab = (m.tab + 1) % len(tabs)
+			m.scroll = 0
 		case "shift+tab", "left", "h":
-			m.tab = (m.tab + 4) % 5
+			m.tab = (m.tab + len(tabs) - 1) % len(tabs)
+			m.scroll = 0
+		case "1", "2", "3", "4", "5", "6", "7":
+			index, _ := strconv.Atoi(msg.String())
+			if index >= 1 && index <= len(tabs) {
+				m.tab = index - 1
+				m.scroll = 0
+			}
+		case "up", "k":
+			if m.scroll > 0 {
+				m.scroll--
+			}
+		case "down", "j":
+			m.scroll++
+		case "pgup":
+			m.scroll -= max(4, m.contentHeight()/2)
+			if m.scroll < 0 {
+				m.scroll = 0
+			}
+		case "pgdown":
+			m.scroll += max(4, m.contentHeight()/2)
+		case "home":
+			m.scroll = 0
+		case "r":
+			m.message = "Refreshing..."
+			return m, refreshCmd(m.cfg)
 		case "w":
+			m.message = "Launching WebSocat watcher..."
 			return m, launchWebSocat(m.cfg)
+		case "o":
+			m.message = "Opening web viewer..."
+			return m, openURL(m.state.ViewerURL)
 		}
 	}
 	return m, nil
 }
 
 func (m model) View() string {
-	tabs := []string{"About", "Config", "Charmap", "Processes", "WebSocat"}
-	rendered := make([]string, len(tabs))
+	width := m.safeWidth()
+	renderedTabs := make([]string, len(tabs))
 	for i, t := range tabs {
+		label := fmt.Sprintf("%d %s", i+1, t.Label)
 		if i == m.tab {
-			rendered[i] = activeTab.Render(t)
+			renderedTabs[i] = activeTab.Render(label)
 		} else {
-			rendered[i] = tabStyle.Render(t)
+			renderedTabs[i] = tabStyle.Render(label)
 		}
 	}
 
-	var body string
-	switch m.tab {
-	case 0:
-		body = m.about()
-	case 1:
-		body = m.config()
-	case 2:
-		body = m.charmap()
-	case 3:
-		body = m.processes()
-	default:
-		body = m.websocat()
+	header := lipgloss.JoinHorizontal(lipgloss.Top,
+		appTitleStyle.Render("Patris Export"),
+		" ",
+		subtitleStyle.Render("Terminal operations dashboard"),
+	)
+	status := m.statusLine()
+	body := m.activeBody()
+	footer := mutedStyle.Render("tab/←/→ navigate  1-7 jump  ↑/↓ scroll  r refresh  o viewer  w WebSocat  q quit")
+	if m.message != "" {
+		footer += "\n" + mutedStyle.Render(m.message)
 	}
 
-	footer := mutedStyle.Render("Tab/←/→ navigate  w launch websocat  q quit")
 	return lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Patris Export"),
-		strings.Join(rendered, " "),
-		boxStyle.Width(max(60, m.width-6)).Render(body),
+		header,
+		status,
+		strings.Join(renderedTabs, " "),
+		panelStyle.Width(width).Render(body),
 		footer,
 	)
 }
 
-func (m model) about() string {
-	return fmt.Sprintf("%s\n\nVersion: %s\nCommit: %s\nBuild: %s\nGo: %s\nPlatform: %s",
-		"Modern Paradox/BDE export service for Patris81.",
-		m.version.Version,
-		m.version.Commit,
-		m.version.BuildDate,
-		m.version.GoVersion,
-		m.version.Platform,
+func (m model) safeWidth() int {
+	if m.width <= 0 {
+		return 110
+	}
+	return max(68, m.width-6)
+}
+
+func (m model) contentHeight() int {
+	if m.height <= 0 {
+		return 20
+	}
+	return max(8, m.height-10)
+}
+
+func (m model) activeBody() string {
+	switch tabs[m.tab].ID {
+	case tabDashboard:
+		return m.dashboard()
+	case tabData:
+		return m.data()
+	case tabConfig:
+		return m.config()
+	case tabCharmap:
+		return m.charmap()
+	case tabProcesses:
+		return m.processes()
+	case tabTools:
+		return m.tools()
+	default:
+		return m.about()
+	}
+}
+
+func (m model) statusLine() string {
+	source := mutedStyle.Render("source unknown")
+	if m.state.SourceName != "" {
+		source = accentStyle.Render(m.state.SourceName)
+	}
+	records := fmt.Sprintf("%d rows", m.state.RecordCount)
+	if m.state.LoadErr != nil {
+		records = badStyle.Render("read error")
+	} else {
+		records = okStyle.Render(records)
+	}
+	patris := okStyle.Render("Patris81 idle")
+	if len(m.state.PatrisProcesses) > 0 {
+		patris = warnStyle.Render(fmt.Sprintf("Patris81 running: %d", len(m.state.PatrisProcesses)))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top,
+		cardStyle.Render("File "+source),
+		" ",
+		cardStyle.Render("Data "+records),
+		" ",
+		cardStyle.Render(patris),
+		" ",
+		cardStyle.Render("Updated "+m.state.LastRefresh.Format("15:04:05")),
+	)
+}
+
+func (m model) dashboard() string {
+	state := m.state
+	left := []string{
+		accentStyle.Render("Source"),
+		kv("Path", empty(state.SourcePath, "(not set)")),
+		kv("Exists", boolText(state.SourceExists)),
+		kv("Remote", boolText(state.SourceRemote)),
+		kv("Size", humanBytes(state.SourceSize)),
+		kv("Modified", timeText(state.SourceModified)),
+	}
+	if state.LoadErr != nil {
+		left = append(left, badStyle.Render("Read error: "+state.LoadErr.Error()))
+	}
+
+	right := []string{
+		accentStyle.Render("Live Data"),
+		kv("Records", fmt.Sprintf("%d", state.RecordCount)),
+		kv("Fields", fmt.Sprintf("%d", state.FieldCount)),
+		kv("Groups", fmt.Sprintf("%d", state.GroupRows)),
+		kv("Subgroups", fmt.Sprintf("%d", state.SubgroupRows)),
+		kv("Items", fmt.Sprintf("%d", state.ItemRows)),
+		kv("Positive stock", fmt.Sprintf("%d", state.PositiveStock)),
+		kv("Zero stock", fmt.Sprintf("%d", state.ZeroStock)),
+	}
+
+	api := []string{
+		accentStyle.Render("API Shortcuts"),
+		kv("Web UI", state.WebURL),
+		kv("Viewer", state.ViewerURL),
+		kv("WebSocket", state.WebSocketURL),
+		kv("Source manifest", state.SourceManifestURL),
+		kv("Source file", state.SourceFileURL),
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		lipgloss.JoinHorizontal(lipgloss.Top,
+			cardStyle.Width(52).Render(strings.Join(left, "\n")),
+			" ",
+			cardStyle.Width(38).Render(strings.Join(right, "\n")),
+		),
+		"",
+		cardStyle.Width(min(m.safeWidth()-6, 94)).Render(strings.Join(api, "\n")),
+	)
+}
+
+func (m model) data() string {
+	if m.state.LoadErr != nil {
+		return badStyle.Render("Could not read records: " + m.state.LoadErr.Error())
+	}
+	fields := m.state.Fields
+	if len(fields) == 0 {
+		return mutedStyle.Render("No fields detected yet.")
+	}
+	limit := clampWindow(len(fields), m.scroll, max(6, m.contentHeight()-8))
+	rows := make([][]string, 0, limit.Count)
+	for _, field := range fields[limit.Start:limit.End] {
+		rows = append(rows, []string{field, classifyField(field), fieldHint(field)})
+	}
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("63"))).
+		Headers("Field", "Type", "Use").
+		Rows(rows...)
+	return fmt.Sprintf("Detected %d fields from %d transformed records.\n%s\n\n%s",
+		m.state.FieldCount,
+		m.state.RecordCount,
+		m.scrollHint(limit.Start, limit.End, len(fields)),
+		t.String(),
 	)
 }
 
 func (m model) config() string {
-	return fmt.Sprintf("Config: %s\nDatabase: %s\nCharmap: %s\nBind: %s\nWatch: %v\nDebounce: %s\nDebug: %v\nTheme: %s\nPage size: %d",
-		m.path,
-		empty(m.cfg.Database.Path, "(not set)"),
-		empty(m.cfg.Database.Charmap, "embedded default"),
-		m.cfg.Addr(),
-		m.cfg.Server.Watch,
-		m.cfg.Server.Debounce,
-		m.cfg.Runtime.Debug,
-		m.cfg.UI.Theme,
-		m.cfg.UI.PageSize,
-	)
+	rows := [][]string{
+		{"Config file", empty(m.path, "(not set)")},
+		{"Database path", empty(m.cfg.Database.Path, "(not set)")},
+		{"Charmap", empty(m.cfg.Database.Charmap, "embedded default")},
+		{"Bind address", m.cfg.Addr()},
+		{"HTTP", boolText(m.cfg.Server.HTTP)},
+		{"IPC", boolText(m.cfg.Server.IPC.Enabled)},
+		{"Watch", boolText(m.cfg.Server.Watch)},
+		{"Debounce", m.cfg.Server.Debounce},
+		{"Direct access", boolText(m.cfg.Database.DirectAccess)},
+		{"RTL conversion", boolText(m.cfg.Database.RTLConversion)},
+		{"Temp policy", m.cfg.Runtime.TempStrategy + " / " + m.cfg.Runtime.TempDir},
+		{"Theme", m.cfg.UI.Theme},
+		{"Page size", fmt.Sprintf("%d", m.cfg.UI.PageSize)},
+	}
+	return renderKVTable("Configuration", rows)
 }
 
 func (m model) charmap() string {
 	mapping := converter.DefaultCharMapping()
-	source := "embedded default"
+	source := "embedded Patris81 default"
 	var issues []converter.CharMappingIssue
 	if strings.TrimSpace(m.cfg.Database.Charmap) != "" {
 		file, err := os.Open(m.cfg.Database.Charmap)
@@ -143,14 +400,9 @@ func (m model) charmap() string {
 	}
 
 	entries := converter.CharMappingEntries(mapping)
-	limit := len(entries)
-	if m.height > 0 && limit > max(8, m.height-14) {
-		limit = max(8, m.height-14)
-	} else if limit > 24 {
-		limit = 24
-	}
-	rows := make([][]string, 0, limit)
-	for _, entry := range entries[:limit] {
+	limit := clampWindow(len(entries), m.scroll, max(8, m.contentHeight()-8))
+	rows := make([][]string, 0, limit.Count)
+	for _, entry := range entries[limit.Start:limit.End] {
 		rows = append(rows, []string{
 			"0x" + entry.Hex,
 			fmt.Sprintf("%d", entry.Decimal),
@@ -168,42 +420,154 @@ func (m model) charmap() string {
 	if len(issues) > 0 {
 		summary += fmt.Sprintf("\nIgnored lines: %d", len(issues))
 	}
-	if limit < len(entries) {
-		summary += fmt.Sprintf("\nShowing first %d entries. Use the web debug page for filtering and custom previews.", limit)
-	}
-	return summary + "\n\n" + t.String()
+	return summary + "\n" + m.scrollHint(limit.Start, limit.End, len(entries)) + "\n\n" + t.String()
 }
 
 func (m model) processes() string {
-	procs, err := processmon.FindProcessByName("patris81.exe")
-	if err != nil {
-		return warnStyle.Render("Could not inspect Patris81.exe: " + err.Error())
+	lines := []string{accentStyle.Render("Process Monitor")}
+	if len(m.state.PatrisProcesses) == 0 {
+		lines = append(lines, "Patris81.exe: "+okStyle.Render("not running"))
+	} else {
+		lines = append(lines, "Patris81.exe: "+warnStyle.Render(fmt.Sprintf("running (%d)", len(m.state.PatrisProcesses))))
+		for _, p := range m.state.PatrisProcesses {
+			lines = append(lines, fmt.Sprintf("  PID %-7d %s", p.PID, empty(p.Exe, p.Name)))
+		}
 	}
-	status := okStyle.Render("not running")
-	if len(procs) > 0 {
-		status = warnStyle.Render(fmt.Sprintf("running (%d)", len(procs)))
-	}
-	lines := []string{"Patris81.exe: " + status}
-	for _, p := range procs {
-		lines = append(lines, fmt.Sprintf("PID %d  %s", p.PID, p.Exe))
-	}
-	if m.cfg.Database.Path != "" {
-		fileInfo, err := processmon.FindProcessesWithFile(m.cfg.Database.Path)
-		if err == nil {
-			lines = append(lines, "", fmt.Sprintf("Database lock: %v (%d process(es))", len(fileInfo.Processes) > 0, len(fileInfo.Processes)))
+	lines = append(lines, "")
+	if m.state.FileAccessErr != nil {
+		lines = append(lines, warnStyle.Render("File lock inspection failed: "+m.state.FileAccessErr.Error()))
+	} else if m.state.FileAccess == nil {
+		lines = append(lines, "Database lock: "+mutedStyle.Render("not inspected"))
+	} else if len(m.state.FileAccess.Processes) == 0 {
+		lines = append(lines, "Database lock: "+okStyle.Render("no external holders detected"))
+	} else {
+		lines = append(lines, "Database lock: "+warnStyle.Render(fmt.Sprintf("%d process(es)", len(m.state.FileAccess.Processes))))
+		for _, p := range m.state.FileAccess.Processes {
+			lines = append(lines, fmt.Sprintf("  PID %-7d %-22s %s", p.PID, p.Name, p.Exe))
 		}
 	}
 	return strings.Join(lines, "\n")
 }
 
-func (m model) websocat() string {
-	url := "ws://" + m.cfg.Addr() + "/ws"
-	return fmt.Sprintf("Inspect live rows and events from a terminal:\n\n  scripts/windows/Watch-WebSocat.ps1 -Url %s -Once\n  scripts/watch-websocket.sh %s --once\n\nPress w to launch websocat in a new terminal when available.", url, url)
+func (m model) tools() string {
+	rows := [][]string{
+		{"Open viewer", keyStyle.Render("o"), m.state.ViewerURL},
+		{"Launch WebSocat watcher", keyStyle.Render("w"), m.state.WebSocketURL},
+		{"Refresh dashboard", keyStyle.Render("r"), "Reload source/process/charmap state"},
+		{"Raw source manifest", "", m.state.SourceManifestURL},
+		{"Raw source file", "", m.state.SourceFileURL},
+		{"Executable manifest", "", m.state.WebURL + "/api/update/manifest"},
+		{"Executable file", "", m.state.WebURL + "/api/update/executable"},
+	}
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("63"))).
+		Headers("Action", "Key", "Target").
+		Rows(rows...)
+	return t.String() + "\n\n" + mutedStyle.Render("Tip: the WebSocat helper is ideal for inspecting live update payloads from a terminal.")
+}
+
+func (m model) about() string {
+	lines := []string{
+		appTitleStyle.Render("Patris Export"),
+		"Modern Paradox/BDE export service for Patris81.",
+		"",
+		kv("Version", m.version.Version),
+		kv("Commit", m.version.Commit),
+		kv("Build date", m.version.BuildDate),
+		kv("Go", m.version.GoVersion),
+		kv("Platform", m.version.Platform),
+		"",
+		accentStyle.Render("TUI capabilities"),
+		"- Live refresh with Bubble Tea ticks",
+		"- Styled dashboard, tables, and status cards with Lip Gloss",
+		"- Source, config, charmap, process, file-lock, API, and WebSocat views",
+		"- Keyboard-first navigation for service operators",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func collectState(cfg appconfig.Config) dashboardState {
+	dbPath := strings.TrimSpace(cfg.Database.Path)
+	state := dashboardState{
+		SourcePath:        dbPath,
+		SourceName:        sourceName(dbPath),
+		SourceRemote:      filecopy.IsURL(dbPath),
+		LastRefresh:       time.Now(),
+		WebURL:            webURL(cfg, ""),
+		ViewerURL:         webURL(cfg, "/viewer"),
+		WebSocketURL:      wsURL(cfg),
+		SourceManifestURL: webURL(cfg, "/api/source/manifest"),
+		SourceFileURL:     webURL(cfg, "/api/source/file"),
+		CharmapSource:     "embedded default",
+	}
+
+	if dbPath != "" && !state.SourceRemote {
+		if info, err := os.Stat(dbPath); err == nil {
+			state.SourceExists = true
+			state.SourceSize = info.Size()
+			state.SourceModified = info.ModTime()
+		}
+	}
+
+	if dbPath != "" {
+		ds, err := datasource.NewDataSource(dbPath, nil, !cfg.Database.DirectAccess)
+		if err != nil {
+			state.LoadErr = err
+		} else {
+			records, err := ds.GetRecords()
+			_ = ds.Close()
+			if err != nil {
+				state.LoadErr = err
+			} else {
+				state.RecordCount = len(records)
+				state.Fields = fieldsFromRecords(records)
+				state.FieldCount = len(state.Fields)
+				state.GroupRows, state.SubgroupRows, state.ItemRows, state.PositiveStock, state.ZeroStock = analyzeRecords(records)
+			}
+		}
+	}
+
+	if procs, err := processmon.FindProcessByName("patris81.exe"); err == nil {
+		state.PatrisProcesses = procs
+	}
+	if dbPath != "" && !state.SourceRemote {
+		info, err := processmon.FindProcessesWithFile(dbPath)
+		state.FileAccess = info
+		state.FileAccessErr = err
+	}
+
+	mapping := converter.DefaultCharMapping()
+	state.CharmapCount = len(mapping)
+	if strings.TrimSpace(cfg.Database.Charmap) != "" {
+		state.CharmapSource = cfg.Database.Charmap
+		if file, err := os.Open(cfg.Database.Charmap); err == nil {
+			if parsed, issues, err := converter.ParseCharMappingReport(file); err == nil {
+				state.CharmapCount = len(parsed)
+				state.CharmapIssues = len(issues)
+			}
+			_ = file.Close()
+		}
+	}
+
+	return state
+}
+
+func refreshCmd(cfg appconfig.Config) tea.Cmd {
+	return func() tea.Msg {
+		return refreshMsg(collectState(cfg))
+	}
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(refreshInterval, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
 }
 
 func launchWebSocat(cfg appconfig.Config) tea.Cmd {
 	return func() tea.Msg {
-		url := "ws://" + cfg.Addr() + "/ws"
+		url := wsURL(cfg)
 		if runtime.GOOS == "windows" {
 			_ = exec.Command("cmd", "/c", "start", "Patris WebSocat", "powershell", "-NoExit", "-ExecutionPolicy", "Bypass", "-File", "scripts\\windows\\Watch-WebSocat.ps1", "-Url", url).Start()
 		} else {
@@ -211,6 +575,232 @@ func launchWebSocat(cfg appconfig.Config) tea.Cmd {
 		}
 		return nil
 	}
+}
+
+func openURL(target string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(target) == "" {
+			return nil
+		}
+		switch runtime.GOOS {
+		case "windows":
+			_ = exec.Command("cmd", "/c", "start", "", target).Start()
+		case "darwin":
+			_ = exec.Command("open", target).Start()
+		default:
+			_ = exec.Command("xdg-open", target).Start()
+		}
+		return nil
+	}
+}
+
+type windowRange struct {
+	Start int
+	End   int
+	Count int
+}
+
+func clampWindow(total, start, count int) windowRange {
+	if count < 1 {
+		count = 1
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start > total {
+		start = max(0, total-count)
+	}
+	end := min(total, start+count)
+	if end < start {
+		end = start
+	}
+	return windowRange{Start: start, End: end, Count: end - start}
+}
+
+func (m model) scrollHint(start, end, total int) string {
+	if total == 0 {
+		return mutedStyle.Render("No rows")
+	}
+	return mutedStyle.Render(fmt.Sprintf("Showing %d-%d of %d", start+1, end, total))
+}
+
+func renderKVTable(title string, rows [][]string) string {
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("63"))).
+		Headers("Setting", "Value").
+		Rows(rows...)
+	return accentStyle.Render(title) + "\n\n" + t.String()
+}
+
+func fieldsFromRecords(records []map[string]interface{}) []string {
+	seen := map[string]bool{}
+	for _, record := range records {
+		for key := range record {
+			seen[key] = true
+		}
+	}
+	fields := make([]string, 0, len(seen))
+	for key := range seen {
+		fields = append(fields, key)
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func analyzeRecords(records []map[string]interface{}) (groups, subgroups, items, positiveStock, zeroStock int) {
+	for _, record := range records {
+		code := fmt.Sprintf("%v", record["Code"])
+		depth := codeDepth(code)
+		switch depth {
+		case 1:
+			groups++
+		case 2:
+			subgroups++
+		default:
+			items++
+		}
+		stock := numericValue(record["ALLANBAR"])
+		if stock > 0 {
+			positiveStock++
+		} else {
+			zeroStock++
+		}
+	}
+	return
+}
+
+func codeDepth(code string) int {
+	digits := strings.Builder{}
+	for _, r := range code {
+		if r >= '0' && r <= '9' {
+			digits.WriteRune(r)
+		}
+	}
+	length := digits.Len()
+	if length == 0 {
+		return 0
+	}
+	depth := (length + 2) / 3
+	if depth > 3 {
+		return 3
+	}
+	return depth
+}
+
+func numericValue(value interface{}) float64 {
+	switch v := value.(type) {
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case string:
+		n, _ := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func classifyField(field string) string {
+	name := strings.ToUpper(field)
+	switch {
+	case name == "CODE":
+		return "hierarchy"
+	case strings.HasPrefix(name, "ANBAR") || name == "ALLANBAR":
+		return "stock"
+	case strings.Contains(name, "DATE"):
+		return "date"
+	case strings.Contains(name, "FOROSH") || strings.Contains(name, "KHARYD"):
+		return "price"
+	default:
+		return "text/number"
+	}
+}
+
+func fieldHint(field string) string {
+	name := strings.ToUpper(field)
+	switch {
+	case name == "CODE":
+		return "group/subgroup/item key"
+	case strings.HasPrefix(name, "ANBAR"):
+		return "warehouse quantity"
+	case name == "ALLANBAR":
+		return "total stock"
+	case name == "NAME":
+		return "display name"
+	default:
+		return "source column"
+	}
+}
+
+func webURL(cfg appconfig.Config, path string) string {
+	host := cfg.Server.Host
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+	port := cfg.Server.Port
+	if port <= 0 {
+		port = 8080
+	}
+	return (&url.URL{Scheme: "http", Host: net.JoinHostPort(host, strconv.Itoa(port)), Path: path}).String()
+}
+
+func wsURL(cfg appconfig.Config) string {
+	u, _ := url.Parse(webURL(cfg, "/ws"))
+	u.Scheme = "ws"
+	return u.String()
+}
+
+func sourceName(path string) string {
+	if path == "" {
+		return ""
+	}
+	if filecopy.IsURL(path) {
+		if u, err := url.Parse(path); err == nil {
+			return filepath.Base(u.Path)
+		}
+	}
+	return filepath.Base(path)
+}
+
+func kv(key, value string) string {
+	return mutedStyle.Render(key+": ") + value
+}
+
+func boolText(value bool) string {
+	if value {
+		return okStyle.Render("yes")
+	}
+	return mutedStyle.Render("no")
+}
+
+func timeText(value time.Time) string {
+	if value.IsZero() {
+		return mutedStyle.Render("unknown")
+	}
+	return value.Format("2006-01-02 15:04:05")
+}
+
+func humanBytes(bytes int64) string {
+	if bytes <= 0 {
+		return mutedStyle.Render("unknown")
+	}
+	units := []string{"B", "KiB", "MiB", "GiB"}
+	value := float64(bytes)
+	unit := 0
+	for value >= 1024 && unit < len(units)-1 {
+		value /= 1024
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%d %s", bytes, units[unit])
+	}
+	return fmt.Sprintf("%.2f %s", value, units[unit])
 }
 
 func empty(value, fallback string) string {
@@ -222,6 +812,13 @@ func empty(value, fallback string) string {
 
 func max(a, b int) int {
 	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
 		return a
 	}
 	return b

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/version"
+)
+
+func TestAnalyzeRecordsClassifiesCodeHierarchyAndStock(t *testing.T) {
+	records := []map[string]interface{}{
+		{"Code": "100", "ALLANBAR": 0},
+		{"Code": "100200", "ALLANBAR": "12.5"},
+		{"Code": "100200300", "ALLANBAR": 7},
+		{"Code": "100200300400", "ALLANBAR": -1},
+	}
+
+	groups, subgroups, items, positiveStock, zeroStock := analyzeRecords(records)
+
+	if groups != 1 || subgroups != 1 || items != 2 {
+		t.Fatalf("unexpected hierarchy counts: groups=%d subgroups=%d items=%d", groups, subgroups, items)
+	}
+	if positiveStock != 2 || zeroStock != 2 {
+		t.Fatalf("unexpected stock counts: positive=%d zero=%d", positiveStock, zeroStock)
+	}
+}
+
+func TestFieldsFromRecordsReturnsSortedUnion(t *testing.T) {
+	fields := fieldsFromRecords([]map[string]interface{}{
+		{"Name": "main", "Code": "100"},
+		{"ALLANBAR": 4, "Name": "child"},
+	})
+
+	got := strings.Join(fields, ",")
+	want := "ALLANBAR,Code,Name"
+	if got != want {
+		t.Fatalf("fieldsFromRecords() = %q, want %q", got, want)
+	}
+}
+
+func TestWebURLNormalizesWildcardAndIPv6Hosts(t *testing.T) {
+	cfg := appconfig.Default()
+	cfg.Server.Host = "0.0.0.0"
+	cfg.Server.Port = 18080
+	if got, want := webURL(cfg, "/viewer"), "http://127.0.0.1:18080/viewer"; got != want {
+		t.Fatalf("webURL wildcard = %q, want %q", got, want)
+	}
+
+	cfg.Server.Host = "::1"
+	if got, want := webURL(cfg, "/ws"), "http://[::1]:18080/ws"; got != want {
+		t.Fatalf("webURL IPv6 = %q, want %q", got, want)
+	}
+}
+
+func TestPreviewRendersOperationalDashboard(t *testing.T) {
+	cfg := appconfig.Default()
+	cfg.Server.Port = 18080
+	cfg.Database.Path = ""
+	out := Preview(cfg, "test-config.json", version.Info{
+		Version:   "test",
+		Commit:    "abc123",
+		BuildDate: "2026-07-11T00:00:00Z",
+		GoVersion: "go-test",
+		Platform:  "windows/amd64",
+	}, 120, 32)
+
+	for _, want := range []string{
+		"Patris Export",
+		"Terminal operations dashboard",
+		"Dashboard",
+		"Source",
+		"Live Data",
+		"API Shortcuts",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("preview output missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
﻿## Summary
- Replaces the static TUI screen with a dynamic Bubble Tea dashboard powered by live refresh ticks.
- Adds Lip Gloss status cards, tabs, tables, keyboard navigation, process/file-lock visibility, charmap inspection, API shortcuts, and WebSocat launch support.
- Documents the terminal dashboard and includes a screenshot generated from the real TUI preview.

## Screenshot
![Patris Export TUI dashboard](https://raw.githubusercontent.com/atomicdeploy/patris-export/agent/issue-3-tui-dashboard/docs/screenshots/issue-3-tui-dashboard.svg)

## Validation
- `go test ./pkg/tui`
- `go test ./...`

Closes #3
