### PR TITLE
Prevent footer toggle double handling

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -558,6 +558,8 @@ async function saveConfigToServer(config) {
     }
 }
 
+const handledFooterToggleEvents = new WeakSet();
+
 // Save sort preferences to localStorage
 function saveSortPreferences(options = {}) {
     localStorage.setItem('patris-sort', JSON.stringify({
@@ -1017,9 +1019,9 @@ function renderFooterToggleButton(button, showFooter) {
 }
 
 function handleFooterToggleClick(event) {
-    if (event?.__patrisFooterToggleHandled) return;
+    if (event && handledFooterToggleEvents.has(event)) return;
     if (event) {
-        event.__patrisFooterToggleHandled = true;
+        handledFooterToggleEvents.add(event);
         event.preventDefault();
         event.stopPropagation();
     }


### PR DESCRIPTION
## Summary
- Use a WeakSet guard for footer toggle events instead of mutating the Event object.
- Prevent capture and target-phase handlers from double-toggling the footer back to its original state.

## Verification
- `npm run build` from `web/`
- `node --check web/src/app.js`
- `git diff --check`

Closes #120