### PR TITLE
Fix table right-edge gap from filter popovers

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -27,6 +27,7 @@ const state = {
     hiddenColumns: new Set(),  // Track hidden columns
     columnOrder: [],
     openRangePanel: null,
+    openRangeAnchor: null,
     scrollAnchor: null,
     isRestoringScroll: false,
     scrollSaveTimer: null,
@@ -2857,6 +2858,58 @@ function createFilterControl(field) {
     return container;
 }
 
+function closeOpenRangePanel() {
+    if (!state.openRangePanel) return;
+    state.openRangePanel.classList.remove('open');
+    state.openRangePanel = null;
+    state.openRangeAnchor = null;
+}
+
+function positionFloatingRangePanel(anchor, panel) {
+    if (!anchor || !panel || !anchor.isConnected || !panel.isConnected) {
+        closeOpenRangePanel();
+        return;
+    }
+
+    const viewportPadding = 8;
+    const anchorRect = anchor.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    const panelWidth = Math.max(panelRect.width || 230, 230);
+    const panelHeight = Math.max(panelRect.height || 120, 120);
+    const availableRight = window.innerWidth - viewportPadding - panelWidth;
+    const left = Math.max(viewportPadding, Math.min(anchorRect.left, availableRight));
+    const preferredTop = anchorRect.bottom + 6;
+    const fallbackTop = anchorRect.top - panelHeight - 6;
+    const top = preferredTop + panelHeight <= window.innerHeight - viewportPadding
+        ? preferredTop
+        : Math.max(viewportPadding, fallbackTop);
+
+    panel.style.setProperty('--range-panel-left', `${Math.round(left)}px`);
+    panel.style.setProperty('--range-panel-top', `${Math.round(top)}px`);
+}
+
+function openFloatingRangePanel(anchor, panel) {
+    if (state.openRangePanel && state.openRangePanel !== panel) {
+        closeOpenRangePanel();
+    }
+
+    panel.classList.toggle('open');
+    if (panel.classList.contains('open')) {
+        state.openRangePanel = panel;
+        state.openRangeAnchor = anchor;
+        positionFloatingRangePanel(anchor, panel);
+    } else {
+        state.openRangePanel = null;
+        state.openRangeAnchor = null;
+    }
+}
+
+function repositionOpenRangePanel() {
+    if (state.openRangePanel) {
+        positionFloatingRangePanel(state.openRangeAnchor, state.openRangePanel);
+    }
+}
+
 function createRangePopover2(field, currentFilter, mode) {
     const wrapper = document.createElement('div');
     wrapper.className = 'range-popover range-combo';
@@ -3012,11 +3065,7 @@ function createRangePopover2(field, currentFilter, mode) {
 
     button.addEventListener('click', event => {
         event.stopPropagation();
-        if (state.openRangePanel && state.openRangePanel !== panel) {
-            state.openRangePanel.classList.remove('open');
-        }
-        panel.classList.toggle('open');
-        state.openRangePanel = panel.classList.contains('open') ? panel : null;
+        openFloatingRangePanel(wrapper, panel);
         if (panel.classList.contains('open')) {
             setTimeout(() => minInput.focus({ preventScroll: true }), 20);
         }
@@ -3241,13 +3290,9 @@ function createJalaliDateFilterControl(field, currentFilter) {
     toInput.addEventListener('input', commitDateFilter);
     button.addEventListener('click', event => {
         event.stopPropagation();
-        if (state.openRangePanel && state.openRangePanel !== panel) {
-            state.openRangePanel.classList.remove('open');
-        }
         pickerState.cursor = JalaliUtils.parse(fromInput.value) || JalaliUtils.parse(toInput.value) || minDate || maxDate || pickerState.cursor;
         renderPicker();
-        panel.classList.toggle('open');
-        state.openRangePanel = panel.classList.contains('open') ? panel : null;
+        openFloatingRangePanel(wrapper, panel);
     });
 
     wrapper.classList.toggle('has-filter', !!(currentFilter?.min || currentFilter?.max));
@@ -4073,11 +4118,12 @@ function init() {
         if (!exportBtn.contains(e.target) && !exportDropdown.contains(e.target)) {
             exportDropdown.classList.remove('open');
         }
-        if (state.openRangePanel && !state.openRangePanel.contains(e.target) && !e.target.closest('.range-trigger')) {
-            state.openRangePanel.classList.remove('open');
-            state.openRangePanel = null;
+        if (state.openRangePanel && !state.openRangePanel.contains(e.target) && !e.target.closest('.range-popover')) {
+            closeOpenRangePanel();
         }
     });
+    window.addEventListener('resize', repositionOpenRangePanel);
+    document.addEventListener('scroll', repositionOpenRangePanel, true);
     
     document.getElementById('settingsBtn').addEventListener('click', () => {
         openModalRoute('settings');

--- a/web/src/styles.scss
+++ b/web/src/styles.scss
@@ -2038,11 +2038,14 @@ body.is-loading .data-table {
 }
 
 .range-panel {
-    position: absolute;
-    top: calc(100% + 0.35rem);
-    left: 0;
+    position: fixed;
+    top: var(--range-panel-top, 0);
+    left: var(--range-panel-left, 0);
     z-index: 80;
     min-width: 230px;
+    max-width: calc(100vw - 1rem);
+    max-height: min(360px, calc(100vh - 1rem));
+    overflow: auto;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0.45rem;


### PR DESCRIPTION
## Summary
- Make numeric and Jalali filter panels viewport-floating overlays instead of scroll-container-positioned boxes.
- Clamp the panels to the visible viewport and reposition them on window/table scroll.
- Keep outside-click behavior working without closing the panel when interacting with the range input group.

## Why
The blank strip at the far-right horizontal scroll edge was caused by hidden `.range-panel` elements contributing to `.table-container.scrollWidth`. In the live viewer, the container had `scrollWidth=2377` while the table width was `2297`, and a hidden range panel was overflowing by exactly `80px`.

After the fix, the live viewer reports `scrollWidth=2297`, the table/header/body right edge equals the container right edge, and there are no overflowing descendants.

Closes #135

## Verification
- `npm run build` in `web/`
- `git diff --check`
- `go test ./...` with CGO, WinLibs, and pxlib DLL path configured
- Rebuilt and restarted `C:\Users\Mahdi\Desktop\AtomicDeploy\deploy\patris-export.exe` on `http://127.0.0.1:18080/viewer`
- Browser geometry verification on the live service

Screenshot captured locally: `C:\Users\Mahdi\Desktop\AtomicDeploy\artifacts\table-right-edge-fixed.png`