### PR TITLE
Use go.mod for CI Go version

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.24.11'
+        go-version-file: go.mod
         cache: false
 
     - name: Set up Node.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.24.11'
+        go-version-file: go.mod
         cache: false
     
     - name: Set up Node.js
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.24.11'
+        go-version-file: go.mod
         cache: false
     
     - name: Set up Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6.5.0
       with:
-        go-version: '1.24.11'
+        go-version-file: go.mod
         cache: false
     
     - name: Set up Node.js


### PR DESCRIPTION
## Summary
- Makes all CI workflows install the Go version declared by the checked-out `go.mod`.
- Prevents Dependabot Go module PRs from failing just because an updated dependency raises the `go` directive.
- Keeps existing Dependabot coverage for Go modules, `/web` npm packages, and GitHub Actions intact.

## Evidence
- Dependabot has already opened PRs for Go modules (#101), GitHub Actions (#102), and `/web` npm tooling (#103).
- #101 failed because its dependency update raised `go.mod` to `go 1.25.0` while CI was pinned to Go `1.24.11`.

## Verification
- `npm.cmd run build`
- `git diff --check`
- Confirmed no remaining `go-version:` pins under `.github/workflows`; all setup-go steps now use `go-version-file: go.mod`.

Closes #133