### PR TITLE
Fix footer toggle click handling

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -4006,6 +4006,13 @@ function init() {
     
     // Set up event listeners
     document.addEventListener('keydown', handleGlobalKeydown);
+    document.addEventListener('click', event => {
+        if (event.target.closest('#footerToggleBtn, #footerCollapseBtn')) {
+            event.preventDefault();
+            event.stopPropagation();
+            toggleFooterVisibility();
+        }
+    }, true);
 
     document.getElementById('searchInput').addEventListener('input', (e) => {
         state.searchTerm = e.target.value;
@@ -4026,8 +4033,6 @@ function init() {
     });
     
     document.getElementById('themeToggle').addEventListener('click', toggleTheme);
-    document.getElementById('footerToggleBtn')?.addEventListener('click', toggleFooterVisibility);
-    document.getElementById('footerCollapseBtn')?.addEventListener('click', toggleFooterVisibility);
     document.getElementById('footerLastUpdate')?.addEventListener('click', cycleLastUpdateMode);
     document.getElementById('headerConnectionButton')?.addEventListener('click', () => openModalRoute('connection'));
     document.getElementById('footerConnectionButton')?.addEventListener('click', () => openModalRoute('connection'));


### PR DESCRIPTION
## Summary
- Route footer show/hide clicks through delegated capture handling so the SPA footer controls keep working even after their SVG contents are regenerated.
- Remove the fragile direct footer button listeners to avoid double toggles.

## Verification
- `npm --prefix web run build`
- `node --check web/src/app.js`
- `git diff --check`

Closes #120