### PR TITLE
Swap config and charmap short flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ patris-export serve kala.db -a :8080 --debounce 1s
 
 ## 🎯 Using Character Mapping
 
-Patris Export embeds the default Patris81 legacy encoding map, so Persian/Farsi text conversion works without passing an external file. Use `-c/--charmap` only when you want to override the built-in map for custom conversion or debugging.
+Patris Export embeds the default Patris81 legacy encoding map, so Persian/Farsi text conversion works without passing an external file. Use `-m/--charmap` only when you want to override the built-in map for custom conversion or debugging.
 
 ```bash
 # Uses the embedded Patris81 character map
@@ -388,7 +388,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO
 
 ### Global Flags
 
-- `-c, --charmap` - Optional path to a custom character mapping file. If omitted, the embedded Patris81 mapping is used.
+- `-c, --config` - Path to a patris-export config file. Repeat to layer JSON/YAML/TOML files.
+- `-m, --charmap` - Optional path to a custom character mapping file. If omitted, the embedded Patris81 mapping is used.
 - `-o, --output` - Output directory for converted files, or `-` for stdout (default: current directory)
 - `--temp-dir` - Explicit temp directory for copied/downloaded database files. Overrides automatic temp storage selection.
 - `--temp-strategy` - Temp storage strategy: `auto`, `system`, or `memory`.

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -112,9 +112,9 @@ Supports Persian/Farsi encoding conversion and file watching.
 	rootCmd.SetVersionTemplate(version.Detailed() + "\n")
 
 	// Global flags
-	rootCmd.PersistentFlags().StringArrayVar(&configFiles, "config", nil, "Path to patris-export config file; repeat to layer JSON/YAML/TOML files")
+	rootCmd.PersistentFlags().StringArrayVarP(&configFiles, "config", "c", nil, "Path to patris-export config file; repeat to layer JSON/YAML/TOML files")
 	rootCmd.PersistentFlags().StringVar(&dbFileFlag, "db", "", "Open a database file in one-shot native viewer mode when no subcommand is used")
-	rootCmd.PersistentFlags().StringVarP(&charMapFile, "charmap", "c", "", "Optional custom character mapping file; embedded Patris81 mapping is used by default")
+	rootCmd.PersistentFlags().StringVarP(&charMapFile, "charmap", "m", "", "Optional custom character mapping file; embedded Patris81 mapping is used by default")
 	rootCmd.PersistentFlags().StringVarP(&outputDir, "output", "o", ".", "Output directory for converted files (use '-' for stdout)")
 	rootCmd.PersistentFlags().StringVar(&tempDir, "temp-dir", "", "Temp directory for copied/downloaded database files (default: system temp)")
 	rootCmd.PersistentFlags().StringVar(&tempStrategy, "temp-strategy", "", "Temp storage strategy: auto, system, or memory (auto prefers /dev/shm on Linux for small files)")

--- a/pkg/converter/embedded_charmap.go
+++ b/pkg/converter/embedded_charmap.go
@@ -7,7 +7,7 @@ import (
 )
 
 // embeddedCharMapText is the built-in Patris81 -> modern text conversion map.
-// It is the default mapping used by the app when the user does not pass -c/--charmap.
+// It is the default mapping used by the app when the user does not pass -m/--charmap.
 //
 //go:embed farsi_chars.txt
 var embeddedCharMapText string


### PR DESCRIPTION
## Summary
- change `--config` to use `-c` as its shorthand
- change `--charmap` to use `-m` as its shorthand
- update README and embedded charmap comments so user-facing docs no longer describe `-c` as charmap

## Verification
- `git diff --check`
- `scripts/windows/Build-LocalWindows.ps1 -SkipPxlibBuild`
- built help shows `-c, --config stringArray` and `-m, --charmap string`

Note: plain `go test ./...` from this shell is blocked because the inherited PATH lacks CGO/GCC and the repo stubs pxlib/sqlite without CGO. The Windows build script resolved Go/GCC and completed the native build/smoke read successfully.

Closes #110