### PR TITLE
Inset range filter ellipsis trigger

### DIFF
--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -1942,6 +1942,11 @@ body.is-loading .data-table {
     align-items: center;
 }
 
+.range-combo {
+    display: block;
+    position: relative;
+}
+
 .jalali-filter {
     grid-template-columns: minmax(5.8rem, 1fr) minmax(5.8rem, 1fr) 2rem;
     gap: 0.25rem;
@@ -1949,9 +1954,10 @@ body.is-loading .data-table {
 
 .range-direct-input {
     min-width: 0;
-    border-radius: 999px 0 0 999px;
-    padding-right: 0.65rem;
+    border-radius: 999px;
+    box-sizing: border-box;
     font-family: var(--font-mono);
+    padding-inline-end: 2.35rem;
 }
 
 .range-trigger {
@@ -1989,6 +1995,35 @@ body.is-loading .data-table {
 
     &:hover {
         background: rgba($primary-color, 0.18);
+    }
+}
+
+.range-combo .range-trigger {
+    position: absolute;
+    inset-inline-end: 0.2rem;
+    top: 0;
+    bottom: 0;
+    z-index: 2;
+    width: 1.85rem;
+    min-width: 1.85rem;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    transform: none;
+    box-shadow: none;
+}
+
+.range-combo .range-trigger-ellipsis {
+    color: $primary-hover;
+    font-size: 1rem;
+    line-height: 1;
+
+    &:hover,
+    &:focus-visible {
+        background: rgba($primary-color, 0.14);
     }
 }
 


### PR DESCRIPTION
## Summary
- Changes numeric range filters from a two-piece input + side button into one full pill input surface.
- Overlays the ellipsis trigger inside the input end inset.
- Keeps the input directly editable while preserving the popover trigger hit target.

## Verification
- `npm.cmd run build`
- `git diff --check`
- Rebuilt the live `127.0.0.1:18080` executable from this branch and measured the control in-browser.
- Browser geometry: trigger is absolute, transparent, borderless, inside the input bounds, and has the exact same height as the input (`heightDelta: 0`).

Closes #131