### PR TITLE
Polish table filters and footer controls

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -742,6 +742,37 @@ const JalaliUtils = {
         // Return as object for comparison
         return { year, month, day };
     },
+
+    format(date) {
+        if (!date) return '';
+        return [
+            String(date.year).padStart(2, '0'),
+            String(date.month).padStart(2, '0'),
+            String(date.day).padStart(2, '0')
+        ].join('.');
+    },
+
+    daysInMonth(year, month) {
+        if (month >= 1 && month <= 6) return 31;
+        if (month >= 7 && month <= 11) return 30;
+        return 29;
+    },
+
+    addMonths(date, delta) {
+        if (!date) return { year: 0, month: 1, day: 1 };
+        let year = date.year;
+        let month = date.month + delta;
+        while (month < 1) {
+            month += 12;
+            year -= 1;
+        }
+        while (month > 12) {
+            month -= 12;
+            year += 1;
+        }
+        const day = Math.min(date.day, JalaliUtils.daysInMonth(year, month));
+        return { year, month, day };
+    },
     
     // Compare two Jalali dates (-1 if a < b, 0 if equal, 1 if a > b)
     compare(a, b) {
@@ -754,6 +785,13 @@ const JalaliUtils = {
     // Check if string looks like a Jalali date
     isJalaliDate(str) {
         return JalaliUtils.parse(str) !== null;
+    },
+
+    clamp(date, min, max) {
+        if (!date) return date;
+        if (min && JalaliUtils.compare(date, min) < 0) return min;
+        if (max && JalaliUtils.compare(date, max) > 0) return max;
+        return date;
     }
 };
 
@@ -957,16 +995,24 @@ function applyFooterVisibility() {
     document.body.classList.toggle('footer-hidden', !showFooter);
     const footer = document.getElementById('appFooter');
     if (footer) footer.hidden = !showFooter;
-    const footerToggleBtn = document.getElementById('footerToggleBtn');
-    if (footerToggleBtn) {
-        footerToggleBtn.title = showFooter ? 'Hide footer' : 'Show footer';
-    }
+    renderFooterToggleButton(document.getElementById('footerToggleBtn'), showFooter);
+    renderFooterToggleButton(document.getElementById('footerCollapseBtn'), showFooter);
 }
 
 function toggleFooterVisibility() {
-    state.settings.showFooter = state.settings.showFooter === false;
+    state.settings.showFooter = !(state.settings.showFooter !== false);
     applySettings();
     saveSettings();
+}
+
+function renderFooterToggleButton(button, showFooter) {
+    if (!button) return;
+    button.title = showFooter ? 'Hide footer' : 'Show footer';
+    button.setAttribute('aria-pressed', String(showFooter));
+    button.setAttribute('aria-label', showFooter ? 'Hide footer' : 'Show footer');
+    button.innerHTML = showFooter
+        ? '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+        : '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6 15l6-6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
 }
 
 function formatRelativeTime(date) {
@@ -1165,7 +1211,7 @@ function initDialogActionButtons() {
         const closeButton = document.getElementById(closeId);
         if (!closeButton || closeButton.dataset.normalizedDialogActions) return;
         closeButton.classList.add('dialog-close-btn');
-        closeButton.innerHTML = '&times;';
+        closeButton.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg>';
         const menuButton = document.createElement('button');
         menuButton.type = 'button';
         menuButton.className = 'btn btn-icon dialog-menu-btn';
@@ -2648,7 +2694,16 @@ function renderTableHeader() {
     // Add clear all filters button
     const clearBtn = document.createElement('button');
     clearBtn.className = 'btn-clear-filters';
-    clearBtn.textContent = '✕ Clear';
+    clearBtn.innerHTML = `
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M5 7h14" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+            <path d="M9 7V5h6v2" />
+            <path d="M7 7l1 13h8l1-13" />
+        </svg>
+        <span>Clear</span>
+    `;
     clearBtn.title = 'Clear all filters';
     clearBtn.addEventListener('click', clearAllFilters);
     actionsFilter.appendChild(clearBtn);
@@ -2750,60 +2805,7 @@ function createFilterControl(field) {
         container.appendChild(createRangePopover2(field, currentFilter, 'numeric'));
         
     } else if (fieldType === 'jalali-date') {
-        // Date range for Jalali dates (YY.mm.dd format)
-        const wrapper = document.createElement('div');
-        wrapper.className = 'filter-range';
-        
-        const minInput = document.createElement('input');
-        minInput.type = 'text';
-        minInput.className = 'filter-input-small';
-        minInput.placeholder = 'From';
-        minInput.value = currentFilter?.min ?? '';
-        minInput.title = 'Format: YY.mm.dd';
-        minInput.setAttribute('aria-label', `Minimum ${displayFieldName(field)} date`);
-        
-        const maxInput = document.createElement('input');
-        maxInput.type = 'text';
-        maxInput.className = 'filter-input-small';
-        maxInput.placeholder = 'To';
-        maxInput.value = currentFilter?.max ?? '';
-        maxInput.title = 'Format: YY.mm.dd';
-        maxInput.setAttribute('aria-label', `Maximum ${displayFieldName(field)} date`);
-        
-        const updateFilter = () => {
-            const min = minInput.value.trim();
-            const max = maxInput.value.trim();
-            const validMin = min ? JalaliUtils.parse(min) : null;
-            const validMax = max ? JalaliUtils.parse(max) : null;
-            minInput.setCustomValidity(min && !validMin ? 'Use YY.mm.dd' : '');
-            maxInput.setCustomValidity(max && !validMax ? 'Use YY.mm.dd' : '');
-            if ((min && !validMin) || (max && !validMax)) {
-                return;
-            }
-            let nextMin = min;
-            let nextMax = max;
-            if (validMin && validMax && JalaliUtils.compare(validMin, validMax) > 0) {
-                nextMin = max;
-                nextMax = min;
-                minInput.value = nextMin;
-                maxInput.value = nextMax;
-            }
-            
-            if (nextMin || nextMax) {
-                state.columnFilters[field] = { type: 'jalali-date', min: nextMin, max: nextMax };
-            } else {
-                delete state.columnFilters[field];
-            }
-            saveColumnFilters();
-            applyFilters();
-        };
-        
-        minInput.addEventListener('change', updateFilter);
-        maxInput.addEventListener('change', updateFilter);
-        
-        wrapper.appendChild(minInput);
-        wrapper.appendChild(maxInput);
-        container.appendChild(wrapper);
+        container.appendChild(createJalaliDateFilterControl(field, currentFilter));
         
     } else {
         // Text search for text fields
@@ -2834,21 +2836,39 @@ function createFilterControl(field) {
 
 function createRangePopover2(field, currentFilter, mode) {
     const wrapper = document.createElement('div');
-    wrapper.className = 'range-popover';
+    wrapper.className = 'range-popover range-combo';
+
+    const stats = state.fieldStats[field] || {};
+    const minLimit = Number.isFinite(stats.min) ? stats.min : 0;
+    const maxLimit = Number.isFinite(stats.max) ? stats.max : Math.max(minLimit + 1, 1);
+    const hasUsableRange = Number.isFinite(stats.min) && Number.isFinite(stats.max) && stats.min !== stats.max;
+    const step = Number.isInteger(minLimit) && Number.isInteger(maxLimit) ? 1 : 0.01;
+
+    const exactInput = document.createElement('input');
+    exactInput.type = 'text';
+    exactInput.inputMode = 'decimal';
+    exactInput.className = 'filter-input range-direct-input';
+    exactInput.placeholder = hasUsableRange ? `${formatRangeValue(minLimit)}-${formatRangeValue(maxLimit)}` : formatRangeValue(minLimit);
+    exactInput.title = hasUsableRange
+        ? `Type an exact value, a range like ${formatRangeValue(minLimit)}-${formatRangeValue(maxLimit)}, >=value, or <=value`
+        : `All sampled values are ${formatRangeValue(minLimit)}`;
+    exactInput.setAttribute('aria-label', `${displayFieldName(field)} exact or range filter`);
 
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'range-trigger';
-    button.setAttribute('aria-label', `Set ${displayFieldName(field)} range filter`);
+    button.className = 'range-trigger range-trigger-ellipsis';
+    button.innerHTML = '<span aria-hidden="true">&hellip;</span>';
+    button.setAttribute('aria-label', `Open ${displayFieldName(field)} range options`);
 
     const panel = document.createElement('div');
     panel.className = 'range-panel';
     panel.addEventListener('click', event => event.stopPropagation());
 
-    const stats = state.fieldStats[field] || {};
-    const minLimit = Number.isFinite(stats.min) ? stats.min : 0;
-    const maxLimit = Number.isFinite(stats.max) ? stats.max : Math.max(minLimit + 1, 1);
-    const step = Number.isInteger(minLimit) && Number.isInteger(maxLimit) ? 1 : 0.01;
+    const meta = document.createElement('div');
+    meta.className = 'range-meta';
+    meta.innerHTML = hasUsableRange
+        ? `<span>Min <strong>${escapeHtml(formatRangeValue(minLimit))}</strong></span><span>Max <strong>${escapeHtml(formatRangeValue(maxLimit))}</strong></span>`
+        : `<span class="range-meta-note">All sampled values are <strong>${escapeHtml(formatRangeValue(minLimit))}</strong></span>`;
 
     const minInput = document.createElement('input');
     minInput.type = 'text';
@@ -2881,16 +2901,27 @@ function createRangePopover2(field, currentFilter, mode) {
     maxSlider.max = String(maxLimit);
     maxSlider.step = String(step);
     maxSlider.value = String(currentFilter?.max ?? maxLimit);
+    minSlider.disabled = !hasUsableRange;
+    maxSlider.disabled = !hasUsableRange;
 
     const clearBtn = document.createElement('button');
     clearBtn.type = 'button';
     clearBtn.className = 'range-clear';
     clearBtn.textContent = 'Clear';
 
-    const updateTrigger = () => {
+    const updateDirectInput = () => {
         const latest = state.columnFilters[field];
         const active = latest?.min !== undefined && latest?.min !== null || latest?.max !== undefined && latest?.max !== null;
-        button.innerHTML = active ? `<span class="filter-badge">${latest.min ?? 'min'}-${latest.max ?? 'max'}</span>` : '<span class="ellipsis">&bull;&bull;&bull;</span>';
+        if (!active) {
+            exactInput.value = '';
+        } else if (latest.min !== null && latest.min !== undefined && latest.max !== null && latest.max !== undefined) {
+            exactInput.value = latest.min === latest.max ? formatRangeValue(latest.min) : `${formatRangeValue(latest.min)}-${formatRangeValue(latest.max)}`;
+        } else if (latest.min !== null && latest.min !== undefined) {
+            exactInput.value = `>=${formatRangeValue(latest.min)}`;
+        } else {
+            exactInput.value = `<=${formatRangeValue(latest.max)}`;
+        }
+        wrapper.classList.toggle('has-filter', !!active);
     };
 
     const commit = debounce(() => {
@@ -2912,15 +2943,38 @@ function createRangePopover2(field, currentFilter, mode) {
             delete state.columnFilters[field];
         }
         saveColumnFilters();
-        updateTrigger();
+        updateDirectInput();
         applyFilters();
     }, 80);
 
-    const syncFromInput = () => {
+    const commitDirect = debounce(() => {
+        const parsed = parseNumericFilterText(exactInput.value);
+        exactInput.setCustomValidity(parsed.error || '');
+        if (parsed.error) return;
+        if (parsed.empty) {
+            minInput.value = '';
+            maxInput.value = '';
+            delete state.columnFilters[field];
+        } else {
+            minInput.value = parsed.min === null || parsed.min === undefined ? '' : String(parsed.min);
+            maxInput.value = parsed.max === null || parsed.max === undefined ? '' : String(parsed.max);
+            state.columnFilters[field] = { type: mode, min: parsed.min, max: parsed.max };
+        }
+        wrapper.classList.toggle('has-filter', !parsed.empty);
+        syncSlidersFromInputs();
+        saveColumnFilters();
+        applyFilters();
+    }, FILTER_INPUT_DEBOUNCE_MS);
+
+    const syncSlidersFromInputs = () => {
         const min = parseFloat(minInput.value);
         const max = parseFloat(maxInput.value);
         if (Number.isFinite(min)) minSlider.value = String(Math.min(Math.max(min, minLimit), maxLimit));
         if (Number.isFinite(max)) maxSlider.value = String(Math.min(Math.max(max, minLimit), maxLimit));
+    };
+
+    const syncFromInput = () => {
+        syncSlidersFromInputs();
         commit();
     };
 
@@ -2945,6 +2999,13 @@ function createRangePopover2(field, currentFilter, mode) {
         }
     });
 
+    exactInput.addEventListener('input', commitDirect);
+    exactInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            exactInput.blur();
+        }
+    });
     minInput.addEventListener('input', syncFromInput);
     maxInput.addEventListener('input', syncFromInput);
     minSlider.addEventListener('input', syncFromSlider);
@@ -2956,18 +3017,218 @@ function createRangePopover2(field, currentFilter, mode) {
         minSlider.value = String(minLimit);
         maxSlider.value = String(maxLimit);
         saveColumnFilters();
-        updateTrigger();
+        updateDirectInput();
         applyFilters();
     });
 
+    panel.appendChild(meta);
     panel.appendChild(wrapRangeField('Min', minInput));
     panel.appendChild(wrapRangeField('Max', maxInput));
     panel.appendChild(minSlider);
     panel.appendChild(maxSlider);
     panel.appendChild(clearBtn);
+    wrapper.appendChild(exactInput);
     wrapper.appendChild(button);
     wrapper.appendChild(panel);
-    updateTrigger();
+    updateDirectInput();
+    return wrapper;
+}
+
+function parseNumericFilterText(text) {
+    const value = String(text || '').trim();
+    if (!value) return { empty: true };
+    const compact = value.replace(/\s+/g, '');
+    let match = compact.match(/^>=(-?\d+(?:\.\d+)?)$/);
+    if (match) return { min: parseFloat(match[1]), max: null };
+    match = compact.match(/^<=(-?\d+(?:\.\d+)?)$/);
+    if (match) return { min: null, max: parseFloat(match[1]) };
+    match = compact.match(/^(-?\d+(?:\.\d+)?)(?:\.\.|-|:)(-?\d+(?:\.\d+)?)$/);
+    if (match) {
+        let min = parseFloat(match[1]);
+        let max = parseFloat(match[2]);
+        if (min > max) [min, max] = [max, min];
+        return { min, max };
+    }
+    match = compact.match(/^-?\d+(?:\.\d+)?$/);
+    if (match) {
+        const exact = parseFloat(compact);
+        return { min: exact, max: exact };
+    }
+    return { error: 'Use a number, min-max, >=min, or <=max' };
+}
+
+function formatRangeValue(value) {
+    if (!Number.isFinite(Number(value))) return '';
+    const n = Number(value);
+    return Number.isInteger(n) ? String(n) : String(Number(n.toFixed(2)));
+}
+
+function createJalaliDateFilterControl(field, currentFilter) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'jalali-filter range-popover';
+    const stats = state.fieldStats[field] || {};
+    const minDate = stats.min || null;
+    const maxDate = stats.max || null;
+
+    const fromInput = document.createElement('input');
+    fromInput.type = 'text';
+    fromInput.inputMode = 'numeric';
+    fromInput.className = 'filter-input jalali-date-input';
+    fromInput.placeholder = minDate ? JalaliUtils.format(minDate) : 'From';
+    fromInput.value = currentFilter?.min ?? '';
+    fromInput.title = 'Jalali date, YY.MM.DD';
+    fromInput.setAttribute('aria-label', `From ${displayFieldName(field)} Jalali date`);
+
+    const toInput = document.createElement('input');
+    toInput.type = 'text';
+    toInput.inputMode = 'numeric';
+    toInput.className = 'filter-input jalali-date-input';
+    toInput.placeholder = maxDate ? JalaliUtils.format(maxDate) : 'To';
+    toInput.value = currentFilter?.max ?? '';
+    toInput.title = 'Jalali date, YY.MM.DD';
+    toInput.setAttribute('aria-label', `To ${displayFieldName(field)} Jalali date`);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'range-trigger range-trigger-ellipsis date-picker-trigger';
+    button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 3v3M17 3v3M4 9h16M6 5h12a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>';
+    button.setAttribute('aria-label', `Open ${displayFieldName(field)} Jalali date picker`);
+
+    const panel = document.createElement('div');
+    panel.className = 'range-panel jalali-picker-panel';
+    panel.addEventListener('click', event => event.stopPropagation());
+
+    const meta = document.createElement('div');
+    meta.className = 'range-meta';
+    meta.innerHTML = minDate && maxDate
+        ? `<span>Min <strong>${escapeHtml(JalaliUtils.format(minDate))}</strong></span><span>Max <strong>${escapeHtml(JalaliUtils.format(maxDate))}</strong></span>`
+        : '<span class="range-meta-note">No valid Jalali dates detected</span>';
+
+    const pickerState = {
+        cursor: JalaliUtils.parse(fromInput.value) || minDate || maxDate || { year: 0, month: 1, day: 1 },
+        target: 'min'
+    };
+
+    const commitDateFilter = debounce(() => {
+        const minText = fromInput.value.trim();
+        const maxText = toInput.value.trim();
+        const parsedMin = minText ? JalaliUtils.parse(minText) : null;
+        const parsedMax = maxText ? JalaliUtils.parse(maxText) : null;
+        fromInput.setCustomValidity(minText && !parsedMin ? 'Use YY.MM.DD' : '');
+        toInput.setCustomValidity(maxText && !parsedMax ? 'Use YY.MM.DD' : '');
+        if ((minText && !parsedMin) || (maxText && !parsedMax)) return;
+
+        let nextMin = minText;
+        let nextMax = maxText;
+        if (parsedMin && parsedMax && JalaliUtils.compare(parsedMin, parsedMax) > 0) {
+            nextMin = maxText;
+            nextMax = minText;
+            fromInput.value = nextMin;
+            toInput.value = nextMax;
+        }
+
+        if (nextMin || nextMax) {
+            state.columnFilters[field] = { type: 'jalali-date', min: nextMin, max: nextMax };
+            wrapper.classList.add('has-filter');
+        } else {
+            delete state.columnFilters[field];
+            wrapper.classList.remove('has-filter');
+        }
+        saveColumnFilters();
+        applyFilters();
+    }, FILTER_INPUT_DEBOUNCE_MS);
+
+    const renderPicker = () => {
+        const title = document.createElement('div');
+        title.className = 'jalali-picker-title';
+        const prev = document.createElement('button');
+        prev.type = 'button';
+        prev.className = 'picker-nav';
+        prev.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 6l-6 6 6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+        const next = document.createElement('button');
+        next.type = 'button';
+        next.className = 'picker-nav';
+        next.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+        const label = document.createElement('strong');
+        label.textContent = `${String(pickerState.cursor.year).padStart(2, '0')}.${String(pickerState.cursor.month).padStart(2, '0')}`;
+        prev.addEventListener('click', () => {
+            pickerState.cursor = JalaliUtils.addMonths(pickerState.cursor, -1);
+            renderPicker();
+        });
+        next.addEventListener('click', () => {
+            pickerState.cursor = JalaliUtils.addMonths(pickerState.cursor, 1);
+            renderPicker();
+        });
+        title.append(prev, label, next);
+
+        const targetSwitch = document.createElement('div');
+        targetSwitch.className = 'jalali-target-switch';
+        ['min', 'max'].forEach(target => {
+            const targetButton = document.createElement('button');
+            targetButton.type = 'button';
+            targetButton.className = pickerState.target === target ? 'active' : '';
+            targetButton.textContent = target === 'min' ? 'From' : 'To';
+            targetButton.addEventListener('click', () => {
+                pickerState.target = target;
+                renderPicker();
+            });
+            targetSwitch.appendChild(targetButton);
+        });
+
+        const grid = document.createElement('div');
+        grid.className = 'jalali-day-grid';
+        const days = JalaliUtils.daysInMonth(pickerState.cursor.year, pickerState.cursor.month);
+        for (let day = 1; day <= days; day += 1) {
+            const date = { year: pickerState.cursor.year, month: pickerState.cursor.month, day };
+            const dayButton = document.createElement('button');
+            dayButton.type = 'button';
+            dayButton.textContent = String(day);
+            dayButton.disabled = (minDate && JalaliUtils.compare(date, minDate) < 0) || (maxDate && JalaliUtils.compare(date, maxDate) > 0);
+            dayButton.addEventListener('click', () => {
+                const formatted = JalaliUtils.format(date);
+                if (pickerState.target === 'min') {
+                    fromInput.value = formatted;
+                    pickerState.target = 'max';
+                } else {
+                    toInput.value = formatted;
+                }
+                commitDateFilter();
+                renderPicker();
+            });
+            grid.appendChild(dayButton);
+        }
+
+        const clearBtn = document.createElement('button');
+        clearBtn.type = 'button';
+        clearBtn.className = 'range-clear';
+        clearBtn.textContent = 'Clear';
+        clearBtn.addEventListener('click', () => {
+            fromInput.value = '';
+            toInput.value = '';
+            delete state.columnFilters[field];
+            wrapper.classList.remove('has-filter');
+            saveColumnFilters();
+            applyFilters();
+        });
+
+        panel.replaceChildren(meta, targetSwitch, title, grid, clearBtn);
+    };
+
+    fromInput.addEventListener('input', commitDateFilter);
+    toInput.addEventListener('input', commitDateFilter);
+    button.addEventListener('click', event => {
+        event.stopPropagation();
+        if (state.openRangePanel && state.openRangePanel !== panel) {
+            state.openRangePanel.classList.remove('open');
+        }
+        pickerState.cursor = JalaliUtils.parse(fromInput.value) || JalaliUtils.parse(toInput.value) || minDate || maxDate || pickerState.cursor;
+        renderPicker();
+        panel.classList.toggle('open');
+        state.openRangePanel = panel.classList.contains('open') ? panel : null;
+    });
+
+    wrapper.classList.toggle('has-filter', !!(currentFilter?.min || currentFilter?.max));
+    wrapper.append(fromInput, toInput, button, panel);
     return wrapper;
 }
 
@@ -2978,90 +3239,6 @@ function wrapRangeField(label, input) {
     span.textContent = label;
     wrapper.appendChild(span);
     wrapper.appendChild(input);
-    return wrapper;
-}
-
-function createRangePopover(field, currentFilter, mode) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'range-popover';
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'range-trigger';
-    button.setAttribute('aria-label', `Set ${displayFieldName(field)} range filter`);
-    const active = currentFilter?.min !== undefined && currentFilter?.min !== null || currentFilter?.max !== undefined && currentFilter?.max !== null;
-    button.innerHTML = active ? `<span class="filter-badge">${currentFilter.min ?? 'min'}–${currentFilter.max ?? 'max'}</span>` : '<span class="ellipsis">•••</span>';
-    const panel = document.createElement('div');
-    panel.className = 'range-panel';
-
-    const minInput = document.createElement('input');
-    minInput.type = mode === 'numeric' ? 'text' : 'text';
-    minInput.inputMode = mode === 'numeric' ? 'decimal' : 'text';
-    minInput.className = 'filter-input-small';
-    minInput.placeholder = mode === 'numeric' ? 'Min' : 'From';
-    minInput.value = currentFilter?.min ?? '';
-    minInput.setAttribute('aria-label', `Minimum ${displayFieldName(field)}`);
-
-    const maxInput = document.createElement('input');
-    maxInput.type = mode === 'numeric' ? 'text' : 'text';
-    maxInput.inputMode = mode === 'numeric' ? 'decimal' : 'text';
-    maxInput.className = 'filter-input-small';
-    maxInput.placeholder = mode === 'numeric' ? 'Max' : 'To';
-    maxInput.value = currentFilter?.max ?? '';
-    maxInput.setAttribute('aria-label', `Maximum ${displayFieldName(field)}`);
-
-    const applyBtn = document.createElement('button');
-    applyBtn.type = 'button';
-    applyBtn.className = 'range-apply';
-    applyBtn.textContent = 'Apply';
-
-    const clearBtn = document.createElement('button');
-    clearBtn.type = 'button';
-    clearBtn.className = 'range-clear';
-    clearBtn.textContent = 'Clear';
-
-    const apply = () => {
-        const rawMin = minInput.value.trim();
-        const rawMax = maxInput.value.trim();
-        let min = mode === 'numeric' && rawMin ? parseFloat(rawMin) : rawMin || null;
-        let max = mode === 'numeric' && rawMax ? parseFloat(rawMax) : rawMax || null;
-        if (mode === 'numeric') {
-            minInput.setCustomValidity(rawMin && !Number.isFinite(min) ? 'Enter a number' : '');
-            maxInput.setCustomValidity(rawMax && !Number.isFinite(max) ? 'Enter a number' : '');
-            if ((rawMin && !Number.isFinite(min)) || (rawMax && !Number.isFinite(max))) {
-                return;
-            }
-            if (min !== null && max !== null && min > max) {
-                [min, max] = [max, min];
-                minInput.value = min;
-                maxInput.value = max;
-            }
-        }
-        if (min !== null || max !== null) {
-            state.columnFilters[field] = { type: mode, min, max };
-        } else {
-            delete state.columnFilters[field];
-        }
-        saveColumnFilters();
-        renderTableHeader();
-        applyFilters();
-    };
-    button.addEventListener('click', (event) => {
-        event.stopPropagation();
-        panel.classList.toggle('open');
-    });
-    applyBtn.addEventListener('click', apply);
-    clearBtn.addEventListener('click', () => {
-        delete state.columnFilters[field];
-        saveColumnFilters();
-        renderTableHeader();
-        applyFilters();
-    });
-    panel.appendChild(minInput);
-    panel.appendChild(maxInput);
-    panel.appendChild(applyBtn);
-    panel.appendChild(clearBtn);
-    wrapper.appendChild(button);
-    wrapper.appendChild(panel);
     return wrapper;
 }
 
@@ -3232,6 +3409,8 @@ function renderTable(changedIndices = new Set()) {
         // Add actions cell
         const actionsCell = document.createElement('td');
         actionsCell.className = 'action-cell';
+        const actionsWrap = document.createElement('div');
+        actionsWrap.className = 'action-cell-content';
         
         const inspectBtn = document.createElement('button');
         inspectBtn.className = 'action-btn';
@@ -3242,7 +3421,8 @@ function renderTable(changedIndices = new Set()) {
             inspectRecord(record);
         };
         
-        actionsCell.appendChild(inspectBtn);
+        actionsWrap.appendChild(inspectBtn);
+        actionsCell.appendChild(actionsWrap);
         row.appendChild(actionsCell);
         
         // Make row clickable to inspect

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -1618,10 +1618,15 @@ body.is-loading .data-table {
 
 // Action cell
 .action-cell {
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.action-cell-content {
     display: flex;
     gap: 0.5rem;
-    align-items: center;  // Center items vertically
-    height: 100%;         // Match parent cell height
+    align-items: center;
+    min-height: 100%;
 }
 
 .action-btn {
@@ -1907,9 +1912,28 @@ body.is-loading .data-table {
     width: 100%;
 }
 
+.range-combo,
+.jalali-filter {
+    display: grid;
+    grid-template-columns: minmax(7.5rem, 1fr) 2rem;
+    align-items: center;
+}
+
+.jalali-filter {
+    grid-template-columns: minmax(5.8rem, 1fr) minmax(5.8rem, 1fr) 2rem;
+    gap: 0.25rem;
+}
+
+.range-direct-input {
+    min-width: 0;
+    border-radius: 999px 0 0 999px;
+    padding-right: 0.65rem;
+    font-family: var(--font-mono);
+}
+
 .range-trigger {
     width: 100%;
-    min-width: 52px;
+    min-width: 2rem;
     height: 32px;
     border: 1px solid $border-light;
     border-radius: 999px;
@@ -1923,6 +1947,32 @@ body.is-loading .data-table {
         color: $text-dark;
         border-color: $border-dark;
     }
+}
+
+.range-trigger-ellipsis {
+    border-left: 0;
+    border-radius: 0 999px 999px 0;
+    background: linear-gradient(180deg, rgba($primary-color, 0.12), rgba($primary-color, 0.04));
+    color: $primary-hover;
+    font-size: 1.15rem;
+    line-height: 1;
+
+    svg {
+        width: 1rem;
+        height: 1rem;
+        display: block;
+        margin: auto;
+    }
+
+    &:hover {
+        background: rgba($primary-color, 0.18);
+    }
+}
+
+.range-combo.has-filter .range-direct-input,
+.jalali-filter.has-filter .filter-input {
+    border-color: rgba($primary-color, 0.65);
+    box-shadow: inset 3px 0 0 $primary-color;
 }
 
 .ellipsis {
@@ -1962,12 +2012,51 @@ body.is-loading .data-table {
     }
 }
 
+.range-meta {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.35rem 0.45rem;
+    border-radius: 0.45rem;
+    background: rgba($primary-color, 0.08);
+    color: $text-light-secondary;
+    font-size: 0.72rem;
+
+    strong {
+        color: $text-light;
+        font-family: var(--font-mono);
+    }
+
+    .range-meta-note {
+        width: 100%;
+        text-align: center;
+    }
+
+    .dark-mode & {
+        background: rgba($primary-color, 0.16);
+        color: $text-dark-secondary;
+
+        strong {
+            color: $text-dark;
+        }
+    }
+}
+
 .range-clear {
-    border: 0;
-    border-radius: 0.375rem;
-    padding: 0.35rem 0.5rem;
+    border: 1px solid rgba($danger-color, 0.28);
+    border-radius: 0.45rem;
+    padding: 0.42rem 0.55rem;
     cursor: pointer;
     grid-column: 1 / -1;
+    background: rgba($danger-color, 0.08);
+    color: $danger-color;
+    font-weight: 700;
+
+    &:hover {
+        background: rgba($danger-color, 0.16);
+        border-color: rgba($danger-color, 0.45);
+    }
 }
 
 .range-field {
@@ -1984,7 +2073,63 @@ body.is-loading .data-table {
 .range-slider {
     grid-column: 1 / -1;
     width: 100%;
+    height: 1.35rem;
     accent-color: $primary-color;
+    background: transparent;
+    appearance: none;
+    -webkit-appearance: none;
+
+    &::-webkit-slider-runnable-track {
+        height: 0.38rem;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba($primary-color, 0.35), rgba($success-color, 0.35));
+        border: 1px solid rgba($primary-color, 0.25);
+    }
+
+    &::-webkit-slider-thumb {
+        margin-top: -0.39rem;
+        width: 1.05rem;
+        height: 1.05rem;
+        border-radius: 50%;
+        background: $primary-color;
+        border: 2px solid $bg-light;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+        appearance: none;
+        -webkit-appearance: none;
+    }
+
+    &::-moz-range-track {
+        height: 0.38rem;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba($primary-color, 0.35), rgba($success-color, 0.35));
+        border: 1px solid rgba($primary-color, 0.25);
+    }
+
+    &::-moz-range-thumb {
+        width: 1.05rem;
+        height: 1.05rem;
+        border-radius: 50%;
+        background: $primary-color;
+        border: 2px solid $bg-light;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    }
+
+    &:disabled {
+        opacity: 0.42;
+    }
+
+    .dark-mode & {
+        &::-webkit-slider-runnable-track,
+        &::-moz-range-track {
+            background: linear-gradient(90deg, rgba($primary-color, 0.5), rgba($success-color, 0.42));
+            border-color: rgba($primary-color, 0.38);
+        }
+
+        &::-webkit-slider-thumb,
+        &::-moz-range-thumb {
+            border-color: $bg-dark;
+        }
+    }
 }
 
 .filter-badge {
@@ -2049,27 +2194,132 @@ body.is-loading .data-table {
     }
 }
 
+.jalali-picker-panel {
+    min-width: 17rem;
+    grid-template-columns: 1fr;
+}
+
+.jalali-target-switch {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.3rem;
+
+    button {
+        border: 1px solid $border-light;
+        border-radius: 999px;
+        padding: 0.35rem 0.5rem;
+        background: transparent;
+        color: $text-light-secondary;
+        cursor: pointer;
+
+        &.active {
+            background: rgba($primary-color, 0.14);
+            color: $primary-hover;
+            border-color: rgba($primary-color, 0.4);
+            font-weight: 700;
+        }
+
+        .dark-mode & {
+            border-color: $border-dark;
+            color: $text-dark-secondary;
+        }
+    }
+}
+
+.jalali-picker-title {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+
+    strong {
+        font-family: var(--font-mono);
+    }
+}
+
+.picker-nav {
+    border: 0;
+    width: 1.8rem;
+    height: 1.8rem;
+    border-radius: 50%;
+    display: inline-grid;
+    place-items: center;
+    background: rgba($primary-color, 0.1);
+    color: $primary-hover;
+    cursor: pointer;
+
+    svg {
+        width: 1rem;
+        height: 1rem;
+    }
+}
+
+.jalali-day-grid {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 0.25rem;
+
+    button {
+        border: 1px solid transparent;
+        border-radius: 0.35rem;
+        min-height: 1.9rem;
+        background: $bg-light-secondary;
+        color: $text-light;
+        cursor: pointer;
+        font-family: var(--font-mono);
+
+        &:hover:not(:disabled) {
+            border-color: rgba($primary-color, 0.45);
+            background: rgba($primary-color, 0.1);
+        }
+
+        &:disabled {
+            opacity: 0.35;
+            cursor: not-allowed;
+        }
+
+        .dark-mode & {
+            background: $bg-dark-secondary;
+            color: $text-dark;
+        }
+    }
+}
+
 .btn-clear-filters {
-    padding: 0.375rem 0.75rem;
-    border: 1px solid $border-light;
-    border-radius: 0.375rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-height: 32px;
+    padding: 0.35rem 0.65rem;
+    border: 1px solid rgba($danger-color, 0.3);
+    border-radius: 999px;
     font-size: 0.75rem;
-    background: $bg-light;
-    color: $text-light;
+    font-weight: 700;
+    background: rgba($danger-color, 0.08);
+    color: $danger-color;
     cursor: pointer;
     white-space: nowrap;
     transition: all 0.15s ease;
+
+    svg {
+        width: 0.95rem;
+        height: 0.95rem;
+    }
     
     .dark-mode & {
-        background: $bg-dark;
-        color: $text-dark;
-        border-color: $border-dark;
+        background: rgba($danger-color, 0.13);
+        color: #fca5a5;
+        border-color: rgba($danger-color, 0.42);
     }
     
     &:hover {
-        background: $danger-color;
-        color: white;
-        border-color: $danger-color;
+        background: rgba($danger-color, 0.18);
+        border-color: rgba($danger-color, 0.52);
+        color: #dc2626;
     }
     
     &:active {
@@ -2150,6 +2400,23 @@ body.is-loading .data-table {
     padding: 0;
     display: inline-grid;
     place-items: center;
+}
+
+.btn-icon svg,
+.footer-collapse svg,
+.btn-clear-filters svg,
+.range-trigger svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    display: block;
+
+    path {
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
 }
 
 button:focus,

--- a/web/src/viewer.html
+++ b/web/src/viewer.html
@@ -31,9 +31,15 @@
                         <span class="status-indicator" id="statusIndicator"></span>
                         <span id="statusText">Connecting...</span>
                     </button>
-                    <button class="btn btn-icon" id="footerToggleBtn" type="button" title="Toggle footer">▤</button>
-                    <button class="btn btn-icon" id="settingsBtn" title="Settings">⚙️</button>
-                    <button class="btn btn-icon" id="themeToggle" title="Toggle Theme">🌙</button>
+                    <button class="btn btn-icon" id="footerToggleBtn" type="button" title="Toggle footer" aria-label="Toggle footer">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h16v14H4z" /><path d="M4 15h16" /></svg>
+                    </button>
+                    <button class="btn btn-icon" id="settingsBtn" title="Settings" aria-label="Settings">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" /><path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.05.05a2 2 0 1 1-2.83 2.83l-.05-.05A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.05V21a2 2 0 1 1-4 0v-.08A1.7 1.7 0 0 0 8.6 19.4a1.7 1.7 0 0 0-1.87.34l-.05.05a2 2 0 1 1-2.83-2.83l.05-.05A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.05-.4H3a2 2 0 1 1 0-4h.08A1.7 1.7 0 0 0 4.6 8.6a1.7 1.7 0 0 0-.34-1.87l-.05-.05a2 2 0 1 1 2.83-2.83l.05.05A1.7 1.7 0 0 0 9 4.6a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.05V3a2 2 0 1 1 4 0v.08A1.7 1.7 0 0 0 15.4 4.6a1.7 1.7 0 0 0 1.87-.34l.05-.05a2 2 0 1 1 2.83 2.83l-.05.05A1.7 1.7 0 0 0 19.4 9c.19.38.52.7 1 .9.31.13.65.2 1 .2H21a2 2 0 1 1 0 4h-.08a1.7 1.7 0 0 0-1.52.9z" /></svg>
+                    </button>
+                    <button class="btn btn-icon" id="themeToggle" title="Toggle Theme" aria-label="Toggle theme">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 14.5A8.5 8.5 0 0 1 9.5 3.5 9 9 0 1 0 20.5 14.5z" /></svg>
+                    </button>
                 </div>
             </div>
         </header>
@@ -117,7 +123,9 @@
                         <h2 id="settingsTitle">Settings</h2>
                         <p id="settingsConfigPath" class="settings-path"></p>
                     </div>
-                    <button class="btn btn-icon" id="closeSettings" type="button" title="Close">✕</button>
+                    <button class="btn btn-icon" id="closeSettings" type="button" title="Close" aria-label="Close">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg>
+                    </button>
                 </div>
                 <div class="settings-tabs" role="tablist" aria-label="Settings sections">
                     <button class="settings-tab active" type="button" data-settings-tab="ui">Interface</button>
@@ -262,7 +270,7 @@
                         <button class="btn btn-secondary" id="showAllColumns" type="button">Show all</button>
                         <button class="btn btn-secondary" id="hideAllColumns" type="button">Hide all</button>
                         <button class="btn btn-icon dialog-menu-btn" type="button" title="More actions" data-dialog-menu="columnsPanel">&hellip;</button>
-                        <button class="btn btn-icon dialog-close-btn" id="closeColumns" type="button" title="Close">&times;</button>
+                        <button class="btn btn-icon dialog-close-btn" id="closeColumns" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
                 <div class="column-manager">
@@ -286,7 +294,7 @@
                     </div>
                     <div class="dialog-actions">
                         <button class="btn btn-icon dialog-menu-btn" type="button" title="More actions" data-dialog-menu="connectionPanel">&hellip;</button>
-                        <button class="btn btn-icon dialog-close-btn" id="closeConnection" type="button" title="Close">&times;</button>
+                        <button class="btn btn-icon dialog-close-btn" id="closeConnection" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
                 <div class="connection-details" id="connectionDetails"></div>
@@ -304,7 +312,7 @@
                     <div class="dialog-actions">
                         <button class="btn btn-secondary" id="clearEventLog" type="button">Clear</button>
                         <button class="btn btn-icon dialog-menu-btn" type="button" title="More actions" data-dialog-menu="eventLogPanel">&hellip;</button>
-                        <button class="btn btn-icon dialog-close-btn" id="closeEventLog" type="button" title="Close">&times;</button>
+                        <button class="btn btn-icon dialog-close-btn" id="closeEventLog" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
                 <div class="event-log-summary" id="eventLogSummary"></div>
@@ -316,7 +324,7 @@
             <div class="inspector-content">
                 <div class="inspector-header">
                     <h2>Record Inspector</h2>
-                    <button class="btn btn-icon" id="closeInspector">✕</button>
+                    <button class="btn btn-icon" id="closeInspector" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                 </div>
                 <div class="inspector-body" id="inspectorBody">
                     <p class="text-muted">Select a record to inspect</p>
@@ -350,7 +358,9 @@
                     <span class="process-status footer-process-status" id="footerProcessStatus">Checking Patris81...</span>
                 </div>
                 <div class="footer-section footer-actions">
-                    <button class="btn btn-icon footer-collapse" id="footerCollapseBtn" type="button" title="Hide footer">⌄</button>
+                    <button class="btn btn-icon footer-collapse" id="footerCollapseBtn" type="button" title="Hide footer" aria-label="Hide footer">
+                        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg>
+                    </button>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
## Summary
- Replace numeric range trigger buttons with editable exact/range inputs plus an end-side ellipsis popover trigger.
- Add data-aware min/max metadata, seamless filtering, normalized slider behavior, and better empty/all-same range handling.
- Add a Jalali-aware date picker for date columns and wire it into the existing filter model.
- Fix footer collapse state toggling, replace letter/glyph controls with SVG icons, and align action cells for multiline rows.
- Restyle global/per-filter clear actions and range sliders for the dark theme.

## Verification
- `npm --prefix web run build`
- `node --check web/src/app.js`
- `git diff --check`

## Notes
- `go test ./...` was attempted with `C:\Program Files\Go\bin\go.exe` but this checkout still requires the native Paradox/CGO path: `paradox.Open` is unavailable and go-sqlite3 reports CGO disabled.

Closes #120