### PR TITLE
Fix local Windows build version fallback

### DIFF
--- a/scripts/windows/Build-LocalWindows.ps1
+++ b/scripts/windows/Build-LocalWindows.ps1
@@ -64,11 +64,18 @@ $useVcpkg = $env:USE_VCPKG -match '^(1|true|yes|on)$'
 if (-not $Version) {
     Push-Location $repoRoot
     try {
+        $previousErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         $Version = (& git describe --tags --abbrev=0 2>$null)
-        if ($LASTEXITCODE -ne 0 -or -not $Version) {
+        $describeExitCode = $LASTEXITCODE
+        $ErrorActionPreference = $previousErrorActionPreference
+        if ($describeExitCode -ne 0 -or -not $Version) {
             $Version = "v1.0.0"
         }
     } finally {
+        if ($previousErrorActionPreference) {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
         Pop-Location
     }
     $Version = $Version -replace '^v', ''


### PR DESCRIPTION
## Summary
- Prevent the local Windows build wrapper from stopping when `git describe --tags` has no tag to describe.
- Preserve the intended fallback to `1.0.0` while keeping strict error handling for the rest of the script.

## Validation
- PowerShell parse check passed.
- The wrapper proceeded through asset generation and native compilation after passing `-Version 1.0.0`; final deploy copy was blocked only because the live exe on port 18080 was running, which is handled separately by stopping and restarting the live process.