### PR TITLE
fix(web): clear dependency audit and gate CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y pxlib-dev pxlib1
     
-    - name: Build web frontend
+    - name: Install and audit web dependencies
       run: |
         cd web
-        npm install
+        npm clean-install
+        npm audit --audit-level=high
+
+    - name: Test and build web frontend
+      run: |
+        cd web
+        npm test
         npm run build
         
     - name: Run tests

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },
@@ -931,9 +931,9 @@
       "optional": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- refresh only the vulnerable transitive web build dependencies in `package-lock.json`
  - `immutable`: 5.1.4 -> 5.1.9
  - `picomatch`: 2.3.1 -> 2.3.2
- make CI install from the committed lockfile with `npm clean-install`
- fail CI on high-severity npm audit findings
- run the existing web tests before producing embedded frontend assets

No runtime feature or UI behavior changes are included.

## Verification

- `npm clean-install` — pass
- `npm audit --audit-level=high` — pass, 0 vulnerabilities
- `npm test` — pass, 2/2
- `npm run build` — pass
- `scripts/windows/Invoke-CGO.ps1 go test ./web ./pkg/server` — pass
- `git diff --check` — pass

Closes #141