### PR TITLE
Add CSV records API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,15 +434,38 @@ watched file.
 Web interface with API documentation.
 
 #### `GET /api/records`
-Returns all database records in JSON format.
+Returns all database records in JSON format by default. CSV is available through
+either content negotiation, a query parameter, or a file-style route:
 
-**Response:**
+```bash
+curl http://localhost:8080/api/records
+curl http://localhost:8080/api/records?format=csv -o kala.csv
+curl http://localhost:8080/api/records.csv -o kala.csv
+curl -H "Accept: text/csv" http://localhost:8080/api/records -o kala.csv
+```
+
+Add `download=1` to ask the API for an attachment filename, for example
+`/api/records.csv?download=1`.
+
+**JSON response:**
 ```json
 {
-  "success": true,
-  "count": 100,
-  "records": [...]
+  "100": {
+    "Name": "Group",
+    "ALLANBAR": 0
+  },
+  "100200300": {
+    "Name": "Item",
+    "ALLANBAR": 12
+  }
 }
+```
+
+**CSV response:**
+```csv
+Code,ALLANBAR,Name
+100,0,Group
+100200300,12,Item
 ```
 
 #### `GET /api/info`

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -524,6 +524,12 @@ func runConvert(cmd *cobra.Command, args []string) {
 	if !cmd.Flags().Changed("format") {
 		outputFormat = cfg.Convert.Format
 	}
+	outputFormat = strings.ToLower(strings.TrimSpace(outputFormat))
+	if outputFormat != "json" && outputFormat != "csv" {
+		errorColor.Printf("❌ Unsupported output format: %s\n", outputFormat)
+		errorColor.Println("💡 Use --format json or --format csv")
+		os.Exit(1)
+	}
 	if !cmd.Flags().Changed("watch") {
 		watchMode = cfg.Convert.Watch
 	}
@@ -549,9 +555,13 @@ func runConvert(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 		converter.SetDefaultMapping(charMap)
-		successColor.Println("✅ Custom character mapping loaded from file")
+		if !useStdout {
+			successColor.Println("✅ Custom character mapping loaded from file")
+		}
 	} else {
-		infoColor.Println("ℹ️  Using embedded character mapping (Patris81 default)")
+		if !useStdout {
+			infoColor.Println("ℹ️  Using embedded character mapping (Patris81 default)")
+		}
 	}
 
 	// Create output directory if it doesn't exist and we're not using stdout

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -107,18 +107,23 @@ curl http://localhost:8080/api/records
 Response:
 ```json
 {
-  "success": true,
-  "count": 354,
-  "records": [
-    {
-      "Code": 101,
-      "Name": "آی سی",
-      "Serial": "101",
-      ...
-    }
-  ]
+  "101": {
+    "Name": "آی سی",
+    "Serial": "101"
+  }
 }
 ```
+
+#### Export Records as CSV
+
+```bash
+curl http://localhost:8080/api/records.csv -o records.csv
+curl 'http://localhost:8080/api/records?format=csv&download=1' -o records.csv
+curl -H 'Accept: text/csv' http://localhost:8080/api/records -o records.csv
+```
+
+CSV responses include `Code` as the first column, followed by the detected
+record fields.
 
 #### Get Database Info
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"crypto/subtle"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
@@ -14,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -205,6 +207,7 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/viewer", s.handleViewer).Methods("GET")
 	s.router.HandleFunc("/debug/charmap", s.handleCharmapViewer).Methods("GET")
 	s.router.HandleFunc("/api/records", s.handleGetRecords).Methods("GET")
+	s.router.HandleFunc("/api/records.{format:json|csv}", s.handleGetRecords).Methods("GET")
 	s.router.HandleFunc("/api/info", s.handleGetInfo).Methods("GET")
 	s.router.HandleFunc("/api/app", s.handleGetApp).Methods("GET")
 	s.router.HandleFunc("/api/charmap", s.handleGetCharmap).Methods("GET")
@@ -438,7 +441,7 @@ func (s *Server) handleCharmapViewer(w http.ResponseWriter, r *http.Request) {
 	w.Write(web.CharmapHTML)
 }
 
-// handleGetRecords returns all database records as JSON
+// handleGetRecords returns all database records as JSON or CSV.
 func (s *Server) handleGetRecords(w http.ResponseWriter, r *http.Request) {
 	transformed, err := s.Records()
 	if err != nil {
@@ -446,10 +449,119 @@ func (s *Server) handleGetRecords(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	format := requestedRecordsFormat(r)
+	if format == "" {
+		http.Error(w, "unsupported records format; use json or csv", http.StatusBadRequest)
+		return
+	}
+	if format == "csv" {
+		s.writeRecordsCSV(w, r, transformed)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if err := json.NewEncoder(w).Encode(transformed); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to encode JSON: %v", err), http.StatusInternalServerError)
 	}
+}
+
+func requestedRecordsFormat(r *http.Request) string {
+	if routeFormat, ok := mux.Vars(r)["format"]; ok {
+		return strings.ToLower(strings.TrimSpace(routeFormat))
+	}
+	queryFormat := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
+	if queryFormat != "" {
+		switch queryFormat {
+		case "json", "csv":
+			return queryFormat
+		default:
+			return ""
+		}
+	}
+	accept := strings.ToLower(r.Header.Get("Accept"))
+	if strings.Contains(accept, "text/csv") {
+		return "csv"
+	}
+	return "json"
+}
+
+func (s *Server) writeRecordsCSV(w http.ResponseWriter, r *http.Request, records map[string]interface{}) {
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	if wantsDownload(r) {
+		name := strings.TrimSuffix(sourceBaseName(s.currentDBPath()), filepath.Ext(sourceBaseName(s.currentDBPath())))
+		if strings.TrimSpace(name) == "" {
+			name = "patris-export"
+		}
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", name+".csv"))
+	}
+
+	if err := writeRecordsCSV(w, records); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to encode CSV: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func wantsDownload(r *http.Request) bool {
+	value := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("download")))
+	return value == "1" || value == "true" || value == "yes"
+}
+
+func writeRecordsCSV(writer io.Writer, records map[string]interface{}) error {
+	keys := make([]string, 0, len(records))
+	fieldSet := map[string]bool{}
+	for code, value := range records {
+		keys = append(keys, code)
+		if record, ok := value.(map[string]interface{}); ok {
+			for field := range record {
+				if field != "Code" {
+					fieldSet[field] = true
+				}
+			}
+		}
+	}
+	sort.Strings(keys)
+
+	fields := make([]string, 0, len(fieldSet))
+	for field := range fieldSet {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	header := append([]string{"Code"}, fields...)
+
+	cw := csv.NewWriter(writer)
+	if err := cw.Write(header); err != nil {
+		return err
+	}
+	for _, code := range keys {
+		row := make([]string, len(header))
+		row[0] = code
+		record, _ := records[code].(map[string]interface{})
+		for i, field := range fields {
+			row[i+1] = csvCell(record[field])
+		}
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func csvCell(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	case []interface{}, []string, []int, []float64, map[string]interface{}:
+		data, err := json.Marshal(v)
+		if err == nil {
+			return string(data)
+		}
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 // handleGetInfo returns database schema information

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"mime/multipart"
 	"net/http"
@@ -83,6 +84,70 @@ func TestServerJSON(t *testing.T) {
 		}
 		if _, ok := response["102"]; !ok {
 			t.Error("Expected record with Code=102")
+		}
+	})
+
+	t.Run("GET /api/records.csv", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/records.csv", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+			t.Fatalf("Expected text/csv Content-Type, got %s", ct)
+		}
+		rows, err := csv.NewReader(strings.NewReader(w.Body.String())).ReadAll()
+		if err != nil {
+			t.Fatalf("Failed to parse CSV: %v", err)
+		}
+		if len(rows) != 3 {
+			t.Fatalf("Expected header plus 2 rows, got %d rows: %#v", len(rows), rows)
+		}
+		if rows[0][0] != "Code" {
+			t.Fatalf("Expected Code as first CSV header, got %#v", rows[0])
+		}
+		codes := map[string]bool{rows[1][0]: true, rows[2][0]: true}
+		if !codes["101"] || !codes["102"] {
+			t.Fatalf("Expected CSV rows for codes 101 and 102, got %#v", codes)
+		}
+	})
+
+	t.Run("GET /api/records?format=csv download", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/records?format=csv&download=1", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "test.csv") {
+			t.Fatalf("Expected CSV attachment filename, got %q", cd)
+		}
+	})
+
+	t.Run("GET /api/records with CSV accept", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/records", nil)
+		req.Header.Set("Accept", "text/csv")
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+			t.Fatalf("Expected text/csv Content-Type, got %s", ct)
+		}
+	})
+
+	t.Run("GET /api/records invalid format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/records?format=xlsx", nil)
+		w := httptest.NewRecorder()
+		srv.router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("Expected status 400, got %d", w.Code)
 		}
 	})
 

--- a/web/src/welcome.html
+++ b/web/src/welcome.html
@@ -320,6 +320,13 @@
                 Retrieve all database records in JSON format<br>
                 <a href="/api/records">Try it →</a>
             </div>
+
+            <div class="endpoint">
+                <strong>GET</strong>
+                <code>/api/records.csv</code><br>
+                Download all database records in CSV format<br>
+                <a href="/api/records.csv?download=1">Try it →</a>
+            </div>
             
             <div class="endpoint">
                 <strong>GET</strong>


### PR DESCRIPTION
## Summary
- Adds first-class CSV output to the records API through `/api/records.csv`, `/api/records?format=csv`, and `Accept: text/csv`.
- Keeps `/api/records` JSON-compatible while documenting both JSON and CSV API usage.
- Tightens CLI export format validation and keeps `-o -` stdout clean for JSON/CSV pipelines.
- Updates the welcome page and examples so CSV support is discoverable.

## Validation
- `npm run build` in `web/`
- `go test ./...`
- `go run ./cmd/patris-export convert testdata/kala.db -f csv -o -` smoke-tested clean CSV stdout

Closes #14