### PR TITLE
Add Windows CGO test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,19 @@ make install       # Install to GOPATH/bin
 go test -v ./...
 ```
 
+On Windows, use the CGO helper when running tests against the native pxlib
+reader:
+
+```bat
+test-cgo.cmd
+```
+
+For custom CGO commands, pass the command after the helper script:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 go test ./pkg/server
+```
+
 ## 📋 Command Reference
 
 ### Global Flags

--- a/scripts/windows/Invoke-CGO.ps1
+++ b/scripts/windows/Invoke-CGO.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Command,
+    [string]$AtomicDeployRoot = "$env:USERPROFILE\Desktop\AtomicDeploy",
+    [string]$PxlibRoot = $env:PXLIB_ROOT,
+    [string]$WinLibsBin
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ExistingPath {
+    param(
+        [string]$Description,
+        [string[]]$Candidates
+    )
+
+    foreach ($candidate in $Candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+    throw "$Description not found. Checked: $($Candidates -join '; ')"
+}
+
+function Resolve-ToolPath {
+    param(
+        [string]$Name,
+        [string[]]$Candidates = @()
+    )
+
+    foreach ($candidate in $Candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    $tool = Get-Command $Name -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($tool) {
+        return $tool.Source
+    }
+
+    throw "Required tool not found: $Name"
+}
+
+if (-not $PxlibRoot) {
+    $PxlibRoot = Join-Path $AtomicDeployRoot "deps\pxlib-install-windows"
+}
+$PxlibRoot = Resolve-ExistingPath "pxlib root" @($PxlibRoot)
+
+if (-not (Test-Path (Join-Path $PxlibRoot "include\paradox.h"))) {
+    throw "pxlib header not found: $(Join-Path $PxlibRoot "include\paradox.h")"
+}
+if (-not (Test-Path (Join-Path $PxlibRoot "lib\libpxlib.dll.a"))) {
+    throw "pxlib import library not found: $(Join-Path $PxlibRoot "lib\libpxlib.dll.a")"
+}
+if (-not (Test-Path (Join-Path $PxlibRoot "bin\libpxlib.dll"))) {
+    throw "pxlib runtime DLL not found: $(Join-Path $PxlibRoot "bin\libpxlib.dll")"
+}
+
+if (-not $WinLibsBin) {
+    $WinLibsBin = Resolve-ExistingPath "WinLibs MinGW bin" @(
+        "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe\mingw64\bin",
+        "C:\msys64\mingw64\bin"
+    )
+} else {
+    $WinLibsBin = Resolve-ExistingPath "WinLibs MinGW bin" @($WinLibsBin)
+}
+
+$go = Resolve-ToolPath "go.exe" @("C:\Program Files\Go\bin\go.exe")
+$gcc = Resolve-ToolPath "gcc.exe" @((Join-Path $WinLibsBin "gcc.exe"))
+
+$env:CGO_ENABLED = "1"
+$env:CC = $gcc
+$env:PXLIB_ROOT = $PxlibRoot
+$env:CGO_CFLAGS = "-I$PxlibRoot\include"
+$env:CGO_LDFLAGS = "-L$PxlibRoot\lib -L$PxlibRoot\bin"
+$env:PATH = "$(Join-Path $PxlibRoot "bin");$WinLibsBin;$(Split-Path -Parent $go);$env:PATH"
+
+if (-not $Command -or $Command.Count -eq 0) {
+    $Command = @("go", "test", "./...")
+}
+
+if ($Command[0] -ieq "go" -or $Command[0] -ieq "go.exe") {
+    $exe = $go
+    $args = @($Command | Select-Object -Skip 1)
+} else {
+    $resolved = Get-Command $Command[0] -ErrorAction SilentlyContinue | Select-Object -First 1
+    $exe = if ($resolved) { $resolved.Source } else { $Command[0] }
+    $args = @($Command | Select-Object -Skip 1)
+}
+
+Write-Host "CGO_ENABLED=$env:CGO_ENABLED"
+Write-Host "CC=$env:CC"
+Write-Host "PXLIB_ROOT=$env:PXLIB_ROOT"
+Write-Host "CGO_CFLAGS=$env:CGO_CFLAGS"
+Write-Host "CGO_LDFLAGS=$env:CGO_LDFLAGS"
+Write-Host "PATH prepended: $(Join-Path $PxlibRoot "bin");$WinLibsBin;$(Split-Path -Parent $go)"
+Write-Host "Running: $exe $($args -join ' ')"
+
+& $exe @args
+exit $LASTEXITCODE

--- a/test-cgo.cmd
+++ b/test-cgo.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal EnableExtensions
+
+set "ROOT=%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%ROOT%scripts\windows\Invoke-CGO.ps1" go test ./...
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary
- Adds `scripts/windows/Invoke-CGO.ps1` to set the local Windows CGO environment for pxlib-backed tests and commands.
- Adds `test-cgo.cmd` as a simple full-suite entrypoint.
- Documents the Windows CGO test path in the README.

## What Was Needed Locally
Plain `go env` had `CGO_ENABLED=0`, and this shell did not have MinGW GCC or the pxlib runtime DLL directory on `PATH`. With those set explicitly, the native Paradox backend compiles and the server tests run.

The helper sets:
- `CGO_ENABLED=1`
- `CC=<WinLibs or MSYS2 gcc.exe>`
- `PXLIB_ROOT=<AtomicDeploy>/deps/pxlib-install-windows`
- `CGO_CFLAGS=-I<PXLIB_ROOT>/include`
- `CGO_LDFLAGS=-L<PXLIB_ROOT>/lib -L<PXLIB_ROOT>/bin`
- prepends `<PXLIB_ROOT>/bin`, MinGW bin, and Go bin to `PATH`

## Validation
- PowerShell parse validation for `scripts/windows/Invoke-CGO.ps1`
- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows/Invoke-CGO.ps1 go test ./pkg/paradox ./pkg/server`
- `cmd /c test-cgo.cmd`