### PR TITLE
Persist sparse config and prune inactive settings tabs

### DIFF
--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -369,7 +370,7 @@ func (m *Manager) Update(fn func(*Config)) error {
 	if err := os.MkdirAll(filepath.Dir(m.path), 0755); err != nil {
 		return err
 	}
-	return os.WriteFile(m.path, append(data, '\n'), 0644)
+	return os.WriteFile(m.path, data, 0644)
 }
 
 func (m *Manager) Save() error {
@@ -430,22 +431,97 @@ func decodeConfig(path string, data []byte, cfg *Config) error {
 }
 
 func encodeConfig(path string, cfg Config) ([]byte, error) {
+	payload, err := sparseConfigMap(cfg)
+	if err != nil {
+		return nil, err
+	}
 	var (
 		data []byte
-		err  error
 	)
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".yaml", ".yml":
-		data, err = yaml.Marshal(cfg)
+		data, err = yaml.Marshal(payload)
 	case ".toml":
-		data, err = toml.Marshal(cfg)
+		data, err = toml.Marshal(payload)
 	default:
-		data, err = json.MarshalIndent(cfg, "", "  ")
+		data, err = json.MarshalIndent(payload, "", "  ")
 	}
 	if err != nil {
 		return nil, err
 	}
 	return append(data, '\n'), nil
+}
+
+func sparseConfigMap(cfg Config) (map[string]interface{}, error) {
+	normalize(&cfg)
+	defaults := Default()
+	normalize(&defaults)
+
+	current, err := configToMap(cfg)
+	if err != nil {
+		return nil, err
+	}
+	defaultMap, err := configToMap(defaults)
+	if err != nil {
+		return nil, err
+	}
+	return diffMap(defaultMap, current), nil
+}
+
+func configToMap(cfg Config) (map[string]interface{}, error) {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func diffMap(defaults, current map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for key, value := range current {
+		defaultValue, ok := defaults[key]
+		if ok {
+			if childCurrent, ok := value.(map[string]interface{}); ok {
+				if childDefault, ok := defaultValue.(map[string]interface{}); ok {
+					childDiff := diffMap(childDefault, childCurrent)
+					if len(childDiff) > 0 {
+						out[key] = childDiff
+					}
+					continue
+				}
+			}
+			if valuesEqual(defaultValue, value) {
+				continue
+			}
+		}
+		if !isEmptyConfigValue(value) {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func valuesEqual(a, b interface{}) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+func isEmptyConfigValue(value interface{}) bool {
+	switch v := value.(type) {
+	case nil:
+		return true
+	case string:
+		return v == ""
+	case []interface{}:
+		return len(v) == 0
+	case map[string]interface{}:
+		return len(v) == 0
+	default:
+		return false
+	}
 }
 
 func (m *Manager) Watch(onChange func(Config)) (*fsnotify.Watcher, error) {

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -69,8 +69,42 @@ func TestManagerSavesNativeFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	if !containsAll(text, "[server]", "port = 18181", "[runtime]") {
+	if !containsAll(text, "[server]", "port = 18181") {
 		t.Fatalf("saved TOML did not contain expected sections:\n%s", text)
+	}
+	if contains(text, "temp_dir") || contains(text, "[runtime]") {
+		t.Fatalf("saved TOML should omit unchanged default runtime values:\n%s", text)
+	}
+}
+
+func TestManagerSavesOnlyChangedValues(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "patris-export.json")
+	mgr, err := LoadFiles([]string{jsonPath})
+	if err != nil {
+		t.Fatalf("LoadFiles failed: %v", err)
+	}
+	if err := mgr.Update(func(cfg *Config) {
+		cfg.UI.Theme = "dark"
+		cfg.UI.PageSize = 100
+		cfg.Notifications.Native = true
+		cfg.Notifications.MaxRows = 3
+		cfg.Database.Path = "C:/Patris/data4/kala.db"
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !containsAll(text, `"ui"`, `"theme": "dark"`, `"database"`, `"path": "C:/Patris/data4/kala.db"`) {
+		t.Fatalf("saved JSON did not contain changed values:\n%s", text)
+	}
+	for _, needle := range []string{`"page_size"`, `"notification_sound_source"`, `"notifications"`, `"column_labels"`, `"schema_version"`} {
+		if contains(text, needle) {
+			t.Fatalf("saved JSON should omit default key %s:\n%s", needle, text)
+		}
 	}
 }
 

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -62,6 +62,7 @@ const state = {
     tabId: '',
     broadcastChannel: null,
     seenBroadcastMessages: new Set(),
+    revealedSettingsTabs: new Set(),
     dragDepth: 0,
     isUploadingSource: false
 };
@@ -1392,6 +1393,7 @@ function closeRouteDialog() {
 
 function applyConfigToSettingsForm() {
     const cfg = state.config || {};
+    updateSettingsTabVisibility();
     setValue('settingsTheme', cfg.ui?.theme || localStorage.getItem('theme') || 'system');
     setValue('serverHost', cfg.server?.host || '');
     setValue('serverPort', cfg.server?.port || '');
@@ -1950,10 +1952,18 @@ function initSettingsTabs() {
             setActiveSettingsTab(tab.dataset.settingsTab);
         });
     });
+    updateSettingsTabVisibility();
 }
 
 function setActiveSettingsTab(target) {
-    const tab = document.querySelector(`[data-settings-tab="${target}"]`) || document.querySelector('[data-settings-tab="ui"]');
+    if (!target) target = 'ui';
+    const requestedTab = document.querySelector(`[data-settings-tab="${target}"]`);
+    if (requestedTab?.hidden) {
+        state.revealedSettingsTabs.add(target);
+        updateSettingsTabVisibility({ preserveActive: true });
+    }
+    const tab = document.querySelector(`[data-settings-tab="${target}"]:not([hidden])`)
+        || document.querySelector('[data-settings-tab="ui"]');
     const paneName = tab?.dataset.settingsTab || 'ui';
     document.querySelectorAll('[data-settings-tab]').forEach(item => {
         item.classList.toggle('active', item === tab);
@@ -1961,6 +1971,58 @@ function setActiveSettingsTab(target) {
     document.querySelectorAll('[data-settings-pane]').forEach(pane => {
         pane.classList.toggle('active', pane.dataset.settingsPane === paneName);
     });
+}
+
+function updateSettingsTabVisibility(options = {}) {
+    const cfg = state.config || {};
+    const visibleTabs = new Set(['ui']);
+    const isCustomized = (section, key, defaultValue) => {
+        const value = cfg[section]?.[key];
+        return typeof value !== 'undefined' && value !== defaultValue;
+    };
+
+    if (state.fileName || cfg.database?.path || cfg.database?.charmap || cfg.database?.direct_access || cfg.database?.rtl_conversion || cfg.database?.raw) {
+        visibleTabs.add('database');
+    }
+    if (
+        cfg.notifications?.enabled ||
+        cfg.notifications?.client_connected ||
+        cfg.notifications?.client_disconnected ||
+        cfg.notifications?.file_updated ||
+        cfg.notifications?.row_updated ||
+        cfg.notifications?.include_row_values ||
+        state.settings.playNotificationSound
+    ) {
+        visibleTabs.add('notifications');
+    }
+    if (
+        cfg.runtime?.debug ||
+        isCustomized('runtime', 'temp_dir', 'system') ||
+        isCustomized('runtime', 'temp_strategy', 'auto') ||
+        isCustomized('runtime', 'temp_memory_limit_mb', 100)
+    ) {
+        visibleTabs.add('runtime');
+    }
+    if (cfg.server?.ipc?.enabled || cfg.server?.http === false || state.revealedSettingsTabs.has('server')) {
+        visibleTabs.add('server');
+    }
+    state.revealedSettingsTabs.forEach(tabName => visibleTabs.add(tabName));
+
+    document.querySelectorAll('[data-settings-tab]').forEach(tab => {
+        const show = visibleTabs.has(tab.dataset.settingsTab);
+        tab.hidden = !show;
+        tab.setAttribute('aria-hidden', show ? 'false' : 'true');
+    });
+    document.querySelectorAll('[data-settings-pane]').forEach(pane => {
+        const show = visibleTabs.has(pane.dataset.settingsPane);
+        pane.hidden = !show;
+        pane.setAttribute('aria-hidden', show ? 'false' : 'true');
+    });
+
+    const activeTab = document.querySelector('[data-settings-tab].active');
+    if (!options.preserveActive && activeTab?.hidden) {
+        setActiveSettingsTab('ui');
+    }
 }
 
 function bindConfigField(id, eventName = 'change') {
@@ -4001,7 +4063,12 @@ function init() {
 
     const settingsTarget = new URLSearchParams(window.location.search).get('settings');
     if (settingsTarget) {
-        setActiveSettingsTab(settingsTarget === '1' ? 'ui' : settingsTarget);
+        const targetTab = settingsTarget === '1' ? 'ui' : settingsTarget;
+        if (targetTab) {
+            state.revealedSettingsTabs.add(targetTab);
+        }
+        updateSettingsTabVisibility({ preserveActive: true });
+        setActiveSettingsTab(targetTab);
         applyConfigToSettingsForm();
         openModalRoute('settings', { replace: true });
     }
@@ -4017,9 +4084,11 @@ async function fetchFileInfo() {
         const info = await response.json();
         state.fileName = info.path || info.file || '';
         updateFooterFileName();
+        updateSettingsTabVisibility();
     } catch (error) {
         console.error('Failed to fetch file info:', error);
         updateFooterFileName();
+        updateSettingsTabVisibility();
     }
 }
 


### PR DESCRIPTION
## Summary
- Persist config files as a sparse diff from normalized defaults instead of dumping every effective setting.
- Keep `/api/config` returning the full effective config shape for the Web UI while `PUT /api/config` writes only changed values.
- Hide inactive settings tabs in the Web UI, with direct `?settings=<tab>` links still revealing hidden tabs for advanced/debug access.

Closes #118

## Verification
- `go test ./pkg/appconfig`
- `node --check web/src/app.js`
- `npm.cmd --prefix web run build`
- `git diff --check`