### PR TITLE
Add drag-and-drop datasource switching

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -392,7 +392,7 @@ func (s *Server) ShowToast(req ToastRequest) error {
 // Refresh forces a data refresh broadcast to browser, IPC, and embedded
 // subscribers.
 func (s *Server) Refresh() {
-	s.broadcastUpdate()
+	s.broadcastInitialSnapshot("source_changed")
 }
 
 // SubscribeEvents subscribes to the same event stream used by the WebSocket
@@ -937,7 +937,7 @@ func (s *Server) handlePostEdgeUpload(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("📥 Edge upload accepted from %s: %s (%d bytes, %d records, crc32=%s)", sourceID, filepath.Base(destPath), written, len(records), gotHash)
 	s.notifyConfigured("file_updated", "Patris edge upload received", fmt.Sprintf("%s uploaded %s (%d records)", sourceID, filepath.Base(originalName), len(records)))
-	s.broadcastUpdate()
+	s.broadcastInitialSnapshot("source_changed")
 
 	writeJSON(w, edgeUploadResponse{
 		Success:  true,
@@ -1086,22 +1086,7 @@ func (s *Server) sendRecordsToClient(conn *websocket.Conn, connMu *sync.Mutex) {
 	records := result.Rows
 	dbPath := s.currentDBPath()
 
-	// Send as initial load (all records are "added")
-	message := map[string]interface{}{
-		"type":        "initial",
-		"timestamp":   time.Now().Format(time.RFC3339),
-		"added":       records,
-		"total_count": len(records),
-		"file_name":   sourceBaseName(dbPath),
-		"file_path":   dbPath,
-		"version":     s.version,
-		"resources":   web.Resources(),
-		"raw":         result.Raw,
-		"key_field":   result.KeyField,
-	}
-	if s.config != nil {
-		message["config"] = s.config.Get()
-	}
+	message := s.initialSnapshotMessage(result, dbPath, "")
 
 	connMu.Lock()
 	err = conn.WriteJSON(message)
@@ -1118,6 +1103,68 @@ func (s *Server) sendRecordsToClient(conn *websocket.Conn, connMu *sync.Mutex) {
 	s.lastRecordsMu.Unlock()
 
 	log.Printf("📤 Sent initial %d records to client", len(records))
+	go s.broadcastProcessInfo()
+}
+
+func (s *Server) initialSnapshotMessage(result recordpipe.Result, dbPath, reason string) map[string]interface{} {
+	message := map[string]interface{}{
+		"type":        "initial",
+		"timestamp":   time.Now().Format(time.RFC3339),
+		"added":       result.Rows,
+		"total_count": len(result.Rows),
+		"file_name":   sourceBaseName(dbPath),
+		"file_path":   dbPath,
+		"version":     s.version,
+		"resources":   web.Resources(),
+		"raw":         result.Raw,
+		"key_field":   result.KeyField,
+	}
+	if reason != "" {
+		message["reason"] = reason
+		message["source_changed"] = true
+	}
+	if s.config != nil {
+		message["config"] = s.config.Get()
+	}
+	return message
+}
+
+func (s *Server) broadcastInitialSnapshot(reason string) {
+	result, err := s.RecordResult()
+	if err != nil {
+		log.Printf("Failed to read records for initial snapshot: %v", err)
+		return
+	}
+	records := result.Rows
+	dbPath := s.currentDBPath()
+	message := s.initialSnapshotMessage(result, dbPath, reason)
+
+	s.lastRecordsMu.Lock()
+	s.lastRecords = records
+	s.lastRecordsMu.Unlock()
+
+	s.wsClientsMu.RLock()
+	for conn, connMu := range s.wsClients {
+		go func(c *websocket.Conn, mu *sync.Mutex) {
+			mu.Lock()
+			err := c.WriteJSON(message)
+			mu.Unlock()
+			if err != nil {
+				log.Printf("Failed to send source snapshot to WebSocket: %v", err)
+			}
+		}(conn, connMu)
+	}
+	s.wsClientsMu.RUnlock()
+
+	log.Printf("📤 Broadcast initial snapshot (%s): %d records from %s", reason, len(records), sourceBaseName(dbPath))
+	s.dispatchUpdateEvent(updateout.Event{
+		Type:      "initial",
+		Timestamp: fmt.Sprintf("%v", message["timestamp"]),
+		Source:    dbPath,
+		Raw:       result.Raw,
+		Records:   records,
+		KeyField:  result.KeyField,
+	})
 	go s.broadcastProcessInfo()
 }
 

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -36,7 +36,9 @@ const state = {
     faviconTimeout: null,
     tabId: '',
     broadcastChannel: null,
-    seenBroadcastMessages: new Set()
+    seenBroadcastMessages: new Set(),
+    dragDepth: 0,
+    isUploadingSource: false
 };
 
 const CONFIG_STORAGE_KEY = 'patris-config';
@@ -906,6 +908,142 @@ function showInAppToast(title, message, options = {}) {
     }
 }
 
+function isSupportedSourceFile(file) {
+    return !!file && /\.(db|json)$/i.test(file.name || '');
+}
+
+function supportedSourceFromTransfer(dataTransfer) {
+    const files = Array.from(dataTransfer?.files || []);
+    return files.find(isSupportedSourceFile) || files[0] || null;
+}
+
+function setDropOverlayVisible(visible, mode = 'ready') {
+    const overlay = document.getElementById('dropOverlay');
+    if (!overlay) {
+        return;
+    }
+    overlay.classList.toggle('visible', visible);
+    overlay.classList.toggle('uploading', mode === 'uploading');
+    overlay.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    const title = overlay.querySelector('[data-drop-title]');
+    const message = overlay.querySelector('[data-drop-message]');
+    if (title && message) {
+        if (mode === 'uploading') {
+            title.textContent = 'Loading source...';
+            message.textContent = 'Uploading the file and switching connected viewers.';
+        } else if (mode === 'invalid') {
+            title.textContent = 'Unsupported file';
+            message.textContent = 'Drop a .db or .json file to switch the active source.';
+        } else {
+            title.textContent = 'Drop database file';
+            message.textContent = 'Release a .db or .json file to load it in this viewer.';
+        }
+    }
+}
+
+async function uploadDroppedSource(file) {
+    if (!file) {
+        return;
+    }
+    if (!isSupportedSourceFile(file)) {
+        setDropOverlayVisible(true, 'invalid');
+        showInAppToast('Unsupported file', 'Drop a .db or .json file to switch the active source.', { error: true });
+        setTimeout(() => setDropOverlayVisible(false), 1500);
+        return;
+    }
+    if (state.isUploadingSource) {
+        return;
+    }
+
+    state.isUploadingSource = true;
+    setDropOverlayVisible(true, 'uploading');
+    setLoadingState(true);
+
+    try {
+        const form = new FormData();
+        form.append('source_id', 'viewer-drop');
+        form.append('file_name', file.name);
+        form.append('size', String(file.size));
+        form.append('mod_time', new Date(file.lastModified || Date.now()).toISOString());
+        form.append('file', file, file.name);
+
+        const response = await fetch('/api/edge/upload', {
+            method: 'POST',
+            body: form
+        });
+        const text = await response.text();
+        let payload = {};
+        try {
+            payload = text ? JSON.parse(text) : {};
+        } catch (error) {
+            payload = { message: text };
+        }
+        if (!response.ok || payload.success === false) {
+            throw new Error(payload.message || `Upload failed with HTTP ${response.status}`);
+        }
+
+        state.fileName = payload.path || payload.file || file.name;
+        updateFooterFileName();
+        showInAppToast('Source loaded', `${payload.file || file.name} is now active (${payload.records ?? 'unknown'} records).`, { broadcastToTabs: true });
+
+        if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+            await fetchInitialData();
+            await fetchFileInfo();
+        }
+    } catch (error) {
+        console.error('Failed to switch dropped source:', error);
+        showInAppToast('Source switch failed', error.message, { error: true });
+        setLoadingState(false);
+    } finally {
+        state.isUploadingSource = false;
+        state.dragDepth = 0;
+        setDropOverlayVisible(false);
+    }
+}
+
+function initSourceDragDrop() {
+    const hasFiles = event => Array.from(event.dataTransfer?.types || []).includes('Files');
+
+    window.addEventListener('dragenter', event => {
+        if (!hasFiles(event)) {
+            return;
+        }
+        event.preventDefault();
+        state.dragDepth += 1;
+        const file = supportedSourceFromTransfer(event.dataTransfer);
+        setDropOverlayVisible(true, file && !isSupportedSourceFile(file) ? 'invalid' : 'ready');
+    });
+
+    window.addEventListener('dragover', event => {
+        if (!hasFiles(event)) {
+            return;
+        }
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'copy';
+        const file = supportedSourceFromTransfer(event.dataTransfer);
+        setDropOverlayVisible(true, file && !isSupportedSourceFile(file) ? 'invalid' : 'ready');
+    });
+
+    window.addEventListener('dragleave', event => {
+        if (!hasFiles(event)) {
+            return;
+        }
+        state.dragDepth = Math.max(0, state.dragDepth - 1);
+        if (state.dragDepth === 0 && !state.isUploadingSource) {
+            setDropOverlayVisible(false);
+        }
+    });
+
+    window.addEventListener('drop', event => {
+        if (!hasFiles(event)) {
+            return;
+        }
+        event.preventDefault();
+        state.dragDepth = 0;
+        uploadDroppedSource(supportedSourceFromTransfer(event.dataTransfer));
+    });
+}
+
 function openPanel(panelId) {
     closePanels();
     document.getElementById(panelId).classList.add('open');
@@ -1158,6 +1296,14 @@ function handleWebSocketMessage(data) {
         }
         // Initial load - records are already transformed with ANBAR as array
         state.records = data.added || [];
+        state.filteredRecords = [];
+        state.fields = [];
+        state.fieldTypes = {};
+        state.fieldStats = {};
+        if (data.source_changed) {
+            state.columnFilters = {};
+            localStorage.removeItem('patris-column-filters');
+        }
         
         // Store file name if provided
         if (data.file_path || data.file_name) {
@@ -2348,6 +2494,7 @@ function initTheme() {
 function init() {
     setLoadingState(true);
     initFrontendBroadcast();
+    initSourceDragDrop();
 
     // Load settings
     loadSettings();
@@ -2582,12 +2729,18 @@ async function fetchInitialData() {
         
         const data = await response.json();
         
-        // data is now in transformed format: { "101": {...}, "102": {...}, ... }
-        // Convert to array, adding Code field from the key
-        state.records = Object.entries(data).map(([code, record]) => ({
-            Code: code,
-            ...record
-        }));
+        // data is usually transformed as { "101": {...}, "102": {...}, ... }.
+        // Some API modes can return an array, so handle both shapes.
+        state.records = Array.isArray(data)
+            ? data
+            : Object.entries(data).map(([code, record]) => ({
+                Code: code,
+                ...record
+            }));
+        state.filteredRecords = [];
+        state.fields = [];
+        state.fieldTypes = {};
+        state.fieldStats = {};
         
         if (state.records.length > 0) {
             extractFields();

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -566,6 +566,81 @@ body.is-loading .data-table {
     to { transform: rotate(360deg); }
 }
 
+.drop-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1400;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(15, 23, 42, 0.56);
+    backdrop-filter: blur(7px);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.16s ease, visibility 0.16s ease;
+
+    &.visible {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+.drop-card {
+    width: min(380px, calc(100vw - 2rem));
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.85rem;
+    padding: 1.5rem;
+    text-align: center;
+    color: #f9fafb;
+    background: rgba(17, 24, 39, 0.9);
+    border: 2px dashed rgba(250, 204, 21, 0.72);
+    border-radius: 8px;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+
+    strong {
+        font-size: 1.15rem;
+        line-height: 1.2;
+    }
+
+    span {
+        max-width: 28ch;
+        color: rgba(249, 250, 251, 0.78);
+    }
+}
+
+.drop-icon {
+    width: 82px;
+    height: 82px;
+    display: grid;
+    place-items: center;
+    border-radius: 8px;
+    background: rgba(250, 204, 21, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.22);
+}
+
+.drop-logo {
+    width: 64px;
+    height: 64px;
+    object-fit: contain;
+    filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.28));
+}
+
+.drop-overlay.uploading {
+    .drop-card {
+        border-style: solid;
+    }
+
+    .drop-icon {
+        animation: pulse 1.1s ease-in-out infinite;
+    }
+}
+
 // Empty state
 .empty-state {
     display: flex;

--- a/web/src/viewer.html
+++ b/web/src/viewer.html
@@ -90,6 +90,14 @@
             </div>
         </div>
 
+        <div class="drop-overlay" id="dropOverlay" aria-hidden="true">
+            <div class="drop-card">
+                <div class="drop-icon"><img class="drop-logo" src="/static/patris-api-icon.png" alt=""></div>
+                <strong data-drop-title>Drop database file</strong>
+                <span data-drop-message>Release a .db or .json file to load it in this viewer.</span>
+            </div>
+        </div>
+
         <div class="panel-backdrop" id="panelBackdrop"></div>
 
         <div class="settings-panel settings-modal" id="settingsPanel" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">


### PR DESCRIPTION
## Summary
- Adds viewer-wide drag-and-drop handling for `.db` and `.json` files.
- Uploads dropped sources through the existing edge upload API and switches the active datasource after validation.
- Broadcasts source switches as a fresh WebSocket initial snapshot so connected tabs reset rows, columns, filters, footer source metadata, and counts cleanly.
- Adds a themed drop overlay using the Patris logo and clear invalid/uploading states.

Closes #73

## Verification
- `npm.cmd --prefix web run build`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 'C:\Program Files\Go\bin\go.exe' test .\pkg\server`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 'C:\Program Files\Go\bin\go.exe' test .\...`
- Rebuilt the local Windows executable and restarted the live service on `http://127.0.0.1:18080/viewer`.
- Smoke-tested `POST /api/edge/upload` with `testdata/kala-before.db`; the active source switched to the temp upload with 548 records, then the service was restored to `C:\Patris\data4\kala.db` with 994 records.

Screenshot captured locally at `C:\Users\Mahdi\Desktop\AtomicDeploy\git-home\patris-export\build\drag-drop-viewer.png`.