### PR TITLE
Add portable build entrypoints

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,75 +52,9 @@ jobs:
       run: |
         "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
 
-    - name: Build web frontend
-      run: |
-        cd web
-        npm install
-        npm run build
-    
-    - name: Generate version resource file
-      shell: bash
-      run: |
-        ${GITHUB_WORKSPACE}/scripts/generate-version-rc.sh cmd/patris-export/patris-export.rc
-        
-    - name: Build upstream pxlib for Windows
-      shell: bash
-      run: |
-        export PATH="/c/msys64/mingw64/bin:$PATH"
-        bash scripts/build-pxlib-mingw.sh /c/pxlib-install
-    
-    - name: Compile resource file for patris-export
-      shell: bash
-      run: |
-        # Use windres to compile the resource file
-        echo "Compiling Windows resource file..."
-        
-        export PATH="/c/msys64/mingw64/bin:$PATH"
-        WINDRES=$(which windres || which x86_64-w64-mingw32-windres)
-        "$WINDRES" \
-          --target=pe-x86-64 \
-          -i cmd/patris-export/patris-export.rc \
-          -o cmd/patris-export/patris-export_windows_amd64.syso \
-          -O coff
-        
-        echo "Resource file compiled successfully:"
-        ls -lh cmd/patris-export/patris-export_windows_amd64.syso
-    
-    - name: Build Windows executable
-      shell: bash
-      run: |
-        mkdir -p build
-        
-        export PATH="/c/msys64/mingw64/bin:$PATH"
-        export CGO_ENABLED=1
-        export CC=gcc
-        export CGO_CFLAGS="-IC:/pxlib-install/include"
-        export CGO_LDFLAGS="-LC:/pxlib-install/lib"
-        
-        # Get version info
-          VERSION="1.0.0"
-          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          COMMIT="${GITHUB_SHA::12}"
-          VERSION_PKG="github.com/atomicdeploy/patris-export/pkg/version"
-
-          go build \
-          -ldflags "-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE} -X ${VERSION_PKG}.Commit=${COMMIT}" \
-          -o build/patris-export-windows-amd64.exe \
-          ./cmd/patris-export
-        
-        echo "Build complete:"
-        ls -lh build/patris-export-windows-amd64.exe
-    
-    - name: Copy pxlib DLL
-      shell: bash
-      run: |
-        # Copy DLL files to build directory
-        if [ -d C:/pxlib-install/bin ]; then
-          cp C:/pxlib-install/bin/*.dll build/ 2>/dev/null || true
-        fi
-        
-        echo "Build directory contents:"
-        ls -la build/
+    - name: Build Windows artifacts
+      shell: cmd
+      run: build.cmd --target windows-native --ci --no-assets
     
     - name: Test Windows executable
       shell: bash
@@ -189,6 +123,8 @@ jobs:
         name: patris-export-windows-mingw-amd64
         path: |
           build/patris-export-windows-amd64.exe
+          build/patris-export.dll
+          build/patris-export.h
           build/*.dll
 
     - name: Generate Windows native build summary
@@ -203,4 +139,5 @@ jobs:
           "patris-export-windows-mingw-amd64" \
           "Native Windows amd64 build with MSYS2 MinGW" \
           build/patris-export-windows-amd64.exe \
+          build/patris-export.h \
           build/*.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,17 +46,9 @@ jobs:
           sudo apt-get install -y pxlib-dev pxlib1
         fi
     
-    - name: Build web frontend
-      run: |
-        cd web
-        npm install
-        npm run build
-        
-    - name: Build
-      run: make build-linux
-
-    - name: Build Linux loadable library
-      run: make build-lib-linux
+    - name: Build Linux artifacts
+      shell: bash
+      run: bash ./build.sh --target linux --ci --skip-pxlib --no-assets
       
     - name: Upload Linux artifact
       uses: actions/upload-artifact@v7.0.1
@@ -113,65 +105,9 @@ jobs:
         x86_64-w64-mingw32-gcc --version
         ls -la /usr/share/mingw-w64/include/ 2>/dev/null || echo "MinGW headers not in standard location"
     
-    - name: Build web frontend
-      run: |
-        cd web
-        npm install
-        npm run build
-
-    - name: Generate version resource file
-      run: |
-        ${GITHUB_WORKSPACE}/scripts/generate-version-rc.sh cmd/patris-export/patris-export.rc
-        
-    - name: Build upstream pxlib for Windows
-      run: |
-        export PXLIB_MINGW_CROSS=1
-        bash scripts/build-pxlib-mingw.sh "$GITHUB_WORKSPACE/.deps/pxlib-windows"
-        echo "CGO_CFLAGS=-I$GITHUB_WORKSPACE/.deps/pxlib-windows/include" >> "$GITHUB_ENV"
-        echo "CGO_LDFLAGS=-L$GITHUB_WORKSPACE/.deps/pxlib-windows/lib" >> "$GITHUB_ENV"
-    
-    - name: Compile resource file for patris-export
-      run: |
-        # Compile the Windows resource file to .syso for embedding
-        echo "Compiling Windows resource file..."
-        x86_64-w64-mingw32-windres \
-          -i cmd/patris-export/patris-export.rc \
-          -o cmd/patris-export/patris-export_windows_amd64.syso \
-          -O coff \
-          --target=pe-x86-64
-        
-        echo "Resource file compiled successfully:"
-        ls -lh cmd/patris-export/patris-export_windows_amd64.syso
-        
-    - name: Build Windows executable
-      run: |
-        mkdir -p build
-        VERSION_PKG="github.com/atomicdeploy/patris-export/pkg/version"
-        CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
-          go build -ldflags "-X ${VERSION_PKG}.Version=1.0.0 -X ${VERSION_PKG}.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PKG}.Commit=${GITHUB_SHA::12}" \
-          -o build/patris-export-windows-amd64.exe ./cmd/patris-export
-
-    - name: Build Windows loadable library
-      run: |
-        VERSION_PKG="github.com/atomicdeploy/patris-export/pkg/version"
-        CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
-          go build -buildmode=c-shared \
-          -ldflags "-X ${VERSION_PKG}.Version=1.0.0 -X ${VERSION_PKG}.BuildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -X ${VERSION_PKG}.Commit=${GITHUB_SHA::12}" \
-          -o build/patris-export.dll ./cmd/patris-export-lib
-      
-    - name: Copy pxlib DLL
-      run: |
-        # Find and copy DLL files
-        mkdir -p build
-        if find "$GITHUB_WORKSPACE/.deps/pxlib-windows/bin" -name "*.dll" -type f 2>/dev/null | grep -q .; then
-          find "$GITHUB_WORKSPACE/.deps/pxlib-windows/bin" -name "*.dll" -type f -exec cp {} build/ \;
-          echo "DLL files copied:"
-          ls -la build/*.dll
-        else
-          echo "Warning: No DLL files found - Windows executable may require runtime linking"
-        fi
-        echo "Build directory contents:"
-        ls -la build/
+    - name: Build Windows cross artifacts
+      shell: bash
+      run: bash ./build.sh --target windows-cross --ci --no-assets
     
     - name: Test Windows executable with Wine
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cmd/patris-export/patris-export.rc
 
 # Dependency directories
 vendor/
+.deps/
 
 # Go workspace file
 go.work

--- a/README.md
+++ b/README.md
@@ -49,8 +49,29 @@ go install github.com/atomicdeploy/patris-export/cmd/patris-export@latest
 ```bash
 git clone https://github.com/atomicdeploy/patris-export.git
 cd patris-export
-make build
+./build.sh --target current
 ```
+
+Windows users can use the batch launcher, which detects Git Bash/MSYS2 and
+calls the same build orchestration:
+
+```cmd
+build.cmd
+```
+
+Useful build variants:
+
+```bash
+./build.sh --target linux
+./build.sh --target windows-cross
+./build.sh --target all --test
+./build.sh --target linux --skip-pxlib
+```
+
+The scripts check required tools, build or reuse upstream pxlib, rebuild the web
+frontend, compile Win32 icon/version resources for Windows targets, and print an
+artifact summary. Set `PXLIB_ROOT` to use an existing pxlib install, or
+`USE_VCPKG=1` to add optional vcpkg C dependency paths.
 
 ## 📖 Usage
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,95 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "ESC="
+set "BOLD=%ESC%[1m"
+set "DIM=%ESC%[2m"
+set "RED=%ESC%[31m"
+set "GREEN=%ESC%[32m"
+set "YELLOW=%ESC%[33m"
+set "CYAN=%ESC%[36m"
+set "RESET=%ESC%[0m"
+
+set "ROOT=%~dp0"
+set "HAS_TARGET=0"
+set "WANTS_HELP=0"
+
+if exist "C:\Program Files\Go\bin\go.exe" set "PATH=C:\Program Files\Go\bin;%PATH%"
+for /D %%D in ("C:\Program Files\Python*") do (
+    if exist "%%~D\python.exe" set "PATH=%%~D;%PATH%"
+)
+if exist "C:\msys64\mingw64\bin\gcc.exe" set "PATH=C:\msys64\mingw64\bin;%PATH%"
+for /D %%D in ("%LOCALAPPDATA%\Microsoft\WinGet\Packages\BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_*") do (
+    if exist "%%~D\mingw64\bin\gcc.exe" set "PATH=%%~D\mingw64\bin;%PATH%"
+)
+if not defined PXLIB_ROOT (
+    if exist "%USERPROFILE%\Desktop\AtomicDeploy\deps\pxlib-install-windows\include\paradox.h" (
+        set "PXLIB_ROOT=%USERPROFILE%\Desktop\AtomicDeploy\deps\pxlib-install-windows"
+    )
+)
+
+for %%A in (%*) do (
+    if /I "%%~A"=="--target" set "HAS_TARGET=1"
+    echo %%~A | findstr /B /I /C:"--target=" >nul && set "HAS_TARGET=1"
+    if /I "%%~A"=="-h" set "WANTS_HELP=1"
+    if /I "%%~A"=="--help" set "WANTS_HELP=1"
+)
+
+call :find_bash
+if not defined BASH_EXE (
+    call :err "Bash was not found. Install MSYS2 or Git for Windows, then retry."
+    exit /b 1
+)
+
+call :info "🏗️  Patris Export Windows build launcher"
+call :info "Bash: %BASH_EXE%"
+
+if "%WANTS_HELP%"=="1" (
+    "%BASH_EXE%" "%ROOT%build.sh" --help
+    exit /b %ERRORLEVEL%
+)
+
+if "%HAS_TARGET%"=="1" (
+    "%BASH_EXE%" "%ROOT%build.sh" %*
+) else (
+    "%BASH_EXE%" "%ROOT%build.sh" --target windows-native %*
+)
+set "EXIT_CODE=%ERRORLEVEL%"
+if "%EXIT_CODE%"=="0" (
+    call :ok "Build finished"
+) else (
+    call :err "Build failed with exit code %EXIT_CODE%"
+)
+exit /b %EXIT_CODE%
+
+:find_bash
+for %%B in (bash.exe) do (
+    if not "%%~$PATH:B"=="" (
+        set "BASH_EXE=%%~$PATH:B"
+        goto :eof
+    )
+)
+for %%B in (
+    "%ProgramFiles%\Git\usr\bin\bash.exe"
+    "%ProgramFiles(x86)%\Git\usr\bin\bash.exe"
+    "C:\msys64\usr\bin\bash.exe"
+    "C:\msys64\mingw64\bin\bash.exe"
+) do (
+    if exist "%%~B" (
+        set "BASH_EXE=%%~B"
+        goto :eof
+    )
+)
+goto :eof
+
+:info
+echo %CYAN%%~1%RESET%
+goto :eof
+
+:ok
+echo %GREEN%✅ %~1%RESET%
+goto :eof
+
+:err
+echo %RED%❌ %~1%RESET% 1>&2
+goto :eof

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$ROOT_DIR/build"
+DEPS_DIR="$ROOT_DIR/.deps"
+VERSION="${VERSION:-1.0.0}"
+VERSION_PKG="github.com/atomicdeploy/patris-export/pkg/version"
+BUILD_DATE="${BUILD_DATE:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"
+COMMIT="${COMMIT:-$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)}"
+TARGET="current"
+CI_MODE="${CI:-0}"
+SKIP_PXLIB=0
+SKIP_WEB=0
+SKIP_ASSETS=0
+RUN_TESTS=0
+
+if [ -t 1 ]; then
+    BOLD=$'\033[1m'
+    DIM=$'\033[2m'
+    RED=$'\033[31m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    CYAN=$'\033[36m'
+    RESET=$'\033[0m'
+else
+    BOLD=""
+    DIM=""
+    RED=""
+    GREEN=""
+    YELLOW=""
+    CYAN=""
+    RESET=""
+fi
+
+usage() {
+    cat <<'EOF'
+Patris Export build helper
+
+Usage:
+  ./build.sh [options]
+
+Options:
+  --target <name>     Build target: current, linux, windows-cross, windows-native, windows, all
+  --ci                CI mode: deterministic paths and non-interactive output
+  --skip-pxlib        Use existing CGO/PXLIB_ROOT settings instead of building upstream pxlib
+  --no-web            Skip npm install and web frontend build
+  --no-assets         Skip optional asset regeneration
+  --test              Run go test ./... after building
+  -h, --help          Show this help
+
+Environment:
+  VERSION             Version string embedded in the binary (default: 1.0.0)
+  PXLIB_ROOT          Existing pxlib install prefix to use
+  PXLIB_REPO/PXLIB_REF Override upstream pxlib source and ref
+  USE_VCPKG=1         Adds VCPKG_ROOT installed include/lib/bin paths as optional C dependency paths
+EOF
+}
+
+log() { printf '%s%s%s\n' "${CYAN}" "$*" "${RESET}"; }
+ok() { printf '%s✅ %s%s\n' "${GREEN}" "$*" "${RESET}"; }
+warn() { printf '%s⚠️  %s%s\n' "${YELLOW}" "$*" "${RESET}"; }
+fail() { printf '%s❌ %s%s\n' "${RED}" "$*" "${RESET}" >&2; exit 1; }
+step() { printf '\n%s%s%s\n' "${BOLD}" "$*" "${RESET}"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+need() {
+    local name="$1"
+    local hint="${2:-Install $1 and retry.}"
+    have "$name" || fail "Required tool not found: $name. $hint"
+}
+
+is_windows_shell() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+to_windows_path() {
+    local value="$1"
+    if is_windows_shell && have cygpath; then
+        cygpath -m "$value"
+    else
+        printf '%s' "$value"
+    fi
+}
+
+ldflags() {
+    printf -- '-X %s.Version=%s -X %s.BuildDate=%s -X %s.Commit=%s' \
+        "$VERSION_PKG" "$VERSION" "$VERSION_PKG" "$BUILD_DATE" "$VERSION_PKG" "$COMMIT"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --target)
+            [ "$#" -ge 2 ] || fail "--target requires a value"
+            TARGET="$2"
+            shift 2
+            ;;
+        --target=*)
+            TARGET="${1#*=}"
+            shift
+            ;;
+        --ci)
+            CI_MODE=1
+            shift
+            ;;
+        --skip-pxlib)
+            SKIP_PXLIB=1
+            shift
+            ;;
+        --no-web|--skip-web)
+            SKIP_WEB=1
+            shift
+            ;;
+        --no-assets|--skip-assets)
+            SKIP_ASSETS=1
+            shift
+            ;;
+        --test)
+            RUN_TESTS=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "Unknown option: $1"
+            ;;
+    esac
+done
+
+if [ "$TARGET" = "current" ]; then
+    if is_windows_shell; then
+        TARGET="windows-native"
+    else
+        TARGET="linux"
+    fi
+fi
+if [ "$TARGET" = "windows" ]; then
+    if is_windows_shell; then
+        TARGET="windows-native"
+    else
+        TARGET="windows-cross"
+    fi
+fi
+
+if [ "$TARGET" = "all" ]; then
+    extra=()
+    [ "$CI_MODE" = "1" ] && extra+=(--ci)
+    [ "$SKIP_WEB" = "1" ] && extra+=(--no-web)
+    [ "$SKIP_ASSETS" = "1" ] && extra+=(--no-assets)
+    [ "$SKIP_PXLIB" = "1" ] && extra+=(--skip-pxlib)
+    "$0" --target linux "${extra[@]}"
+    "$0" --target windows-cross "${extra[@]}"
+    exit 0
+fi
+
+cd "$ROOT_DIR"
+if is_windows_shell && have cygpath; then
+    [ -n "${PXLIB_ROOT:-}" ] && PXLIB_ROOT="$(cygpath -u "$PXLIB_ROOT")" && export PXLIB_ROOT
+    [ -n "${VCPKG_ROOT:-}" ] && VCPKG_ROOT="$(cygpath -u "$VCPKG_ROOT")" && export VCPKG_ROOT
+fi
+
+step "🏗️  Patris Export build"
+log "Target: ${BOLD}$TARGET${RESET}"
+log "Version: ${VERSION}  Commit: ${COMMIT}  Date: ${BUILD_DATE}"
+
+need git "Git is required for version metadata and upstream pxlib fetches."
+need go "Install Go 1.24 or newer."
+if [ "$SKIP_WEB" -eq 0 ]; then
+    need npm "Install Node.js/npm 24 or newer."
+fi
+
+run_assets() {
+    [ "$SKIP_ASSETS" -eq 0 ] || return 0
+    if have magick || have convert; then
+        step "🎨 Rebuilding assets"
+        bash "$ROOT_DIR/scripts/rebuild-assets.sh"
+    elif [ -f "$ROOT_DIR/assets/windows/patris-api.ico" ] && [ -f "$ROOT_DIR/web/assets/favicon.ico" ]; then
+        warn "ImageMagick not found; using checked-in icon/favicon assets."
+    else
+        fail "ImageMagick is required because generated icon assets are missing."
+    fi
+}
+
+run_web() {
+    [ "$SKIP_WEB" -eq 0 ] || return 0
+    step "🌐 Building web frontend"
+    (cd "$ROOT_DIR/web" && npm install && npm run build)
+}
+
+run_tests() {
+    [ "$RUN_TESTS" -eq 1 ] || return 0
+    step "🧪 Running Go tests"
+    go test ./...
+}
+
+ensure_python3() {
+    if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys' >/dev/null 2>&1; then
+        return 0
+    fi
+    local shim_dir="$DEPS_DIR/build-bin"
+    mkdir -p "$shim_dir"
+    if command -v python >/dev/null 2>&1 && python -c 'import sys' >/dev/null 2>&1; then
+        cat > "$shim_dir/python3" <<'EOF'
+#!/usr/bin/env bash
+exec python "$@"
+EOF
+    elif command -v py >/dev/null 2>&1 && py -3 -c 'import sys' >/dev/null 2>&1; then
+        cat > "$shim_dir/python3" <<'EOF'
+#!/usr/bin/env bash
+exec py -3 "$@"
+EOF
+    else
+        fail "Python 3 is required to generate Windows resources."
+    fi
+    chmod +x "$shim_dir/python3"
+    export PATH="$shim_dir:$PATH"
+}
+
+use_optional_vcpkg() {
+    if [[ "${USE_VCPKG:-}" =~ ^(1|true|yes|on)$ ]]; then
+        local vcpkg_root="${VCPKG_ROOT:-$DEPS_DIR/vcpkg}"
+        local triplet="${VCPKG_DEFAULT_TRIPLET:-x64-windows}"
+        local installed="$vcpkg_root/installed/$triplet"
+        if [ -d "$installed" ]; then
+            warn "Using optional vcpkg C dependency paths: $installed"
+            export CGO_CFLAGS="${CGO_CFLAGS:-} -I$(to_windows_path "$installed")/include"
+            export CGO_LDFLAGS="${CGO_LDFLAGS:-} -L$(to_windows_path "$installed")/lib -L$(to_windows_path "$installed")/bin"
+            export PATH="$installed/bin:$PATH"
+        fi
+    fi
+}
+
+prepare_linux_pxlib() {
+    if [ -n "${PXLIB_ROOT:-}" ] && [ -f "$PXLIB_ROOT/include/paradox.h" ]; then
+        warn "Using pxlib from PXLIB_ROOT=$PXLIB_ROOT"
+        export CGO_CFLAGS="-I$PXLIB_ROOT/include ${CGO_CFLAGS:-}"
+        export CGO_LDFLAGS="-L$PXLIB_ROOT/lib ${CGO_LDFLAGS:-}"
+        export LD_LIBRARY_PATH="$PXLIB_ROOT/lib:${LD_LIBRARY_PATH:-}"
+        return 0
+    fi
+    if [ "$SKIP_PXLIB" -eq 1 ]; then
+        warn "Skipping pxlib build; using existing CGO_CFLAGS/CGO_LDFLAGS."
+        return 0
+    fi
+    need cmake "Install CMake or use --skip-pxlib with system pxlib-dev."
+    step "📦 Building upstream pxlib for Linux"
+    local prefix="$DEPS_DIR/pxlib-linux"
+    bash "$ROOT_DIR/scripts/build-pxlib-linux.sh" "$prefix"
+    export CGO_CFLAGS="-I$prefix/include ${CGO_CFLAGS:-}"
+    export CGO_LDFLAGS="-L$prefix/lib ${CGO_LDFLAGS:-}"
+    export LD_LIBRARY_PATH="$prefix/lib:${LD_LIBRARY_PATH:-}"
+}
+
+prepare_windows_pxlib() {
+    local prefix="$1"
+    if [ -n "${PXLIB_ROOT:-}" ] && [ -f "$PXLIB_ROOT/include/paradox.h" ]; then
+        warn "Using pxlib from PXLIB_ROOT=$PXLIB_ROOT"
+        prefix="$PXLIB_ROOT"
+        export PXLIB_ROOT="$prefix"
+        export CGO_CFLAGS="-I$(to_windows_path "$prefix")/include ${CGO_CFLAGS:-}"
+        export CGO_LDFLAGS="-L$(to_windows_path "$prefix")/lib -L$(to_windows_path "$prefix")/bin ${CGO_LDFLAGS:-}"
+        return 0
+    fi
+    if [ "$SKIP_PXLIB" -eq 1 ]; then
+        warn "Skipping pxlib build; using existing CGO_CFLAGS/CGO_LDFLAGS."
+        return 0
+    else
+        need cmake "Install CMake for upstream pxlib builds."
+        step "📦 Building upstream pxlib for Windows"
+        if [ "$TARGET" = "windows-cross" ]; then
+            export PXLIB_MINGW_CROSS=1
+        fi
+        bash "$ROOT_DIR/scripts/build-pxlib-mingw.sh" "$prefix"
+    fi
+    export PXLIB_ROOT="$prefix"
+    export CGO_CFLAGS="-I$(to_windows_path "$prefix")/include ${CGO_CFLAGS:-}"
+    export CGO_LDFLAGS="-L$(to_windows_path "$prefix")/lib -L$(to_windows_path "$prefix")/bin ${CGO_LDFLAGS:-}"
+}
+
+copy_windows_dlls() {
+    local prefix="${PXLIB_ROOT:-}"
+    mkdir -p "$BUILD_DIR"
+    if [ -n "$prefix" ] && [ -d "$prefix/bin" ]; then
+        for dll in "$prefix"/bin/*.dll; do
+            [ -f "$dll" ] && cp "$dll" "$BUILD_DIR/" || true
+        done
+    fi
+    local gcc_path
+    gcc_path="$(command -v "${CC:-gcc}" 2>/dev/null || true)"
+    if [ -n "$gcc_path" ]; then
+        local gcc_dir
+        gcc_dir="$(dirname "$gcc_path")"
+        for dll in libgcc_s_seh-1.dll libwinpthread-1.dll libstdc++-6.dll; do
+            [ -f "$gcc_dir/$dll" ] && cp "$gcc_dir/$dll" "$BUILD_DIR/" || true
+        done
+    fi
+}
+
+compile_windows_resources() {
+    local windres_name="$1"
+    step "🪟 Compiling Win32 icon/version resources"
+    ensure_python3
+    bash "$ROOT_DIR/scripts/generate-version-rc.sh" cmd/patris-export/patris-export.rc
+    "$windres_name" \
+        --target=pe-x86-64 \
+        -i cmd/patris-export/patris-export.rc \
+        -o cmd/patris-export/patris-export_windows_amd64.syso \
+        -O coff
+}
+
+build_linux() {
+    prepare_linux_pxlib
+    run_web
+    step "🐧 Building Linux executable and shared library"
+    make build-linux build-lib-linux
+    run_tests
+}
+
+build_windows_cross() {
+    need x86_64-w64-mingw32-gcc "Install mingw-w64 cross GCC."
+    need x86_64-w64-mingw32-windres "Install mingw-w64 windres."
+    export CC=x86_64-w64-mingw32-gcc
+    prepare_windows_pxlib "$DEPS_DIR/pxlib-windows"
+    use_optional_vcpkg
+    run_assets
+    run_web
+    compile_windows_resources x86_64-w64-mingw32-windres
+    mkdir -p "$BUILD_DIR"
+    step "🪟 Building Windows executable and DLL"
+    CGO_ENABLED=1 GOOS=windows GOARCH=amd64 "$GO_BINARY" build -ldflags "$(ldflags)" -o "$BUILD_DIR/patris-export-windows-amd64.exe" ./cmd/patris-export
+    CGO_ENABLED=1 GOOS=windows GOARCH=amd64 "$GO_BINARY" build -buildmode=c-shared -ldflags "$(ldflags)" -o "$BUILD_DIR/patris-export.dll" ./cmd/patris-export-lib
+    copy_windows_dlls
+    run_tests
+}
+
+build_windows_native() {
+    need gcc "Install MSYS2/MinGW or WinLibs GCC and put it on PATH."
+    local windres_name
+    windres_name="$(command -v windres 2>/dev/null || command -v x86_64-w64-mingw32-windres 2>/dev/null || true)"
+    [ -n "$windres_name" ] || fail "Required tool not found: windres."
+    export CC="${CC:-gcc}"
+    prepare_windows_pxlib "$DEPS_DIR/pxlib-windows-native"
+    use_optional_vcpkg
+    run_assets
+    run_web
+    compile_windows_resources "$windres_name"
+    mkdir -p "$BUILD_DIR"
+    step "🪟 Building native Windows executable and DLL"
+    CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -ldflags "$(ldflags)" -o "$BUILD_DIR/patris-export-windows-amd64.exe" ./cmd/patris-export
+    CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -buildmode=c-shared -ldflags "$(ldflags)" -o "$BUILD_DIR/patris-export.dll" ./cmd/patris-export-lib
+    copy_windows_dlls
+    run_tests
+}
+
+GO_BINARY="$(command -v go)"
+mkdir -p "$BUILD_DIR" "$DEPS_DIR"
+
+case "$TARGET" in
+    linux) build_linux ;;
+    windows-cross) build_windows_cross ;;
+    windows-native) build_windows_native ;;
+    *) fail "Unsupported target: $TARGET" ;;
+esac
+
+step "📦 Build artifacts"
+artifact_count=0
+for artifact in "$BUILD_DIR"/*; do
+    [ -f "$artifact" ] || continue
+    artifact_count=$((artifact_count + 1))
+    size="$(wc -c < "$artifact" | tr -d '[:space:]')"
+    printf '  %s  %s bytes\n' "$(basename "$artifact")" "$size"
+done
+[ "$artifact_count" -gt 0 ] || warn "No files found in $BUILD_DIR"
+ok "Build complete"


### PR DESCRIPTION
## Summary
- Adds root `build.sh` and `build.cmd` entry points with colored/emoji progress output, tool detection, pxlib handling, Win32 resource compilation, web build orchestration, optional vcpkg paths, and artifact summaries.
- Makes `build.cmd` a Windows-friendly launcher that finds Git Bash/MSYS2, Go, Python, MinGW, and the AtomicDeploy pxlib install when available.
- Updates Linux, Windows cross-compile, and native Windows CI jobs to call the shared build scripts for artifact generation instead of duplicating Go build commands in YAML.
- Documents common build script usage in the README.

## Validation
- `bash -n build.sh`
- `cmd /c build.cmd --help`
- `cmd /c build.cmd --target windows-native --skip-pxlib --no-web --no-assets`
- `go test ./...`

Closes #8