### PR TITLE
Fix SPA home route placement from viewer branding

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -1344,6 +1344,7 @@ async function showPartialRoute(route) {
     if (state.router.tableContainer) state.router.tableContainer.hidden = true;
     document.body.classList.add('partial-route-active');
     state.router.outlet.hidden = false;
+    resetPartialRouteScroll();
     state.router.outlet.innerHTML = '<div class="route-loading">Loading...</div>';
     const controller = new AbortController();
     state.router.partialController = controller;
@@ -1357,10 +1358,17 @@ async function showPartialRoute(route) {
         const html = await response.text();
         if (state.router.partialController !== controller) return;
         renderPartialHTML(html);
+        resetPartialRouteScroll();
     } catch (error) {
         if (error.name === 'AbortError') return;
         state.router.outlet.innerHTML = `<div class="route-error"><strong>Could not load page.</strong><span>${escapeHtml(error.message)}</span></div>`;
+        resetPartialRouteScroll();
     }
+}
+
+function resetPartialRouteScroll() {
+    document.querySelector('.main-content')?.scrollTo?.({ top: 0, left: 0, behavior: 'auto' });
+    state.router.outlet?.scrollTo?.({ top: 0, left: 0, behavior: 'auto' });
 }
 
 function cancelPartialRoute() {

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -347,6 +347,16 @@ body.footer-hidden {
 .partial-route-active {
     .main-content {
         overflow: auto;
+        padding: 0;
+    }
+
+    .route-outlet {
+        height: auto;
+        min-height: 100%;
+        overflow: visible;
+        background: transparent;
+        border-radius: 0;
+        box-shadow: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- Makes SPA partial routes occupy the main app surface instead of being framed inside the viewer table/card layout.
- Resets partial-route scroll before and after loading so clicking the branding from `/viewer` lands at the top of the home page.
- Keeps viewer route behavior unchanged when returning to `/viewer`.

## Verification
- `npm.cmd run build`
- `git diff --check`
- Rebuilt live `127.0.0.1:18080` executable from this branch and verified the branding click in the browser.
- Browser measurement after branding click: route is `/`, outlet top equals main-content top, main padding is `0px`, viewer table/toolbar are hidden, and main/outlet scroll positions are `0`.

## Note
- Direct local `go test ./...` is blocked in this shell because `go` is not on PATH by default; using `C:\Program Files\Go\bin\go.exe` reaches the toolchain but fails with the current CGO/build-tag environment (`paradox.Open` undefined and go-sqlite3 reports CGO disabled). CI is expected to run with the repository workflow environment.

Closes #129