### PR TITLE
Fix webhook change delivery

### DIFF
--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
@@ -24,6 +25,7 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/oneshot"
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
+	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
 	"github.com/atomicdeploy/patris-export/pkg/recordsink"
@@ -626,11 +628,19 @@ func runConvert(cmd *cobra.Command, args []string) {
 		checkProcessConflicts(dbFile)
 	}
 
+	var convertMu sync.Mutex
+	var updateState watchChangeState
 	convertAndSend := func(path, eventType string) {
+		convertMu.Lock()
+		defer convertMu.Unlock()
+
 		result, err := convertFile(path, charMap, useStdout, cfg)
-		if err == nil {
-			sendConvertUpdate(cfg, path, result, eventType, nil)
+		if err != nil {
+			return
 		}
+
+		changes := updateState.Next(result, eventType, time.Now())
+		sendConvertUpdate(cfg, path, result, eventType, changes)
 	}
 
 	if watchMode {
@@ -815,16 +825,20 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 	return nil
 }
 
-func sendConvertUpdate(cfg appconfig.Config, source string, result recordpipe.Result, eventType string, changes map[string]interface{}) {
+func sendConvertUpdate(cfg appconfig.Config, source string, result recordpipe.Result, eventType string, changes *recorddiff.ChangeSet) {
 	if !cfg.SendUpdates.Enabled {
 		return
 	}
 	if eventType == "initial" && !cfg.SendUpdates.Initial {
 		return
 	}
+	timestamp := time.Now().Format(time.RFC3339)
+	if changes != nil && changes.Timestamp != "" {
+		timestamp = changes.Timestamp
+	}
 	event := updateout.Event{
 		Type:      eventType,
-		Timestamp: time.Now().Format(time.RFC3339),
+		Timestamp: timestamp,
 		Source:    source,
 		Raw:       result.Raw,
 		Records:   result.Rows,
@@ -834,6 +848,21 @@ func sendConvertUpdate(cfg appconfig.Config, source string, result recordpipe.Re
 	if err := updateout.Dispatch(context.Background(), cfg.SendUpdates, event); err != nil {
 		warningColor.Printf("Send update failed: %v\n", err)
 	}
+}
+
+type watchChangeState struct {
+	previousRows []map[string]interface{}
+}
+
+func (state *watchChangeState) Next(result recordpipe.Result, eventType string, at time.Time) *recorddiff.ChangeSet {
+	var changes *recorddiff.ChangeSet
+	if eventType != "initial" {
+		changeSet := recorddiff.Between(state.previousRows, result.Rows, result.KeyField, at)
+		changeSet.Raw = result.Raw
+		changes = &changeSet
+	}
+	state.previousRows = recordmap.CopyRows(result.Rows)
+	return changes
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cmd/patris-export/main_test.go
+++ b/cmd/patris-export/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
+)
+
+func TestWatchChangeStateBuildsChangesAfterInitialBaseline(t *testing.T) {
+	state := &watchChangeState{}
+	initial := recordpipe.Result{
+		KeyField: "sku",
+		Rows: []map[string]interface{}{
+			{"sku": "100", "title": "Bolt", "price": 10},
+		},
+	}
+	if changes := state.Next(initial, "initial", time.Unix(1, 0)); changes != nil {
+		t.Fatalf("initial event must carry the full records payload, not a changeset: %#v", changes)
+	}
+
+	update := recordpipe.Result{
+		KeyField: "sku",
+		Rows: []map[string]interface{}{
+			{"sku": "100", "title": "Bolt", "price": 12},
+			{"sku": "200", "title": "Nut", "price": 5},
+		},
+	}
+	changes := state.Next(update, "update", time.Unix(2, 0))
+	if changes == nil {
+		t.Fatal("watch update returned a nil changeset")
+	}
+	added, modified, deleted := changes.Counts()
+	if added != 1 || modified != 1 || deleted != 0 {
+		t.Fatalf("unexpected watch changes: added=%d modified=%d deleted=%d", added, modified, deleted)
+	}
+	if changes.Modified[0].Record["sku"] != "100" || changes.Modified[0].Record["title"] != "Bolt" {
+		t.Fatalf("modified watch row is incomplete: %#v", changes.Modified[0].Record)
+	}
+}

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -81,7 +81,12 @@ the configured key field.
 
 When watch mode is enabled, the initial payload can be sent once and later file
 changes can be sent as either a changeset or a full snapshot. Payloads can go to
-an HTTP endpoint, a command on stdin, or both.
+an HTTP endpoint, a command on stdin, or both. The initial event contains the
+complete transformed snapshot. Later `changes` events use the same key-aware
+diff implementation as the WebSocket server and contain `added`, `modified`,
+and `deleted` entries. Modified entries include both the changed field values
+and the complete transformed `record`, so downstream upserts do not need to
+reconstruct unchanged fields.
 
 ```powershell
 patris-export convert C:\Patris\data4\kala.db -f json -w `
@@ -114,3 +119,9 @@ Config equivalent:
   }
 }
 ```
+
+In CSV `changes` mode, each row includes `_change_type` with `added`,
+`modified`, or `deleted`. Modified rows contain the complete transformed row
+and `_changed_fields`; deleted rows are tombstones containing the configured
+key field. This makes the CSV stream actionable without exposing raw Patris
+fields when transform mapping is enabled.

--- a/pkg/recorddiff/diff.go
+++ b/pkg/recorddiff/diff.go
@@ -1,0 +1,197 @@
+package recorddiff
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RecordChange describes one modified record while preserving the legacy
+// WebSocket fields and carrying the complete new record for downstream sinks.
+type RecordChange struct {
+	Code          string                 `json:"code"`
+	ChangeType    string                 `json:"change_type"`
+	OldValues     map[string]interface{} `json:"old_values,omitempty"`
+	NewValues     map[string]interface{} `json:"new_values,omitempty"`
+	ChangedFields []string               `json:"changed_fields,omitempty"`
+	Record        map[string]interface{} `json:"record,omitempty"`
+}
+
+// ChangeSet is the shared incremental payload used by the WebSocket server,
+// CLI watch webhooks, and command sinks.
+type ChangeSet struct {
+	Type       string                   `json:"type"`
+	Timestamp  string                   `json:"timestamp"`
+	Added      []map[string]interface{} `json:"added,omitempty"`
+	Deleted    []string                 `json:"deleted,omitempty"`
+	Modified   []RecordChange           `json:"modified,omitempty"`
+	TotalCount int                      `json:"total_count"`
+	KeyField   string                   `json:"key_field"`
+	Raw        bool                     `json:"raw"`
+}
+
+// Between compares two transformed snapshots using keyField. It never mutates
+// either input and keeps record ordering stable while sorting changed fields.
+func Between(previous, current []map[string]interface{}, keyField string, at time.Time) ChangeSet {
+	keyField = strings.TrimSpace(keyField)
+	if keyField == "" {
+		keyField = "Code"
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+
+	result := ChangeSet{
+		Type:       "update",
+		Timestamp:  at.Format(time.RFC3339),
+		TotalCount: len(current),
+		KeyField:   keyField,
+	}
+
+	if len(previous) == 0 {
+		result.Added = copyRows(current)
+		return result
+	}
+
+	oldByKey, oldOrder := indexRows(previous, keyField)
+	newByKey, newOrder := indexRows(current, keyField)
+
+	for _, key := range newOrder {
+		newRecord := newByKey[key]
+		oldRecord, exists := oldByKey[key]
+		if !exists {
+			result.Added = append(result.Added, copyRecord(newRecord))
+			continue
+		}
+
+		changedFields, oldValues, newValues := changedValues(oldRecord, newRecord, keyField)
+		if len(changedFields) == 0 {
+			continue
+		}
+		result.Modified = append(result.Modified, RecordChange{
+			Code:          key,
+			ChangeType:    "modified",
+			OldValues:     oldValues,
+			NewValues:     newValues,
+			ChangedFields: changedFields,
+			Record:        copyRecord(newRecord),
+		})
+	}
+
+	for _, key := range oldOrder {
+		if _, exists := newByKey[key]; !exists {
+			result.Deleted = append(result.Deleted, key)
+		}
+	}
+
+	return result
+}
+
+func (changes ChangeSet) Empty() bool {
+	return len(changes.Added) == 0 && len(changes.Modified) == 0 && len(changes.Deleted) == 0
+}
+
+func (changes ChangeSet) Counts() (added, modified, deleted int) {
+	return len(changes.Added), len(changes.Modified), len(changes.Deleted)
+}
+
+// Map preserves the map-shaped WebSocket payload used by existing clients.
+func (changes ChangeSet) Map() map[string]interface{} {
+	result := map[string]interface{}{
+		"type":        changes.Type,
+		"timestamp":   changes.Timestamp,
+		"total_count": changes.TotalCount,
+		"key_field":   changes.KeyField,
+		"raw":         changes.Raw,
+	}
+	if len(changes.Added) > 0 {
+		result["added"] = changes.Added
+	}
+	if len(changes.Deleted) > 0 {
+		result["deleted"] = changes.Deleted
+	}
+	if len(changes.Modified) > 0 {
+		result["modified"] = changes.Modified
+	}
+	return result
+}
+
+func indexRows(rows []map[string]interface{}, keyField string) (map[string]map[string]interface{}, []string) {
+	indexed := make(map[string]map[string]interface{}, len(rows))
+	order := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		value, exists := row[keyField]
+		if !exists {
+			continue
+		}
+		key := fmt.Sprintf("%v", value)
+		indexed[key] = row
+		if _, exists := seen[key]; !exists {
+			seen[key] = struct{}{}
+			order = append(order, key)
+		}
+	}
+	return indexed, order
+}
+
+func changedValues(oldRecord, newRecord map[string]interface{}, keyField string) ([]string, map[string]interface{}, map[string]interface{}) {
+	fields := make(map[string]struct{}, len(oldRecord)+len(newRecord))
+	for field := range oldRecord {
+		if field != keyField {
+			fields[field] = struct{}{}
+		}
+	}
+	for field := range newRecord {
+		if field != keyField {
+			fields[field] = struct{}{}
+		}
+	}
+
+	ordered := make([]string, 0, len(fields))
+	for field := range fields {
+		ordered = append(ordered, field)
+	}
+	sort.Strings(ordered)
+
+	changed := make([]string, 0, len(ordered))
+	oldValues := make(map[string]interface{})
+	newValues := make(map[string]interface{})
+	for _, field := range ordered {
+		oldValue, hadOld := oldRecord[field]
+		newValue, hasNew := newRecord[field]
+		if hadOld == hasNew && reflect.DeepEqual(oldValue, newValue) {
+			continue
+		}
+		changed = append(changed, field)
+		if hadOld {
+			oldValues[field] = oldValue
+		} else {
+			oldValues[field] = nil
+		}
+		if hasNew {
+			newValues[field] = newValue
+		} else {
+			newValues[field] = nil
+		}
+	}
+	return changed, oldValues, newValues
+}
+
+func copyRows(rows []map[string]interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, copyRecord(row))
+	}
+	return result
+}
+
+func copyRecord(record map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(record))
+	for key, value := range record {
+		result[key] = value
+	}
+	return result
+}

--- a/pkg/recorddiff/diff_test.go
+++ b/pkg/recorddiff/diff_test.go
@@ -1,0 +1,89 @@
+package recorddiff
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBetweenUsesCustomKeyAndCapturesCompleteChanges(t *testing.T) {
+	at := time.Date(2026, 7, 16, 6, 30, 0, 0, time.FixedZone("IRST", 3*60*60+30*60))
+	previous := []map[string]interface{}{
+		{"sku": "100", "title": "Bolt", "price": 10.0, "stock": 2},
+		{"sku": "200", "title": "Nut", "price": 5.0},
+	}
+	current := []map[string]interface{}{
+		{"sku": "100", "title": "Bolt", "price": 12.0},
+		{"sku": "300", "title": "Washer", "price": 3.0},
+	}
+
+	changes := Between(previous, current, "sku", at)
+	if changes.Timestamp != "2026-07-16T06:30:00+03:30" || changes.KeyField != "sku" || changes.TotalCount != 2 {
+		t.Fatalf("unexpected metadata: %#v", changes)
+	}
+	if len(changes.Added) != 1 || changes.Added[0]["sku"] != "300" {
+		t.Fatalf("unexpected added rows: %#v", changes.Added)
+	}
+	if !reflect.DeepEqual(changes.Deleted, []string{"200"}) {
+		t.Fatalf("unexpected deleted keys: %#v", changes.Deleted)
+	}
+	if len(changes.Modified) != 1 {
+		t.Fatalf("unexpected modified rows: %#v", changes.Modified)
+	}
+	modified := changes.Modified[0]
+	if modified.Code != "100" || modified.Record["title"] != "Bolt" || modified.Record["price"] != 12.0 {
+		t.Fatalf("modified record does not preserve the complete new row: %#v", modified)
+	}
+	if !reflect.DeepEqual(modified.ChangedFields, []string{"price", "stock"}) {
+		t.Fatalf("changed fields should be sorted and include removed fields: %#v", modified.ChangedFields)
+	}
+	if modified.OldValues["price"] != 10.0 || modified.NewValues["price"] != 12.0 || modified.NewValues["stock"] != nil {
+		t.Fatalf("unexpected field values: old=%#v new=%#v", modified.OldValues, modified.NewValues)
+	}
+}
+
+func TestBetweenInitialSnapshotCopiesRowsWithoutMutatingInputs(t *testing.T) {
+	current := []map[string]interface{}{{"Code": "100", "Name": "Original"}}
+	changes := Between(nil, current, "", time.Time{})
+	if len(changes.Added) != 1 || changes.KeyField != "Code" {
+		t.Fatalf("unexpected initial changes: %#v", changes)
+	}
+	changes.Added[0]["Name"] = "Changed"
+	if current[0]["Name"] != "Original" {
+		t.Fatal("Between mutated the caller's current snapshot")
+	}
+	if changes.Empty() {
+		t.Fatal("initial snapshot must not be empty")
+	}
+}
+
+func TestBetweenIsStableAndDoesNotMutateInputs(t *testing.T) {
+	previous := []map[string]interface{}{
+		{"Code": "2", "z": 1, "a": 1},
+		{"Code": "1", "value": "deleted"},
+	}
+	current := []map[string]interface{}{
+		{"Code": "2", "z": 2, "a": 2},
+		{"Code": "3", "value": "added"},
+	}
+	previousCopy := []map[string]interface{}{
+		{"Code": "2", "z": 1, "a": 1},
+		{"Code": "1", "value": "deleted"},
+	}
+	currentCopy := []map[string]interface{}{
+		{"Code": "2", "z": 2, "a": 2},
+		{"Code": "3", "value": "added"},
+	}
+
+	changes := Between(previous, current, "Code", time.Unix(1, 0))
+	if !reflect.DeepEqual(changes.Modified[0].ChangedFields, []string{"a", "z"}) {
+		t.Fatalf("changed fields are not deterministic: %#v", changes.Modified[0].ChangedFields)
+	}
+	if !reflect.DeepEqual(previous, previousCopy) || !reflect.DeepEqual(current, currentCopy) {
+		t.Fatal("Between mutated an input snapshot")
+	}
+	added, modified, deleted := changes.Counts()
+	if added != 1 || modified != 1 || deleted != 1 {
+		t.Fatalf("unexpected counts: %d %d %d", added, modified, deleted)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,6 +26,7 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/notifier"
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
+	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
 	"github.com/atomicdeploy/patris-export/pkg/recordsink"
@@ -73,24 +73,10 @@ type Options struct {
 	Version version.Info
 }
 
-// RecordChange represents a change to a specific record
-type RecordChange struct {
-	Code          string                 `json:"code"`
-	ChangeType    string                 `json:"change_type"` // "added", "deleted", "modified"
-	OldValues     map[string]interface{} `json:"old_values,omitempty"`
-	NewValues     map[string]interface{} `json:"new_values,omitempty"`
-	ChangedFields []string               `json:"changed_fields,omitempty"`
-}
-
-// ChangeSet represents incremental changes to the database
-type ChangeSet struct {
-	Type       string                   `json:"type"`
-	Timestamp  string                   `json:"timestamp"`
-	Added      []map[string]interface{} `json:"added,omitempty"`
-	Deleted    []string                 `json:"deleted,omitempty"`
-	Modified   []RecordChange           `json:"modified,omitempty"`
-	TotalCount int                      `json:"total_count"`
-}
+// Compatibility aliases keep the existing server API while sharing one diff
+// implementation with CLI watch-mode webhooks.
+type RecordChange = recorddiff.RecordChange
+type ChangeSet = recorddiff.ChangeSet
 
 // ToastRequest represents a desktop/browser notification request.
 type ToastRequest struct {
@@ -1239,25 +1225,14 @@ func (s *Server) broadcastUpdate() {
 
 	// Compute changes
 	s.lastRecordsMu.Lock()
-	changes := s.computeChangesByKey(records, result.KeyField)
+	changeSet := s.computeChangeSetByKey(records, result.KeyField)
 	s.lastRecords = records
 	s.lastRecordsMu.Unlock()
-	changes["raw"] = result.Raw
-	changes["key_field"] = result.KeyField
+	changeSet.Raw = result.Raw
+	changes := changeSet.Map()
 
 	// Log what we're sending
-	added := 0
-	deleted := 0
-	modified := 0
-	if a, ok := changes["added"].([]map[string]interface{}); ok {
-		added = len(a)
-	}
-	if d, ok := changes["deleted"].([]string); ok {
-		deleted = len(d)
-	}
-	if m, ok := changes["modified"].([]RecordChange); ok {
-		modified = len(m)
-	}
+	added, modified, deleted := changeSet.Counts()
 	log.Printf("📊 Broadcasting: %d added, %d modified, %d deleted", added, modified, deleted)
 
 	// Broadcast to all clients
@@ -1279,11 +1254,11 @@ func (s *Server) broadcastUpdate() {
 		s.notifyConfigured("row_updated", "Patris rows changed", s.rowChangeMessage(added, modified, deleted, changes))
 		s.dispatchUpdateEvent(updateout.Event{
 			Type:      "update",
-			Timestamp: fmt.Sprintf("%v", changes["timestamp"]),
+			Timestamp: changeSet.Timestamp,
 			Source:    s.currentDBPath(),
 			Raw:       result.Raw,
 			Records:   records,
-			Changes:   changes,
+			Changes:   &changeSet,
 			KeyField:  result.KeyField,
 		})
 	}
@@ -1834,121 +1809,16 @@ func (s *Server) computeChanges(newRecords []map[string]interface{}) map[string]
 }
 
 func (s *Server) computeChangesByKey(newRecords []map[string]interface{}, keyField string) map[string]interface{} {
-	if strings.TrimSpace(keyField) == "" {
-		keyField = "Code"
-	}
-	changes := map[string]interface{}{
-		"type":        "update",
-		"timestamp":   time.Now().Format(time.RFC3339),
-		"total_count": len(newRecords),
-		"key_field":   keyField,
-	}
+	return s.computeChangeSetByKey(newRecords, keyField).Map()
+}
 
-	// If no previous records, all are new
+func (s *Server) computeChangeSetByKey(newRecords []map[string]interface{}, keyField string) recorddiff.ChangeSet {
+	changes := recorddiff.Between(s.lastRecords, newRecords, keyField, time.Now())
 	if len(s.lastRecords) == 0 {
-		changes["added"] = newRecords
 		log.Printf("🆕 First load: all %d records are new", len(newRecords))
 		return changes
 	}
-
-	// Create maps by Code for efficient lookup
-	oldMap := make(map[string]map[string]interface{})
-	for _, record := range s.lastRecords {
-		if code, ok := record[keyField]; ok {
-			codeStr := fmt.Sprintf("%v", code)
-			oldMap[codeStr] = record
-		}
-	}
-
-	newMap := make(map[string]map[string]interface{})
-	for _, record := range newRecords {
-		if code, ok := record[keyField]; ok {
-			codeStr := fmt.Sprintf("%v", code)
-			newMap[codeStr] = record
-		}
-	}
-
-	added := []map[string]interface{}{}
-	deleted := []string{}
-	modified := []RecordChange{}
-
-	// Find added records
-	for code, record := range newMap {
-		if _, exists := oldMap[code]; !exists {
-			added = append(added, record)
-		}
-	}
-
-	// Find deleted records
-	for code := range oldMap {
-		if _, exists := newMap[code]; !exists {
-			deleted = append(deleted, code)
-		}
-	}
-
-	// Find modified records (records that exist in both but have different values)
-	for code, newRecord := range newMap {
-		if oldRecord, exists := oldMap[code]; exists {
-			changedFields := []string{}
-			oldValues := make(map[string]interface{})
-			newValues := make(map[string]interface{})
-
-			// Compare each field
-			for key, newVal := range newRecord {
-				if key == keyField {
-					continue // Skip the key field
-				}
-				oldVal, hasOldVal := oldRecord[key]
-
-				// Check if values differ
-				if !hasOldVal || !reflect.DeepEqual(oldVal, newVal) {
-					changedFields = append(changedFields, key)
-					if hasOldVal {
-						oldValues[key] = oldVal
-					} else {
-						oldValues[key] = nil
-					}
-					newValues[key] = newVal
-				}
-			}
-
-			// Check for fields that existed in old but not in new
-			for key, oldVal := range oldRecord {
-				if key == keyField {
-					continue
-				}
-				if _, exists := newRecord[key]; !exists {
-					changedFields = append(changedFields, key)
-					oldValues[key] = oldVal
-					newValues[key] = nil
-				}
-			}
-
-			if len(changedFields) > 0 {
-				modified = append(modified, RecordChange{
-					Code:          code,
-					ChangeType:    "modified",
-					OldValues:     oldValues,
-					NewValues:     newValues,
-					ChangedFields: changedFields,
-				})
-			}
-		}
-	}
-
-	// Log detailed change information
-	s.logDetailedChanges(added, deleted, modified)
-
-	if len(added) > 0 {
-		changes["added"] = added
-	}
-	if len(deleted) > 0 {
-		changes["deleted"] = deleted
-	}
-	if len(modified) > 0 {
-		changes["modified"] = modified
-	}
-
+	s.logDetailedChanges(changes.Added, changes.Deleted, changes.Modified)
 	return changes
 }
 

--- a/pkg/updateout/updateout.go
+++ b/pkg/updateout/updateout.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 	"github.com/atomicdeploy/patris-export/pkg/recordsink"
 )
 
@@ -33,7 +34,7 @@ type Event struct {
 	Source    string                   `json:"source,omitempty"`
 	Raw       bool                     `json:"raw,omitempty"`
 	Records   []map[string]interface{} `json:"records,omitempty"`
-	Changes   map[string]interface{}   `json:"changes,omitempty"`
+	Changes   *recorddiff.ChangeSet    `json:"changes,omitempty"`
 	KeyField  string                   `json:"key_field,omitempty"`
 }
 
@@ -159,7 +160,7 @@ func encode(cfg Config, event Event) ([]byte, string, error) {
 	if cfg.Format == "csv" {
 		rows := event.Records
 		if len(rows) == 0 && event.Changes != nil {
-			rows = rowsFromChanges(event.Changes)
+			rows = rowsFromChanges(event.Changes, event.KeyField)
 		}
 		data, err := recordsink.CSVBytes(rows, event.KeyField)
 		return data, "text/csv; charset=utf-8", err
@@ -171,19 +172,50 @@ func encode(cfg Config, event Event) ([]byte, string, error) {
 	return append(data, '\n'), "application/json; charset=utf-8", nil
 }
 
-func rowsFromChanges(changes map[string]interface{}) []map[string]interface{} {
-	rows := []map[string]interface{}{}
-	if added, ok := changes["added"].([]map[string]interface{}); ok {
-		rows = append(rows, added...)
+func rowsFromChanges(changes *recorddiff.ChangeSet, keyField string) []map[string]interface{} {
+	if changes == nil {
+		return nil
 	}
-	if modified, ok := changes["modified"].([]interface{}); ok {
-		for _, item := range modified {
-			if m, ok := item.(map[string]interface{}); ok {
-				if values, ok := m["new_values"].(map[string]interface{}); ok {
-					rows = append(rows, values)
-				}
-			}
+	if strings.TrimSpace(keyField) == "" {
+		keyField = changes.KeyField
+	}
+	if strings.TrimSpace(keyField) == "" {
+		keyField = "Code"
+	}
+
+	rows := []map[string]interface{}{}
+	for _, added := range changes.Added {
+		row := copyRow(added)
+		row["_change_type"] = "added"
+		rows = append(rows, row)
+	}
+	for _, modified := range changes.Modified {
+		row := copyRow(modified.Record)
+		if len(row) == 0 {
+			row = copyRow(modified.NewValues)
 		}
+		if _, exists := row[keyField]; !exists {
+			row[keyField] = modified.Code
+		}
+		row["_change_type"] = "modified"
+		if len(modified.ChangedFields) > 0 {
+			row["_changed_fields"] = strings.Join(modified.ChangedFields, ",")
+		}
+		rows = append(rows, row)
+	}
+	for _, deleted := range changes.Deleted {
+		rows = append(rows, map[string]interface{}{
+			keyField:       deleted,
+			"_change_type": "deleted",
+		})
 	}
 	return rows
+}
+
+func copyRow(row map[string]interface{}) map[string]interface{} {
+	copy := make(map[string]interface{}, len(row)+2)
+	for key, value := range row {
+		copy[key] = value
+	}
+	return copy
 }

--- a/pkg/updateout/updateout_test.go
+++ b/pkg/updateout/updateout_test.go
@@ -1,8 +1,16 @@
 package updateout
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 )
 
 func TestEncodeCSVFullPayload(t *testing.T) {
@@ -29,4 +37,191 @@ func TestNormalizeDefaults(t *testing.T) {
 	if cfg.Method != "POST" || cfg.Format != "json" || cfg.Mode != "changes" || cfg.Timeout != "10s" {
 		t.Fatalf("unexpected defaults: %#v", cfg)
 	}
+}
+
+func TestEncodeJSONChangesKeepsChangeSetAndDropsFullRecords(t *testing.T) {
+	changes := recorddiff.ChangeSet{
+		Type:       "update",
+		Timestamp:  "2026-07-16T06:30:00+03:30",
+		KeyField:   "sku",
+		TotalCount: 2,
+		Added:      []map[string]interface{}{{"sku": "200", "title": "Nut"}},
+	}
+	body, contentType, err := encode(Config{Format: "json", Mode: "changes"}, Event{
+		Type:     "update",
+		Records:  []map[string]interface{}{{"sku": "100", "title": "Bolt"}},
+		Changes:  &changes,
+		KeyField: "sku",
+	})
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("expected JSON content type, got %q", contentType)
+	}
+	var envelope map[string]interface{}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, exists := envelope["records"]; exists {
+		t.Fatalf("change mode must omit the full records payload: %s", body)
+	}
+	encodedChanges, ok := envelope["changes"].(map[string]interface{})
+	if !ok || len(encodedChanges["added"].([]interface{})) != 1 {
+		t.Fatalf("expected a non-empty changeset: %s", body)
+	}
+}
+
+func TestEncodeCSVChangesIncludesTypedModifiedRowsAndDeletionTombstones(t *testing.T) {
+	changes := recorddiff.ChangeSet{
+		Type:       "update",
+		KeyField:   "sku",
+		TotalCount: 2,
+		Added:      []map[string]interface{}{{"sku": "300", "title": "Washer", "price": 3}},
+		Modified: []recorddiff.RecordChange{{
+			Code:          "100",
+			ChangeType:    "modified",
+			ChangedFields: []string{"price"},
+			NewValues:     map[string]interface{}{"price": 12},
+			Record:        map[string]interface{}{"sku": "100", "title": "Bolt", "price": 12},
+		}},
+		Deleted: []string{"200"},
+	}
+	body, _, err := encode(Config{Format: "csv", Mode: "changes"}, Event{
+		Type:     "update",
+		Changes:  &changes,
+		KeyField: "sku",
+	})
+	if err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	text := string(body)
+	for _, expected := range []string{"_change_type", "_changed_fields", "added", "modified", "deleted", "100", "200", "300", "Bolt", "price"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("CSV changes are missing %q:\n%s", expected, text)
+		}
+	}
+}
+
+func TestDispatchHTTPChangePayloadAndHeaders(t *testing.T) {
+	var method string
+	var eventHeader string
+	var sourceHeader string
+	var customHeader string
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		eventHeader = r.Header.Get("X-Patris-Event")
+		sourceHeader = r.Header.Get("X-Patris-Source")
+		customHeader = r.Header.Get("X-Integration-Test")
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	changes := recorddiff.ChangeSet{
+		Type:       "update",
+		Timestamp:  "2026-07-16T06:30:00+03:30",
+		KeyField:   "sku",
+		TotalCount: 1,
+		Modified: []recorddiff.RecordChange{{
+			Code:          "100",
+			ChangeType:    "modified",
+			ChangedFields: []string{"price"},
+			NewValues:     map[string]interface{}{"price": 12},
+			Record:        map[string]interface{}{"sku": "100", "title": "Bolt", "price": 12},
+		}},
+	}
+	err := Dispatch(t.Context(), Config{
+		Enabled: true,
+		URL:     server.URL,
+		Method:  http.MethodPut,
+		Format:  "json",
+		Mode:    "changes",
+		Headers: map[string]string{"X-Integration-Test": "yes"},
+	}, Event{
+		Type:      "update",
+		Timestamp: changes.Timestamp,
+		Source:    "kala.db",
+		Records:   []map[string]interface{}{{"sku": "100", "price": 12}},
+		Changes:   &changes,
+		KeyField:  "sku",
+	})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if method != http.MethodPut || eventHeader != "update" || sourceHeader != "kala.db" || customHeader != "yes" {
+		t.Fatalf("unexpected request metadata: method=%q event=%q source=%q custom=%q", method, eventHeader, sourceHeader, customHeader)
+	}
+	if !strings.Contains(string(body), `"modified"`) || !strings.Contains(string(body), `"sku": "100"`) {
+		t.Fatalf("HTTP body did not contain the typed changeset: %s", body)
+	}
+	if strings.Contains(string(body), `"records"`) {
+		t.Fatalf("change-mode HTTP body included the full records snapshot: %s", body)
+	}
+}
+
+func TestDispatchHTTPReportsNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	err := Dispatch(t.Context(), Config{Enabled: true, URL: server.URL}, Event{Type: "update"})
+	if err == nil || !strings.Contains(err.Error(), "503 Service Unavailable") {
+		t.Fatalf("expected non-2xx error, got %v", err)
+	}
+}
+
+func TestDispatchCommandReceivesChangePayloadAndMetadata(t *testing.T) {
+	t.Setenv("GO_WANT_UPDATEOUT_HELPER", "1")
+	output := filepath.Join(t.TempDir(), "payload.json")
+	t.Setenv("UPDATEOUT_HELPER_FILE", output)
+
+	changes := recorddiff.ChangeSet{
+		Type:       "update",
+		Timestamp:  "2026-07-16T06:30:00+03:30",
+		KeyField:   "sku",
+		TotalCount: 1,
+		Added:      []map[string]interface{}{{"sku": "100", "title": "Bolt"}},
+	}
+	err := Dispatch(t.Context(), Config{
+		Enabled: true,
+		Command: []string{os.Args[0], "-test.run=TestUpdateoutHelperProcess", "--"},
+		Format:  "json",
+		Mode:    "changes",
+	}, Event{
+		Type:      "update",
+		Timestamp: changes.Timestamp,
+		Source:    "kala.db",
+		Changes:   &changes,
+		KeyField:  "sku",
+	})
+	if err != nil {
+		t.Fatalf("command dispatch failed: %v", err)
+	}
+	body, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read helper payload: %v", err)
+	}
+	if !strings.Contains(string(body), `"added"`) || !strings.Contains(string(body), `"100"`) {
+		t.Fatalf("command received an incomplete payload: %s", body)
+	}
+}
+
+func TestUpdateoutHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_UPDATEOUT_HELPER") != "1" {
+		return
+	}
+	payload, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(2)
+	}
+	if os.Getenv("PATRIS_EXPORT_EVENT_TYPE") != "update" || os.Getenv("PATRIS_EXPORT_EVENT_KEY_FIELD") != "sku" {
+		os.Exit(3)
+	}
+	if err := os.WriteFile(os.Getenv("UPDATEOUT_HELPER_FILE"), payload, 0o600); err != nil {
+		os.Exit(4)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
## Summary

- fixes CLI watch-mode `changes` delivery so update events contain an actionable added/modified/deleted changeset instead of an empty envelope
- extracts key-aware record comparison into `pkg/recorddiff` and reuses it from both CLI watch mode and the WebSocket server
- includes the complete transformed row on modified records so remote consumers can upsert without reconstructing unchanged fields
- makes CSV change delivery explicit with `_change_type`, `_changed_fields`, and deletion tombstones
- documents the JSON/CSV change contract

## Root cause

The CLI watch callback always passed `changes=nil`. The outbound encoder correctly removes `records` for non-initial events in `changes` mode, leaving no usable payload. CSV had an additional type mismatch: it expected generic modified maps while the server supplied typed record changes, so modified rows were silently skipped.

## Compatibility

Existing WebSocket fields (`code`, `change_type`, `old_values`, `new_values`, and `changed_fields`) are preserved. The new `record` field is additive and carries the complete transformed current row. Custom mapped key fields remain supported.

## Validation

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 go test ./...`
- `git diff --check`
- regression coverage for CLI initial/update state, custom keys, add/modify/delete, removed fields, HTTP methods and headers, non-2xx responses, command stdin delivery, JSON changes, and typed CSV changes

Fixes #23
