### PR TITLE
Fix modal body scrolling and action spacing

### DIFF
--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -682,8 +682,12 @@ body.is-loading .data-table {
 .dialog-actions {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
     flex-wrap: wrap;
+
+    .dialog-menu-btn + .dialog-close-btn {
+        margin-inline-start: -0.4rem;
+    }
 }
 
 .dialog-close-btn,
@@ -874,6 +878,7 @@ body.is-loading .data-table {
     visibility: hidden;
     transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
     z-index: 1000;
+    overflow: hidden;
     
     .dark-mode & {
         background: $bg-dark;
@@ -888,9 +893,10 @@ body.is-loading .data-table {
 }
 
 .settings-content {
-    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
     max-height: inherit;
-    overflow-y: auto;
+    overflow: hidden;
     
     h2 {
         margin: 0;
@@ -903,7 +909,9 @@ body.is-loading .data-table {
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1rem;
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 1.25rem 1.25rem 1rem;
 }
 
 .settings-path {
@@ -921,12 +929,25 @@ body.is-loading .data-table {
 .settings-tabs {
     display: flex;
     gap: 0.35rem;
-    margin-bottom: 1rem;
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 0 1.25rem;
     border-bottom: 1px solid $border-light;
+    overflow-x: auto;
+    scrollbar-width: thin;
 
     .dark-mode & {
         border-color: $border-dark;
     }
+}
+
+.settings-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 1rem 1.25rem 1.25rem;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
 }
 
 .settings-tab {
@@ -954,6 +975,7 @@ body.is-loading .data-table {
 
 .settings-pane {
     display: none;
+    min-height: 0;
 
     &.active {
         display: block;
@@ -1155,12 +1177,7 @@ body.is-loading .data-table {
 }
 
 .column-manager-header {
-    position: sticky;
-    top: -1.25rem;
-    z-index: 5;
     background: $bg-light;
-    padding-top: 1.25rem;
-    padding-bottom: 0.75rem;
     border-bottom: 1px solid $border-light;
 
     .dark-mode & {
@@ -1329,8 +1346,6 @@ body.is-loading .data-table {
 .connection-log {
     display: grid;
     gap: 0.45rem;
-    max-height: 320px;
-    overflow: auto;
     font-family: var(--font-mono);
 }
 
@@ -1422,8 +1437,6 @@ body.is-loading .data-table {
 .event-log-list {
     display: grid;
     gap: 0.6rem;
-    max-height: min(58vh, 560px);
-    overflow: auto;
     padding-right: 0.25rem;
 }
 

--- a/web/src/viewer.html
+++ b/web/src/viewer.html
@@ -134,127 +134,129 @@
                     <button class="settings-tab" type="button" data-settings-tab="notifications">Notifications</button>
                     <button class="settings-tab" type="button" data-settings-tab="runtime">Runtime</button>
                 </div>
-                <div class="settings-pane active" data-settings-pane="ui">
-                    <div class="settings-grid">
-                        <label class="field-label">Theme
-                            <select id="settingsTheme" class="select-input">
-                                <option value="system">System</option>
-                                <option value="light">Light</option>
-                                <option value="dark">Dark</option>
-                            </select>
-                        </label>
-                        <label class="field-label">Records per page
-                            <select id="pageSize" class="select-input">
-                                <option value="25">25</option>
-                                <option value="50">50</option>
-                                <option value="100" selected>100</option>
-                                <option value="500">500</option>
-                            </select>
-                        </label>
-                        <label class="field-label">Notification sound
-                            <select id="notificationSoundSource" class="select-input">
-                                <option value="external" selected>External file</option>
-                                <option value="generated">Generated melody</option>
-                            </select>
-                        </label>
-                        <label class="field-label">Last update
-                            <select id="lastUpdateDisplayMode" class="select-input">
-                                <option value="both">Absolute and relative</option>
-                                <option value="absolute">Absolute</option>
-                                <option value="relative">Relative</option>
-                            </select>
-                        </label>
-                    </div>
-                    <div class="settings-group">
-                        <label class="checkbox-label"><input type="checkbox" id="showFooter" checked><span>Show footer</span></label>
-                        <label class="checkbox-label"><input type="checkbox" id="autoScrollToChanged"><span>Auto-scroll to changed items</span></label>
-                        <label class="checkbox-label"><input type="checkbox" id="highlightChanges" checked><span>Highlight changed items</span></label>
-                        <label class="checkbox-label"><input type="checkbox" id="rtlTextDirection"><span>Display table text right-to-left</span></label>
-                        <label class="checkbox-label"><input type="checkbox" id="enablePagination"><span>Enable pagination</span></label>
-                        <label class="checkbox-label"><input type="checkbox" id="playNotificationSound"><span>Play notification sound on updates</span></label>
-                    </div>
-                    <div class="settings-subsection">
-                        <h3>Row coloring</h3>
-                        <div class="settings-grid color-grid">
-                            <label class="checkbox-label color-toggle"><input type="checkbox" id="enableRowColoring" checked><span>Enable row coloring rules</span></label>
-                            <label class="field-label">Group rows
-                                <input id="rowColorGroup" class="color-input" type="color" value="#6366f1">
+                <div class="settings-body">
+                    <div class="settings-pane active" data-settings-pane="ui">
+                        <div class="settings-grid">
+                            <label class="field-label">Theme
+                                <select id="settingsTheme" class="select-input">
+                                    <option value="system">System</option>
+                                    <option value="light">Light</option>
+                                    <option value="dark">Dark</option>
+                                </select>
                             </label>
-                            <label class="field-label">Subgroup rows
-                                <input id="rowColorSubgroup" class="color-input" type="color" value="#0ea5e9">
+                            <label class="field-label">Records per page
+                                <select id="pageSize" class="select-input">
+                                    <option value="25">25</option>
+                                    <option value="50">50</option>
+                                    <option value="100" selected>100</option>
+                                    <option value="500">500</option>
+                                </select>
                             </label>
-                            <label class="field-label">No stock text
-                                <input id="rowColorNoStock" class="color-input" type="color" value="#6b7280">
+                            <label class="field-label">Notification sound
+                                <select id="notificationSoundSource" class="select-input">
+                                    <option value="external" selected>External file</option>
+                                    <option value="generated">Generated melody</option>
+                                </select>
                             </label>
-                            <label class="field-label">Stock accent
-                                <input id="rowColorHasStock" class="color-input" type="color" value="#10b981">
+                            <label class="field-label">Last update
+                                <select id="lastUpdateDisplayMode" class="select-input">
+                                    <option value="both">Absolute and relative</option>
+                                    <option value="absolute">Absolute</option>
+                                    <option value="relative">Relative</option>
+                                </select>
                             </label>
                         </div>
+                        <div class="settings-group">
+                            <label class="checkbox-label"><input type="checkbox" id="showFooter" checked><span>Show footer</span></label>
+                            <label class="checkbox-label"><input type="checkbox" id="autoScrollToChanged"><span>Auto-scroll to changed items</span></label>
+                            <label class="checkbox-label"><input type="checkbox" id="highlightChanges" checked><span>Highlight changed items</span></label>
+                            <label class="checkbox-label"><input type="checkbox" id="rtlTextDirection"><span>Display table text right-to-left</span></label>
+                            <label class="checkbox-label"><input type="checkbox" id="enablePagination"><span>Enable pagination</span></label>
+                            <label class="checkbox-label"><input type="checkbox" id="playNotificationSound"><span>Play notification sound on updates</span></label>
+                        </div>
+                        <div class="settings-subsection">
+                            <h3>Row coloring</h3>
+                            <div class="settings-grid color-grid">
+                                <label class="checkbox-label color-toggle"><input type="checkbox" id="enableRowColoring" checked><span>Enable row coloring rules</span></label>
+                                <label class="field-label">Group rows
+                                    <input id="rowColorGroup" class="color-input" type="color" value="#6366f1">
+                                </label>
+                                <label class="field-label">Subgroup rows
+                                    <input id="rowColorSubgroup" class="color-input" type="color" value="#0ea5e9">
+                                </label>
+                                <label class="field-label">No stock text
+                                    <input id="rowColorNoStock" class="color-input" type="color" value="#6b7280">
+                                </label>
+                                <label class="field-label">Stock accent
+                                    <input id="rowColorHasStock" class="color-input" type="color" value="#10b981">
+                                </label>
+                            </div>
+                        </div>
+                        <div class="button-row">
+                            <button class="btn btn-secondary" id="testNotificationSound" type="button">Test sound</button>
+                            <button class="btn btn-secondary" id="testNativeToast" type="button">Test toast</button>
+                        </div>
                     </div>
-                    <div class="button-row">
-                        <button class="btn btn-secondary" id="testNotificationSound" type="button">Test sound</button>
-                        <button class="btn btn-secondary" id="testNativeToast" type="button">Test toast</button>
+                    <div class="settings-pane" data-settings-pane="server">
+                        <div class="settings-grid">
+                            <label class="field-label">Host
+                                <input id="serverHost" class="text-input" type="text" autocomplete="off">
+                            </label>
+                            <label class="field-label">Port
+                                <input id="serverPort" class="text-input" type="number" min="1" max="65535">
+                            </label>
+                            <label class="field-label">Debounce
+                                <input id="serverDebounce" class="text-input" type="text" placeholder="500ms">
+                            </label>
+                        </div>
+                        <label class="checkbox-label"><input type="checkbox" id="serverWatch"><span>Watch source and broadcast updates</span></label>
                     </div>
-                </div>
-                <div class="settings-pane" data-settings-pane="server">
-                    <div class="settings-grid">
-                        <label class="field-label">Host
-                            <input id="serverHost" class="text-input" type="text" autocomplete="off">
-                        </label>
-                        <label class="field-label">Port
-                            <input id="serverPort" class="text-input" type="number" min="1" max="65535">
-                        </label>
-                        <label class="field-label">Debounce
-                            <input id="serverDebounce" class="text-input" type="text" placeholder="500ms">
-                        </label>
+                    <div class="settings-pane" data-settings-pane="database">
+                        <div class="settings-grid">
+                            <label class="field-label wide">Database path or URL
+                                <input id="databasePath" class="text-input" type="text" autocomplete="off">
+                            </label>
+                            <label class="field-label wide">Custom charmap
+                                <input id="databaseCharmap" class="text-input" type="text" autocomplete="off">
+                            </label>
+                        </div>
+                        <label class="checkbox-label"><input type="checkbox" id="directAccess"><span>Read database directly without temp copy</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="rtlConversion"><span>Enable opt-in RTL conversion</span></label>
                     </div>
-                    <label class="checkbox-label"><input type="checkbox" id="serverWatch"><span>Watch source and broadcast updates</span></label>
-                </div>
-                <div class="settings-pane" data-settings-pane="database">
-                    <div class="settings-grid">
-                        <label class="field-label wide">Database path or URL
-                            <input id="databasePath" class="text-input" type="text" autocomplete="off">
-                        </label>
-                        <label class="field-label wide">Custom charmap
-                            <input id="databaseCharmap" class="text-input" type="text" autocomplete="off">
-                        </label>
+                    <div class="settings-pane" data-settings-pane="notifications">
+                        <div class="settings-grid">
+                            <label class="field-label">Max detailed rows
+                                <input id="notifyMaxRows" class="text-input" type="number" min="1" max="20">
+                            </label>
+                        </div>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyEnabled"><span>Enable event notifications</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyNative"><span>Show native OS toast messages</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyInApp"><span>Relay notifications to connected web clients</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyClientConnected"><span>Client connected</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyClientDisconnected"><span>Client disconnected</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyFileUpdated"><span>Source file updated with old/new hash</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyRowUpdated"><span>Rows changed</span></label>
+                        <label class="checkbox-label"><input type="checkbox" id="notifyIncludeRowValues"><span>Include old/new row values in notifications</span></label>
                     </div>
-                    <label class="checkbox-label"><input type="checkbox" id="directAccess"><span>Read database directly without temp copy</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="rtlConversion"><span>Enable opt-in RTL conversion</span></label>
-                </div>
-                <div class="settings-pane" data-settings-pane="notifications">
-                    <div class="settings-grid">
-                        <label class="field-label">Max detailed rows
-                            <input id="notifyMaxRows" class="text-input" type="number" min="1" max="20">
-                        </label>
+                    <div class="settings-pane" data-settings-pane="runtime">
+                        <div class="settings-grid">
+                            <label class="field-label wide">Temp directory
+                                <input id="runtimeTempDir" class="text-input" type="text" placeholder="system">
+                            </label>
+                            <label class="field-label">Temp strategy
+                                <select id="runtimeTempStrategy" class="text-input">
+                                    <option value="auto">Auto</option>
+                                    <option value="system">System temp</option>
+                                    <option value="memory">Memory temp</option>
+                                </select>
+                            </label>
+                            <label class="field-label">Memory temp limit (MiB)
+                                <input id="runtimeTempMemoryLimitMB" class="text-input" type="number" min="1" max="4096" step="1" placeholder="100">
+                            </label>
+                        </div>
+                        <label class="checkbox-label"><input type="checkbox" id="runtimeDebug"><span>Enable debug tools and custom charmap previews</span></label>
+                        <p class="settings-help">Use <code>system</code> for the operating system temp directory. Auto prefers <code>/dev/shm</code> on Linux for known-size files within the memory limit.</p>
                     </div>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyEnabled"><span>Enable event notifications</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyNative"><span>Show native OS toast messages</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyInApp"><span>Relay notifications to connected web clients</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyClientConnected"><span>Client connected</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyClientDisconnected"><span>Client disconnected</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyFileUpdated"><span>Source file updated with old/new hash</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyRowUpdated"><span>Rows changed</span></label>
-                    <label class="checkbox-label"><input type="checkbox" id="notifyIncludeRowValues"><span>Include old/new row values in notifications</span></label>
-                </div>
-                <div class="settings-pane" data-settings-pane="runtime">
-                    <div class="settings-grid">
-                        <label class="field-label wide">Temp directory
-                            <input id="runtimeTempDir" class="text-input" type="text" placeholder="system">
-                        </label>
-                        <label class="field-label">Temp strategy
-                            <select id="runtimeTempStrategy" class="text-input">
-                                <option value="auto">Auto</option>
-                                <option value="system">System temp</option>
-                                <option value="memory">Memory temp</option>
-                            </select>
-                        </label>
-                        <label class="field-label">Memory temp limit (MiB)
-                            <input id="runtimeTempMemoryLimitMB" class="text-input" type="number" min="1" max="4096" step="1" placeholder="100">
-                        </label>
-                    </div>
-                    <label class="checkbox-label"><input type="checkbox" id="runtimeDebug"><span>Enable debug tools and custom charmap previews</span></label>
-                    <p class="settings-help">Use <code>system</code> for the operating system temp directory. Auto prefers <code>/dev/shm</code> on Linux for known-size files within the memory limit.</p>
                 </div>
             </div>
         </div>
@@ -273,14 +275,16 @@
                         <button class="btn btn-icon dialog-close-btn" id="closeColumns" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
-                <div class="column-manager">
-                    <div class="column-manager-row column-manager-head">
-                        <span>Visible</span>
-                        <span>Source key</span>
-                        <span>Display label</span>
-                        <span>Type</span>
+                <div class="settings-body">
+                    <div class="column-manager">
+                        <div class="column-manager-row column-manager-head">
+                            <span>Visible</span>
+                            <span>Source key</span>
+                            <span>Display label</span>
+                            <span>Type</span>
+                        </div>
+                        <div class="column-manager-rows" id="columnCheckboxes"></div>
                     </div>
-                    <div class="column-manager-rows" id="columnCheckboxes"></div>
                 </div>
             </div>
         </div>
@@ -297,8 +301,10 @@
                         <button class="btn btn-icon dialog-close-btn" id="closeConnection" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
-                <div class="connection-details" id="connectionDetails"></div>
-                <div class="connection-log" id="connectionLog" aria-live="polite"></div>
+                <div class="settings-body">
+                    <div class="connection-details" id="connectionDetails"></div>
+                    <div class="connection-log" id="connectionLog" aria-live="polite"></div>
+                </div>
             </div>
         </div>
 
@@ -315,8 +321,10 @@
                         <button class="btn btn-icon dialog-close-btn" id="closeEventLog" type="button" title="Close" aria-label="Close"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12" /><path d="M18 6L6 18" /></svg></button>
                     </div>
                 </div>
-                <div class="event-log-summary" id="eventLogSummary"></div>
-                <div class="event-log-list" id="eventLogList" aria-live="polite"></div>
+                <div class="settings-body">
+                    <div class="event-log-summary" id="eventLogSummary"></div>
+                    <div class="event-log-list" id="eventLogList" aria-live="polite"></div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Keeps modal headers and settings tabs fixed while only the modal body scrolls.
- Applies the same body-scroll shell to settings, column visibility, connection status, and event logs dialogs.
- Removes the unwanted visual gap between adjacent ellipsis and close icon buttons.

## Verification
- `npm.cmd run build` in `web/`
- `git diff --check`

Closes #127