### PR TITLE
Batch-prefetch Digitalogic pricing assignments

### DIFF
--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -86,7 +86,10 @@ stores results in the existing assignment LRU. It does not create a second
 pricing client or transformation path. With the default `batch_size: 500` and
 `max_entries: 2048`, a cold 1,002-Code catalog performs exactly three batch
 POSTs plus one catalog GET, and performs zero single-Code requests. Duplicate
-source Codes remain quarantined before prefetch.
+source Codes remain quarantined before prefetch. Batch successes consume the
+minimal assignment projection and preserve the exact decimal together with its
+`profit_percent_source`. A `global_default` value must exactly match the one
+shared default snapshot; inconsistent source/value pairs fail closed.
 
 Live outbound delivery to the current Digitalogic `/patris/push` receiver must
 remain disabled; this branch does not enable or deploy it. That receiver must first
@@ -107,8 +110,7 @@ stored in the Patris config:
       "mode": "digitalogic",
       "digitalogic": {
         "base_url": "https://digitalogic.ir/wp-json/digitalogic/v1",
-        "username_env": "DIGITALOGIC_CONSUMER_KEY",
-        "password_env": "DIGITALOGIC_CONSUMER_SECRET",
+        "bearer_token_env": "DIGITALOGIC_PRICING_READ_TOKEN",
         "batch_assignment_path": "pricing-assignments/batch",
         "batch_size": 500,
         "fresh_for": "5m",
@@ -124,18 +126,20 @@ stored in the Patris config:
 ```
 
 ```powershell
-$env:DIGITALOGIC_CONSUMER_KEY = "ck_..."
-$env:DIGITALOGIC_CONSUMER_SECRET = "cs_..."
+$env:DIGITALOGIC_PRICING_READ_TOKEN = "..."
 patris-export serve C:\Patris\data4\kala.db
 ```
 
 Only HTTPS is accepted remotely; plain HTTP is limited to loopback. Provider
 paths must stay relative and on the configured origin, redirects are refused,
-request/response bodies and the per-Code LRU are bounded, configured credential
-environment variables must be populated, and cached values are usable only
-inside `max_stale`. The batch POST reuses the same Basic or Bearer auth path,
-HTTP client, timeout, TLS rules, redirect policy, and response limit as catalog
-and single-Code reads.
+request/response bodies, assignment LRU, and diagnostic LRU are bounded,
+configured credential environment variables must be populated, and cached
+values are usable only inside `max_stale`. One `bearer_token_env` supplies the
+same read token to the exact integration-catalog GET and assignment-batch POST;
+the batch request otherwise reuses the existing HTTP client, timeout, TLS
+rules, redirect policy, and response limit. Basic authentication and the
+single-Code route remain compatibility options for replaceable older providers,
+not the production least-privilege path.
 
 HTTP 404, 405, or 501 from the batch route means a replaceable/older provider
 does not support prefetch; Patris safely falls back to existing bounded
@@ -144,17 +148,20 @@ Authentication failures, other HTTP/transport failures, oversized responses,
 malformed schemas, changed result order/Codes, and inconsistent result counts
 fail closed for that freshness window. Typed not-found and ambiguous-Code
 results are cached as authoritative empty assignments, never retried through a
-different lookup path. Cached stale assignments may still be used only within
-`max_stale`, with explicit warnings. Static/standalone mode implements no
-prefetch capability and makes no remote requests.
+different lookup path. Only a per-Code server error explicitly marked
+`retryable: true` with a 5xx status may fall back to the existing single-Code
+resolver. Cached stale assignments may still be used only within `max_stale`,
+with explicit warnings; recent catalog failures are also backed off for the
+freshness window so an outage cannot recreate an N+1 catalog storm.
+Static/standalone mode implements no prefetch capability and makes no remote
+requests.
 
-Digitalogic currently gates the batch route through its existing read scope:
-`manage_woocommerce` or an exact boolean grant from
-`digitalogic_rest_api_permission` for `scope=read`. Do not reuse Patris push or
-product-sync write secrets. Deployments that need a least-privilege machine
-identity should add a separate header-only credential scoped to this read route
-before enabling production prefetch, then reference it through
-`bearer_token_env`.
+Digitalogic's dedicated pricing-input bearer credential authorizes exactly the
+integration-catalog GET and assignment-batch POST. It does not authorize the
+legacy single-Code route or any write route. Do not reuse Patris push or
+product-sync write secrets. Deploy the compatible Digitalogic endpoint and its
+read credential before enabling production prefetch, then reference that one
+credential through `bearer_token_env`.
 
 Patris calculates only when the catalog is
 `digitalogic.integration-catalog` major version 1, `currency.local` is `IRT`,

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -156,12 +156,13 @@ freshness window so an outage cannot recreate an N+1 catalog storm.
 Static/standalone mode implements no prefetch capability and makes no remote
 requests.
 
-Digitalogic's dedicated pricing-input bearer credential authorizes exactly the
-integration-catalog GET and assignment-batch POST. It does not authorize the
-legacy single-Code route or any write route. Do not reuse Patris push or
-product-sync write secrets. Deploy the compatible Digitalogic endpoint and its
-read credential before enabling production prefetch, then reference that one
-credential through `bearer_token_env`.
+Production rollout depends on the pending Digitalogic least-privilege
+credential work in issue #60. Once implemented and deployed, its dedicated
+pricing-input bearer must authorize exactly the integration-catalog GET and
+assignment-batch POST, not the legacy single-Code route or any write route. Do
+not reuse Patris push or product-sync write secrets. Deploy the compatible
+Digitalogic endpoint and that read credential before enabling production
+prefetch, then reference the one credential through `bearer_token_env`.
 
 Patris calculates only when the catalog is
 `digitalogic.integration-catalog` major version 1, `currency.local` is `IRT`,

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -74,8 +74,19 @@ Digitalogic mode reads, but does not mutate:
 
 - `GET /wp-json/digitalogic/v1/integration/catalog` for FX, selected
   warehouses, and freight methods;
+- `POST /wp-json/digitalogic/v1/pricing-assignments/batch` for ordered,
+  versioned assignment prefetches of at most 500 unique Codes;
 - `GET /wp-json/digitalogic/v1/products/by-code/{code}/import-pricing` for the
-  exact Code/SKU method and percentage markup.
+  exact Code/SKU method and percentage markup when an older compatible provider
+  does not expose the batch contract.
+
+Canonical transform collects unique, non-quarantined Codes before its normal
+per-record resolution, prefetches them in bounded request-order chunks, and
+stores results in the existing assignment LRU. It does not create a second
+pricing client or transformation path. With the default `batch_size: 500` and
+`max_entries: 2048`, a cold 1,002-Code catalog performs exactly three batch
+POSTs plus one catalog GET, and performs zero single-Code requests. Duplicate
+source Codes remain quarantined before prefetch.
 
 Live outbound delivery to the current Digitalogic `/patris/push` receiver must
 remain disabled; this branch does not enable or deploy it. That receiver must first
@@ -98,11 +109,13 @@ stored in the Patris config:
         "base_url": "https://digitalogic.ir/wp-json/digitalogic/v1",
         "username_env": "DIGITALOGIC_CONSUMER_KEY",
         "password_env": "DIGITALOGIC_CONSUMER_SECRET",
+        "batch_assignment_path": "pricing-assignments/batch",
+        "batch_size": 500,
         "fresh_for": "5m",
         "max_stale": "1h",
         "timeout": "5s",
-        "max_entries": 1000,
-		"max_concurrency": 8,
+        "max_entries": 2048,
+        "max_concurrency": 8,
         "max_response_bytes": 2097152
       }
     }
@@ -118,9 +131,30 @@ patris-export serve C:\Patris\data4\kala.db
 
 Only HTTPS is accepted remotely; plain HTTP is limited to loopback. Provider
 paths must stay relative and on the configured origin, redirects are refused,
-responses and the per-Code LRU are bounded, and cached values are usable only
-inside `max_stale`. Patris continues emitting canonical rows with null pricing
-and warnings when the provider is unavailable.
+request/response bodies and the per-Code LRU are bounded, configured credential
+environment variables must be populated, and cached values are usable only
+inside `max_stale`. The batch POST reuses the same Basic or Bearer auth path,
+HTTP client, timeout, TLS rules, redirect policy, and response limit as catalog
+and single-Code reads.
+
+HTTP 404, 405, or 501 from the batch route means a replaceable/older provider
+does not support prefetch; Patris safely falls back to existing bounded
+single-Code resolution and emits `pricing_assignment_batch_unsupported`.
+Authentication failures, other HTTP/transport failures, oversized responses,
+malformed schemas, changed result order/Codes, and inconsistent result counts
+fail closed for that freshness window. Typed not-found and ambiguous-Code
+results are cached as authoritative empty assignments, never retried through a
+different lookup path. Cached stale assignments may still be used only within
+`max_stale`, with explicit warnings. Static/standalone mode implements no
+prefetch capability and makes no remote requests.
+
+Digitalogic currently gates the batch route through its existing read scope:
+`manage_woocommerce` or an exact boolean grant from
+`digitalogic_rest_api_permission` for `scope=read`. Do not reuse Patris push or
+product-sync write secrets. Deployments that need a least-privilege machine
+identity should add a separate header-only credential scoped to this read route
+before enabling production prefetch, then reference it through
+`bearer_token_env`.
 
 Patris calculates only when the catalog is
 `digitalogic.integration-catalog` major version 1, `currency.local` is `IRT`,

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -82,14 +82,25 @@ Digitalogic mode reads, but does not mutate:
 
 Canonical transform collects unique, non-quarantined Codes before its normal
 per-record resolution, prefetches them in bounded request-order chunks, and
-stores results in the existing assignment LRU. It does not create a second
-pricing client or transformation path. With the default `batch_size: 500` and
-`max_entries: 2048`, a cold 1,002-Code catalog performs exactly three batch
-POSTs plus one catalog GET, and performs zero single-Code requests. Duplicate
-source Codes remain quarantined before prefetch. Batch successes consume the
-minimal assignment projection and preserve the exact decimal together with its
-`profit_percent_source`. A `global_default` value must exactly match the one
-shared default snapshot; inconsistent source/value pairs fail closed.
+stores results in the existing bounded assignment LRU. A transform-scoped
+result barrier also retains only that run's unique Codes and releases each
+outcome as the row resolves, so a deliberately small `max_entries` cannot evict
+current-run successes or diagnostics and recreate single-Code N+1 requests. It
+does not create a second pricing client or transformation path. With the
+default `batch_size: 500` and `max_entries: 2048`, a cold 1,002-Code catalog
+performs exactly three batch POSTs plus one catalog GET, and performs zero
+single-Code requests. Duplicate source Codes remain quarantined before
+prefetch.
+
+All chunks are staged before one atomic cache commit. Every chunk must carry
+the same non-empty default-markup revision and the same schema, configured
+state, source, type, and exact value; a mismatch discards every staged result.
+Batch successes consume the minimal assignment projection and preserve the
+exact decimal together with its `profit_percent_source`. Pricing decimals must
+be quoted, canonical base-10 strings with at most 12 fractional digits;
+unquoted numbers, exponent notation, redundant formatting, and over-scale
+values fail closed. A `global_default` value must exactly match the shared
+default snapshot.
 
 Live outbound delivery to the current Digitalogic `/patris/push` receiver must
 remain disabled; this branch does not enable or deploy it. That receiver must first
@@ -146,13 +157,16 @@ does not support prefetch; Patris safely falls back to existing bounded
 single-Code resolution and emits `pricing_assignment_batch_unsupported`.
 Authentication failures, other HTTP/transport failures, oversized responses,
 malformed schemas, changed result order/Codes, and inconsistent result counts
-fail closed for that freshness window. Typed not-found and ambiguous-Code
-results are cached as authoritative empty assignments, never retried through a
-different lookup path. Only a per-Code server error explicitly marked
-`retryable: true` with a 5xx status may fall back to the existing single-Code
-resolver. Cached stale assignments may still be used only within `max_stale`,
-with explicit warnings; recent catalog failures are also backed off for the
-freshness window so an outage cannot recreate an N+1 catalog storm.
+fail closed for that freshness window. Fresh fail-closed diagnostics are
+honored by later prefetch runs, including when the per-Code diagnostic LRU is
+smaller than a transform, so repeated transforms do not hammer a failing batch
+route. Typed not-found and ambiguous-Code results are cached as authoritative
+empty assignments, never retried through a different lookup path. Only a
+per-Code server error explicitly marked `retryable: true` with a 5xx status may
+fall back to the existing single-Code resolver. Cached stale assignments may
+still be used only within `max_stale`, with explicit warnings; recent catalog
+failures are also backed off for the freshness window so an outage cannot
+recreate an N+1 catalog storm.
 Static/standalone mode implements no prefetch capability and makes no remote
 requests.
 

--- a/docs/WINDOWS_BUILD.md
+++ b/docs/WINDOWS_BUILD.md
@@ -24,7 +24,8 @@ The CI/CD builds in that repository produce Windows DLLs that can be used direct
 ### Prerequisites
 - CMake 3.12 or later
 - Visual Studio 2019 or later (or MinGW-w64)
-- Go 1.23 or later
+- Go 1.25 or later (Go's automatic toolchain selection can download the
+  required toolchain when `GOTOOLCHAIN=auto` is enabled)
 
 ### Build Steps
 

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -159,10 +159,12 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_URL", "https://digitalogic.example/wp-json/digitalogic/v1/")
 	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_USERNAME_ENV", "DIGITALOGIC_KEY")
 	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_PASSWORD_ENV", "DIGITALOGIC_SECRET")
+	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_BEARER_ENV", "DIGITALOGIC_PRICING_READ_TOKEN")
 	t.Setenv("PATRIS_EXPORT_PRICING_FRESH_FOR", "2m")
 	t.Setenv("PATRIS_EXPORT_PRICING_MAX_STALE", "30m")
 	t.Setenv("DIGITALOGIC_KEY", "must-not-be-copied")
 	t.Setenv("DIGITALOGIC_SECRET", "must-not-be-copied")
+	t.Setenv("DIGITALOGIC_PRICING_READ_TOKEN", "must-not-be-copied-bearer")
 
 	cfg := Default()
 	ApplyEnv(&cfg)
@@ -170,7 +172,7 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	if cfg.Canonical.Pricing.Mode != "digitalogic" || digitalogic.BaseURL != "https://digitalogic.example/wp-json/digitalogic/v1" {
 		t.Fatalf("Digitalogic pricing provider was not selected: %+v", cfg.Canonical.Pricing)
 	}
-	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" {
+	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.BearerTokenEnv != "DIGITALOGIC_PRICING_READ_TOKEN" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" {
 		t.Fatalf("Digitalogic provider environment references were not normalized: %+v", digitalogic)
 	}
 	encoded, err := json.Marshal(cfg)

--- a/pkg/canonical/canonical_test.go
+++ b/pkg/canonical/canonical_test.go
@@ -352,7 +352,7 @@ func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T)
 				"schema": "digitalogic.pricing-assignment-batch", "schema_version": "1.0.0",
 				"requested_count": len(request.Codes), "resolved_count": len(request.Codes), "error_count": 0, "maximum_codes": 500,
 				"default_percentage_markup": map[string]interface{}{
-					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "profit_percent": "30", "source": "global_default",
+					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "type": "percentage", "profit_percent": "30", "source": "global_default", "revision": "rev-30",
 				},
 				"results": results,
 			}})
@@ -367,7 +367,7 @@ func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T)
 	cfg.Pricing = pricingcatalog.Config{
 		Mode: pricingcatalog.ModeDigitalogic,
 		Digitalogic: pricingcatalog.DigitalogicConfig{
-			BaseURL: server.URL, FreshFor: "1m", MaxStale: "1h",
+			BaseURL: server.URL, FreshFor: "1m", MaxStale: "1h", MaxEntries: 1,
 		},
 	}
 	rows := make([]map[string]interface{}, 1002)
@@ -379,6 +379,11 @@ func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T)
 	products, _ := Transform(context.Background(), rows, "kala.db", cfg, pricingcatalog.NewProvider(cfg.Pricing), time.Now())
 	if len(products) != len(rows) {
 		t.Fatalf("products = %d, want %d", len(products), len(rows))
+	}
+	for index, product := range products {
+		if got := product["import_freight_method_id"]; got != "air" {
+			t.Fatalf("product %d import_freight_method_id = %v, want air; scoped prefetch result was lost", index, got)
+		}
 	}
 	if got := atomic.LoadInt32(&catalogRequests); got != 1 {
 		t.Fatalf("catalog requests = %d, want 1", got)

--- a/pkg/canonical/canonical_test.go
+++ b/pkg/canonical/canonical_test.go
@@ -280,6 +280,10 @@ func TestDigitalogicProfileBoundsConcurrentAssignmentReads(t *testing.T) {
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":120}]}}`)
 			return
 		}
+		if r.URL.Path == "/pricing-assignments/batch" {
+			http.NotFound(w, r)
+			return
+		}
 		current := atomic.AddInt32(&active, 1)
 		for {
 			seen := atomic.LoadInt32(&maximum)
@@ -315,5 +319,74 @@ func TestDigitalogicProfileBoundsConcurrentAssignmentReads(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&maximum); got < 2 || got > 3 {
 		t.Fatalf("assignment concurrency = %d, want 2..3", got)
+	}
+}
+
+func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T) {
+	var catalogRequests int32
+	var batchRequests int32
+	var singleRequests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			atomic.AddInt32(&catalogRequests, 1)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":120}]}}`)
+		case "/pricing-assignments/batch":
+			atomic.AddInt32(&batchRequests, 1)
+			var request struct {
+				Codes []string `json:"codes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode batch request: %v", err)
+			}
+			results := make([]map[string]interface{}, 0, len(request.Codes))
+			for _, code := range request.Codes {
+				results = append(results, map[string]interface{}{
+					"code": code, "status": "ok", "assignment": map[string]interface{}{
+						"code": code, "import_freight_method_id": "air", "profit_percent": "30", "pricing_warnings": []string{},
+					},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "data": map[string]interface{}{
+				"schema": "digitalogic.pricing-assignment-batch", "schema_version": "1.0.0",
+				"requested_count": len(request.Codes), "resolved_count": len(request.Codes), "error_count": 0, "maximum_codes": 500,
+				"default_percentage_markup": map[string]interface{}{
+					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "profit_percent": "30",
+				},
+				"results": results,
+			}})
+		default:
+			atomic.AddInt32(&singleRequests, 1)
+			fmt.Fprint(w, `{"data":{"import_freight_method_id":"air","profit_percent":30}}`)
+		}
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig()
+	cfg.Pricing = pricingcatalog.Config{
+		Mode: pricingcatalog.ModeDigitalogic,
+		Digitalogic: pricingcatalog.DigitalogicConfig{
+			BaseURL: server.URL, FreshFor: "1m", MaxStale: "1h",
+		},
+	}
+	rows := make([]map[string]interface{}, 1002)
+	for index := range rows {
+		rows[index] = map[string]interface{}{
+			"Code": fmt.Sprintf("P-%04d", index), "Sharh1": "0 0 0 24.5", "Sharh2": "240 Ú¯Ø±Ù…", "ALLANBAR": 1,
+		}
+	}
+	products, _ := Transform(context.Background(), rows, "kala.db", cfg, pricingcatalog.NewProvider(cfg.Pricing), time.Now())
+	if len(products) != len(rows) {
+		t.Fatalf("products = %d, want %d", len(products), len(rows))
+	}
+	if got := atomic.LoadInt32(&catalogRequests); got != 1 {
+		t.Fatalf("catalog requests = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&batchRequests); got != 3 {
+		t.Fatalf("batch requests = %d, want exactly 3 for 1,002 Codes at 500/request", got)
+	}
+	if got := atomic.LoadInt32(&singleRequests); got != 0 {
+		t.Fatalf("single-Code requests = %d, want 0", got)
 	}
 }

--- a/pkg/canonical/canonical_test.go
+++ b/pkg/canonical/canonical_test.go
@@ -344,7 +344,7 @@ func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T)
 			for _, code := range request.Codes {
 				results = append(results, map[string]interface{}{
 					"code": code, "status": "ok", "assignment": map[string]interface{}{
-						"code": code, "import_freight_method_id": "air", "profit_percent": "30", "pricing_warnings": []string{},
+						"code": code, "import_freight_method_id": "air", "profit_percent": "30", "profit_percent_source": "global_default", "pricing_warnings": []string{},
 					},
 				})
 			}
@@ -352,7 +352,7 @@ func TestDigitalogicProfilePrefetches1002CodesInThreeBatchRequests(t *testing.T)
 				"schema": "digitalogic.pricing-assignment-batch", "schema_version": "1.0.0",
 				"requested_count": len(request.Codes), "resolved_count": len(request.Codes), "error_count": 0, "maximum_codes": 500,
 				"default_percentage_markup": map[string]interface{}{
-					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "profit_percent": "30",
+					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "profit_percent": "30", "source": "global_default",
 				},
 				"results": results,
 			}})

--- a/pkg/canonical/kala.go
+++ b/pkg/canonical/kala.go
@@ -89,7 +89,7 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 		for _, index := range eligible {
 			codes = append(codes, codeString(firstValue(rows[index], "product_code", "code", "Code")))
 		}
-		prefetcher.Prefetch(ctx, codes)
+		provider = prefetcher.Prefetch(ctx, codes)
 	}
 	parsedProducts := make([]Product, len(rows))
 	workers := 1

--- a/pkg/canonical/kala.go
+++ b/pkg/canonical/kala.go
@@ -84,6 +84,13 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 			eligible = append(eligible, index)
 		}
 	}
+	if prefetcher, ok := provider.(pricingcatalog.Prefetcher); ok && len(eligible) > 0 {
+		codes := make([]string, 0, len(eligible))
+		for _, index := range eligible {
+			codes = append(codes, codeString(firstValue(rows[index], "product_code", "code", "Code")))
+		}
+		prefetcher.Prefetch(ctx, codes)
+	}
 	parsedProducts := make([]Product, len(rows))
 	workers := 1
 	normalizedPricing := pricingcatalog.Normalize(cfg.Pricing)

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -94,10 +94,11 @@ type Provider interface {
 }
 
 // Prefetcher is an optional provider capability used by canonical transforms.
-// Providers that do not implement it retain the existing per-record Resolve
-// behavior, which keeps static and independently replaceable providers simple.
+// It returns a transform-scoped Provider whose bounded result barrier protects
+// the current run from persistent-LRU eviction. Providers that do not implement
+// it retain per-record Resolve behavior, keeping static providers simple.
 type Prefetcher interface {
-	Prefetch(context.Context, []string)
+	Prefetch(context.Context, []string) Provider
 }
 
 func DefaultConfig() Config {

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -84,6 +84,7 @@ type Resolution struct {
 	MethodID              string
 	FreightCNYPerKg       *Decimal
 	MarkupPercent         *Decimal
+	MarkupPercentSource   string
 	IRTPerCNY             *Decimal
 	Warnings              []string
 }

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -232,12 +232,14 @@ func (p *staticProvider) Resolve(_ context.Context, code string) Resolution {
 }
 
 func finishResolution(value Resolution) Resolution {
+	value.MarkupPercentSource = strings.TrimSpace(value.MarkupPercentSource)
 	if !validPositive(value.FreightCNYPerKg) {
 		value.FreightCNYPerKg = nil
 		value.Warnings = append(value.Warnings, "freight_rate_missing")
 	}
 	if !validNonNegative(value.MarkupPercent) {
 		value.MarkupPercent = nil
+		value.MarkupPercentSource = ""
 		value.Warnings = append(value.Warnings, "markup_percent_missing")
 	}
 	if !validPositive(value.IRTPerCNY) {

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -18,9 +18,11 @@ const (
 	defaultFreshFor    = 5 * time.Minute
 	defaultMaxStale    = time.Hour
 	defaultTimeout     = 5 * time.Second
-	defaultMaxEntries  = 1000
+	defaultMaxEntries  = 2048
 	defaultMaxBytes    = int64(2 << 20)
 	defaultConcurrency = 8
+	defaultBatchSize   = 500
+	maximumBatchSize   = 500
 )
 
 // Config selects a replaceable pricing-catalog provider. Static is suitable
@@ -43,18 +45,20 @@ type StaticConfig struct {
 }
 
 type DigitalogicConfig struct {
-	BaseURL          string `json:"base_url,omitempty" yaml:"base_url,omitempty" toml:"base_url,omitempty"`
-	CatalogPath      string `json:"catalog_path,omitempty" yaml:"catalog_path,omitempty" toml:"catalog_path,omitempty"`
-	AssignmentPath   string `json:"assignment_path,omitempty" yaml:"assignment_path,omitempty" toml:"assignment_path,omitempty"`
-	UsernameEnv      string `json:"username_env,omitempty" yaml:"username_env,omitempty" toml:"username_env,omitempty"`
-	PasswordEnv      string `json:"password_env,omitempty" yaml:"password_env,omitempty" toml:"password_env,omitempty"`
-	BearerTokenEnv   string `json:"bearer_token_env,omitempty" yaml:"bearer_token_env,omitempty" toml:"bearer_token_env,omitempty"`
-	FreshFor         string `json:"fresh_for,omitempty" yaml:"fresh_for,omitempty" toml:"fresh_for,omitempty"`
-	MaxStale         string `json:"max_stale,omitempty" yaml:"max_stale,omitempty" toml:"max_stale,omitempty"`
-	Timeout          string `json:"timeout,omitempty" yaml:"timeout,omitempty" toml:"timeout,omitempty"`
-	MaxEntries       int    `json:"max_entries,omitempty" yaml:"max_entries,omitempty" toml:"max_entries,omitempty"`
-	MaxConcurrency   int    `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" toml:"max_concurrency,omitempty"`
-	MaxResponseBytes int64  `json:"max_response_bytes,omitempty" yaml:"max_response_bytes,omitempty" toml:"max_response_bytes,omitempty"`
+	BaseURL             string `json:"base_url,omitempty" yaml:"base_url,omitempty" toml:"base_url,omitempty"`
+	CatalogPath         string `json:"catalog_path,omitempty" yaml:"catalog_path,omitempty" toml:"catalog_path,omitempty"`
+	AssignmentPath      string `json:"assignment_path,omitempty" yaml:"assignment_path,omitempty" toml:"assignment_path,omitempty"`
+	BatchAssignmentPath string `json:"batch_assignment_path,omitempty" yaml:"batch_assignment_path,omitempty" toml:"batch_assignment_path,omitempty"`
+	BatchSize           int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
+	UsernameEnv         string `json:"username_env,omitempty" yaml:"username_env,omitempty" toml:"username_env,omitempty"`
+	PasswordEnv         string `json:"password_env,omitempty" yaml:"password_env,omitempty" toml:"password_env,omitempty"`
+	BearerTokenEnv      string `json:"bearer_token_env,omitempty" yaml:"bearer_token_env,omitempty" toml:"bearer_token_env,omitempty"`
+	FreshFor            string `json:"fresh_for,omitempty" yaml:"fresh_for,omitempty" toml:"fresh_for,omitempty"`
+	MaxStale            string `json:"max_stale,omitempty" yaml:"max_stale,omitempty" toml:"max_stale,omitempty"`
+	Timeout             string `json:"timeout,omitempty" yaml:"timeout,omitempty" toml:"timeout,omitempty"`
+	MaxEntries          int    `json:"max_entries,omitempty" yaml:"max_entries,omitempty" toml:"max_entries,omitempty"`
+	MaxConcurrency      int    `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" toml:"max_concurrency,omitempty"`
+	MaxResponseBytes    int64  `json:"max_response_bytes,omitempty" yaml:"max_response_bytes,omitempty" toml:"max_response_bytes,omitempty"`
 }
 
 type Method struct {
@@ -88,6 +92,13 @@ type Provider interface {
 	Resolve(context.Context, string) Resolution
 }
 
+// Prefetcher is an optional provider capability used by canonical transforms.
+// Providers that do not implement it retain the existing per-record Resolve
+// behavior, which keeps static and independently replaceable providers simple.
+type Prefetcher interface {
+	Prefetch(context.Context, []string)
+}
+
 func DefaultConfig() Config {
 	return Config{Mode: ModeStatic}
 }
@@ -113,6 +124,15 @@ func Normalize(cfg Config) Config {
 	}
 	if strings.TrimSpace(d.AssignmentPath) == "" {
 		d.AssignmentPath = "products/by-code/{code}/import-pricing"
+	}
+	if strings.TrimSpace(d.BatchAssignmentPath) == "" {
+		d.BatchAssignmentPath = "pricing-assignments/batch"
+	}
+	if d.BatchSize <= 0 {
+		d.BatchSize = defaultBatchSize
+	}
+	if d.BatchSize > maximumBatchSize {
+		d.BatchSize = maximumBatchSize
 	}
 	if parseDuration(d.FreshFor, 0) <= 0 {
 		d.FreshFor = defaultFreshFor.String()

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -56,6 +57,17 @@ func TestStaticProviderResolvesExactCodeAndDefaults(t *testing.T) {
 	for _, expected := range []string{"freight_rate_missing", "import_freight_method_missing", "markup_percent_missing"} {
 		if !strings.Contains(warnings, expected) {
 			t.Fatalf("missing warning %q in %v", expected, missing.Warnings)
+		}
+	}
+}
+
+func TestStaticAndDisabledProvidersDoNotExposeRemotePrefetch(t *testing.T) {
+	for name, provider := range map[string]Provider{
+		"static":   NewProvider(Config{Mode: ModeStatic}),
+		"disabled": NewProvider(Config{Mode: ModeNone}),
+	} {
+		if _, ok := provider.(Prefetcher); ok {
+			t.Fatalf("%s provider unexpectedly exposes a remote prefetch capability", name)
 		}
 	}
 }
@@ -175,6 +187,124 @@ func TestHTTPProviderBoundsAssignmentCache(t *testing.T) {
 	}
 }
 
+func TestHTTPProviderBatchPrefetchUsesGoldenContractAndSharedAuth(t *testing.T) {
+	fixture, err := os.ReadFile("../../testdata/digitalogic-pricing-assignment-batch-v1.golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var batchRequests, singleRequests int
+	var authHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air_express","price_per_kg_cny":120}]}}`)
+		case "/pricing-assignments/batch":
+			batchRequests++
+			fmt.Fprintf(w, `{"success":true,"data":%s}`, fixture)
+		default:
+			singleRequests++
+			fmt.Fprint(w, `{"data":{"code":"unexpected","import_freight_method_id":"air_express","profit_percent":"30"}}`)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("PATRIS_BATCH_TEST_TOKEN", "read-only-token")
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: server.URL, BearerTokenEnv: "PATRIS_BATCH_TEST_TOKEN", FreshFor: "1m", MaxStale: "1h",
+	}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"113007045", "MISSING"})
+	resolved := provider.Resolve(context.Background(), "113007045")
+	missing := provider.Resolve(context.Background(), "MISSING")
+
+	if batchRequests != 1 || singleRequests != 0 {
+		t.Fatalf("requests: batch=%d single=%d, want 1/0", batchRequests, singleRequests)
+	}
+	if resolved.MethodID != "air_express" || decimalText(resolved.MarkupPercent) != "30" || decimalText(resolved.FreightCNYPerKg) != "120" {
+		t.Fatalf("golden assignment did not resolve exactly: %+v", resolved)
+	}
+	if !contains(missing.Warnings, "product_pricing_assignment_not_found") {
+		t.Fatalf("typed not-found result was lost: %+v", missing)
+	}
+	for _, header := range authHeaders {
+		if header != "Bearer read-only-token" {
+			t.Fatalf("shared auth header = %q", header)
+		}
+	}
+}
+
+func TestHTTPProviderBatchUnsupportedFallsBackWithDiagnostic(t *testing.T) {
+	var singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			http.NotFound(w, r)
+		default:
+			singleRequests++
+			fmt.Fprint(w, `{"data":{"import_freight_method_id":"air","profit_percent":"0"}}`)
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"A"})
+	resolved := provider.Resolve(context.Background(), "A")
+	if singleRequests != 1 || !contains(resolved.Warnings, "pricing_assignment_batch_unsupported") {
+		t.Fatalf("unsupported batch fallback was not explicit and safe: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
+func TestHTTPProviderMalformedBatchFailsClosedWithoutSingleRequests(t *testing.T) {
+	var singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			fmt.Fprint(w, `{"data":{"schema":"wrong","schema_version":"1.0.0","results":[]}}`)
+		default:
+			singleRequests++
+			fmt.Fprint(w, `{"data":{"import_freight_method_id":"air","profit_percent":"0"}}`)
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"A"})
+	resolved := provider.Resolve(context.Background(), "A")
+	if singleRequests != 0 || !contains(resolved.Warnings, "pricing_assignment_batch_contract_invalid") {
+		t.Fatalf("malformed batch did not fail closed: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
+func TestHTTPProviderBatchAmbiguityIsAuthoritative(t *testing.T) {
+	var singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
+		case "/pricing-assignments/batch":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false},"results":[{"code":"COLLISION","status":"error","error":{"code":"digitalogic_product_code_ambiguous","http_status":409,"retryable":false}}]}}`)
+		default:
+			singleRequests++
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"COLLISION"})
+	resolved := provider.Resolve(context.Background(), "COLLISION")
+	if singleRequests != 0 || !contains(resolved.Warnings, "product_pricing_assignment_ambiguous") {
+		t.Fatalf("ambiguous Code was retried or lost: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
 func TestJoinURLRejectsOriginChangesAndAbsolutePaths(t *testing.T) {
 	base := "https://example.test/wp-json/digitalogic/v1"
 	for _, path := range []string{
@@ -202,10 +332,11 @@ func TestHTTPProviderRejectsUntrustedConfiguredPathsBeforeRequest(t *testing.T) 
 		"scheme relative catalog": {BaseURL: "https://example.test/wp-json/digitalogic/v1", CatalogPath: "//evil.test/catalog"},
 		"assignment without Code": {BaseURL: "https://example.test/wp-json/digitalogic/v1", AssignmentPath: "products/import-pricing"},
 		"absolute assignment":     {BaseURL: "https://example.test/wp-json/digitalogic/v1", AssignmentPath: "https://evil.test/{code}"},
+		"absolute batch":          {BaseURL: "https://example.test/wp-json/digitalogic/v1", BatchAssignmentPath: "https://evil.test/batch"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			resolution := newHTTPProvider(cfg, nil, time.Now).Resolve(context.Background(), "A")
-			if !contains(resolution.Warnings, "pricing_catalog_path_invalid") && !contains(resolution.Warnings, "pricing_assignment_path_invalid") {
+			if !contains(resolution.Warnings, "pricing_catalog_path_invalid") && !contains(resolution.Warnings, "pricing_assignment_path_invalid") && !contains(resolution.Warnings, "pricing_assignment_batch_path_invalid") {
 				t.Fatalf("unsafe configured path was not rejected: %+v", resolution)
 			}
 		})

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -261,10 +261,27 @@ func TestHTTPProviderBatchPrefetchUsesGoldenContractAndSharedAuth(t *testing.T) 
 	if !contains(missing.Warnings, "product_pricing_assignment_not_found") {
 		t.Fatalf("typed not-found result was lost: %+v", missing)
 	}
+	if len(authHeaders) != 2 {
+		t.Fatalf("shared token covered %d requests, want catalog GET plus batch POST", len(authHeaders))
+	}
 	for _, header := range authHeaders {
 		if header != "Bearer read-only-token" {
 			t.Fatalf("shared auth header = %q", header)
 		}
+	}
+}
+
+func TestHTTPProviderMissingConfiguredBearerMakesNoNetworkRequest(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, BearerTokenEnv: "PATRIS_MISSING_PRICING_TOKEN"}, server.Client(), time.Now)
+	resolved := provider.Resolve(context.Background(), "A")
+	if requests != 0 || !contains(resolved.Warnings, "pricing_catalog_fetch_failed") || !contains(resolved.Warnings, "pricing_catalog_unavailable") {
+		t.Fatalf("missing configured bearer was not rejected before transport: requests=%d resolution=%+v", requests, resolved)
 	}
 }
 
@@ -405,6 +422,85 @@ func TestHTTPProviderBatchAmbiguityIsAuthoritative(t *testing.T) {
 	resolved := provider.Resolve(context.Background(), "COLLISION")
 	if singleRequests != 0 || !contains(resolved.Warnings, "product_pricing_assignment_ambiguous") {
 		t.Fatalf("ambiguous Code was retried or lost: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
+func TestHTTPProviderBatchFailureUsesOnlyBoundedStaleAssignment(t *testing.T) {
+	var batchRequests, singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			batchRequests++
+			http.Error(w, "offline", http.StatusServiceUnavailable)
+		default:
+			singleRequests++
+			fmt.Fprint(w, `{"data":{"code":"A","import_freight_method_id":"air","profit_percent":"5","profit_percent_source":"product_override","pricing_warnings":[]}}`)
+		}
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, FreshFor: "1m", MaxStale: "10m"}, server.Client(), func() time.Time { return now })
+	if initial := provider.Resolve(context.Background(), "A"); decimalText(initial.MarkupPercent) != "5" {
+		t.Fatalf("initial assignment did not seed the cache: %+v", initial)
+	}
+
+	now = now.Add(2 * time.Minute)
+	provider.Prefetch(context.Background(), []string{"A"})
+	stale := provider.Resolve(context.Background(), "A")
+	if batchRequests != 1 || singleRequests != 1 || decimalText(stale.MarkupPercent) != "5" || !contains(stale.Warnings, "pricing_assignment_batch_http_failed") || !contains(stale.Warnings, "product_pricing_assignment_stale") {
+		t.Fatalf("batch failure did not use one bounded stale value: batch=%d single=%d resolution=%+v", batchRequests, singleRequests, stale)
+	}
+}
+
+func TestHTTPProviderBatchAuthAndBodyLimitsFailClosed(t *testing.T) {
+	tests := []struct {
+		name          string
+		code          string
+		batchResponse func(http.ResponseWriter)
+		warning       string
+		batchRequests int
+	}{
+		{
+			name: "auth", code: "A", warning: "pricing_assignment_batch_auth_failed", batchRequests: 1,
+			batchResponse: func(w http.ResponseWriter) { http.Error(w, "forbidden", http.StatusForbidden) },
+		},
+		{
+			name: "response limit", code: "A", warning: "pricing_assignment_batch_response_too_large", batchRequests: 1,
+			batchResponse: func(w http.ResponseWriter) { fmt.Fprint(w, strings.Repeat("x", 1024)) },
+		},
+		{
+			name: "request limit", code: strings.Repeat("A", 600), warning: "pricing_assignment_batch_request_too_large", batchRequests: 0,
+			batchResponse: func(w http.ResponseWriter) { t.Error("oversized request reached the server") },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var batchRequests, singleRequests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/integration/catalog":
+					fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
+				case "/pricing-assignments/batch":
+					batchRequests++
+					test.batchResponse(w)
+				default:
+					singleRequests++
+				}
+			}))
+			defer server.Close()
+
+			provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, MaxResponseBytes: 512}, server.Client(), time.Now)
+			provider.Prefetch(context.Background(), []string{test.code})
+			resolved := provider.Resolve(context.Background(), test.code)
+			if batchRequests != test.batchRequests || singleRequests != 0 || !contains(resolved.Warnings, test.warning) {
+				t.Fatalf("batch guard mismatch: batch=%d single=%d resolution=%+v", batchRequests, singleRequests, resolved)
+			}
+		})
 	}
 }
 

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -199,6 +199,96 @@ func TestHTTPProviderBoundsPrefetchDiagnosticCache(t *testing.T) {
 	}
 }
 
+func TestHTTPProviderRunBarrierSurvivesPersistentCacheEviction(t *testing.T) {
+	var batchRequests, singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			batchRequests++
+			var request struct {
+				Codes []string `json:"codes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			results := make([]map[string]interface{}, 0, len(request.Codes))
+			resolvedCount := 0
+			for _, code := range request.Codes {
+				if code == "B" {
+					results = append(results, map[string]interface{}{
+						"code": code, "status": "error", "error": map[string]interface{}{
+							"code": "digitalogic_product_temporarily_invalid", "http_status": 422, "retryable": false,
+						},
+					})
+					continue
+				}
+				resolvedCount++
+				results = append(results, map[string]interface{}{
+					"code": code, "status": "ok", "assignment": map[string]interface{}{
+						"code": code, "import_freight_method_id": "air", "profit_percent": "30", "profit_percent_source": "global_default", "pricing_warnings": []string{},
+					},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"schema": "digitalogic.pricing-assignment-batch", "schema_version": "1.0.0",
+				"requested_count": len(request.Codes), "resolved_count": resolvedCount, "error_count": len(request.Codes) - resolvedCount, "maximum_codes": 500,
+				"default_percentage_markup": map[string]interface{}{
+					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "type": "percentage", "profit_percent": "30", "source": "global_default", "revision": "rev-30",
+				},
+				"results": results,
+			}})
+		default:
+			singleRequests++
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, MaxEntries: 1}, server.Client(), time.Now)
+	scoped := provider.Prefetch(context.Background(), []string{"A", "B", "C"})
+	scopedProvider, ok := scoped.(*prefetchedProvider)
+	if !ok {
+		t.Fatalf("Prefetch returned %T, want transform-scoped provider", scoped)
+	}
+	scopedProvider.run.mu.Lock()
+	runEntries := len(scopedProvider.run.outcomes)
+	scopedProvider.run.mu.Unlock()
+	if runEntries != 3 {
+		t.Fatalf("run barrier entries = %d, want exactly the 3 requested Codes", runEntries)
+	}
+	provider.mu.Lock()
+	assignmentEntries := provider.lru.Len()
+	diagnosticEntries := provider.diagnosticLRU.Len()
+	provider.mu.Unlock()
+	if assignmentEntries > 1 || diagnosticEntries > 1 {
+		t.Fatalf("persistent bounds were exceeded: assignments=%d diagnostics=%d", assignmentEntries, diagnosticEntries)
+	}
+
+	for _, code := range []string{"A", "B", "C"} {
+		resolved := scoped.Resolve(context.Background(), code)
+		if code == "B" {
+			if !contains(resolved.Warnings, "product_pricing_assignment_batch_result_failed") {
+				t.Fatalf("run-scoped diagnostic for B was evicted: %+v", resolved)
+			}
+			continue
+		}
+		if resolved.MethodID != "air" || decimalText(resolved.MarkupPercent) != "30" {
+			t.Fatalf("run-scoped success for %s was evicted: %+v", code, resolved)
+		}
+	}
+	if batchRequests != 1 || singleRequests != 0 {
+		t.Fatalf("run barrier allowed N+1 fallback: batch=%d single=%d", batchRequests, singleRequests)
+	}
+	scopedProvider.run.mu.Lock()
+	runEntries = len(scopedProvider.run.outcomes)
+	scopedProvider.run.mu.Unlock()
+	if runEntries != 0 {
+		t.Fatalf("run barrier retained %d consumed outcomes", runEntries)
+	}
+}
+
 func TestHTTPProviderBoundsAssignmentCache(t *testing.T) {
 	counts := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -292,7 +382,7 @@ func TestHTTPProviderBatchPreservesExactProductOverrideSource(t *testing.T) {
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":120}]}}`)
 		case "/pricing-assignments/batch":
-			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"profit_percent":"30","source":"global_default"},"results":[{"code":"EXACT","status":"ok","assignment":{"code":"EXACT","import_freight_method_id":"air","profit_percent":"12.500000000001","profit_percent_source":"product_override","pricing_warnings":[]}}]}}`)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"type":"percentage","profit_percent":"30","source":"global_default","revision":"rev-30"},"results":[{"code":"EXACT","status":"ok","assignment":{"code":"EXACT","import_freight_method_id":"air","profit_percent":"12.500000000001","profit_percent_source":"product_override","pricing_warnings":[]}}]}}`)
 		default:
 			t.Fatalf("unexpected single-Code request: %s", r.URL.Path)
 		}
@@ -315,7 +405,7 @@ func TestHTTPProviderRetryableBatchResultFallsBackToSingleResolver(t *testing.T)
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
 		case "/pricing-assignments/batch":
-			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"source":"unset"},"results":[{"code":"A","status":"error","error":{"code":"digitalogic_pricing_temporarily_unavailable","http_status":503,"retryable":true}}]}}`)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"type":"percentage","source":"unset","revision":"rev-unset"},"results":[{"code":"A","status":"error","error":{"code":"digitalogic_pricing_temporarily_unavailable","http_status":503,"retryable":true}}]}}`)
 		default:
 			singleRequests++
 			fmt.Fprint(w, `{"data":{"code":"A","import_freight_method_id":"air","profit_percent":"7.25","profit_percent_source":"product_override","pricing_warnings":[]}}`)
@@ -339,7 +429,7 @@ func TestHTTPProviderRejectsInconsistentBatchMarkupSource(t *testing.T) {
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
 		case "/pricing-assignments/batch":
-			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"profit_percent":"30","source":"global_default"},"results":[{"code":"A","status":"ok","assignment":{"code":"A","import_freight_method_id":"air","profit_percent":"31","profit_percent_source":"global_default","pricing_warnings":[]}}]}}`)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"type":"percentage","profit_percent":"30","source":"global_default","revision":"rev-30"},"results":[{"code":"A","status":"ok","assignment":{"code":"A","import_freight_method_id":"air","profit_percent":"31","profit_percent_source":"global_default","pricing_warnings":[]}}]}}`)
 		default:
 			singleRequests++
 		}
@@ -351,6 +441,107 @@ func TestHTTPProviderRejectsInconsistentBatchMarkupSource(t *testing.T) {
 	resolved := provider.Resolve(context.Background(), "A")
 	if singleRequests != 0 || !contains(resolved.Warnings, "pricing_assignment_batch_contract_invalid") {
 		t.Fatalf("inconsistent source/default semantics did not fail closed: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
+func TestHTTPProviderRejectsInvalidBatchDecimalsAndMissingDefaultRevision(t *testing.T) {
+	tests := []struct {
+		name             string
+		defaultProfit    string
+		assignmentProfit string
+		assignmentSource string
+		revision         string
+	}{
+		{name: "unquoted default", defaultProfit: `30`, assignmentProfit: `"30"`, assignmentSource: "global_default", revision: "rev-30"},
+		{name: "unquoted assignment", defaultProfit: `"30"`, assignmentProfit: `30`, assignmentSource: "global_default", revision: "rev-30"},
+		{name: "non-canonical default", defaultProfit: `"30.0"`, assignmentProfit: `"30"`, assignmentSource: "global_default", revision: "rev-30"},
+		{name: "non-canonical assignment", defaultProfit: `"30"`, assignmentProfit: `"30.0"`, assignmentSource: "product_override", revision: "rev-30"},
+		{name: "thirteen fractional digits in default", defaultProfit: `"0.1234567890123"`, assignmentProfit: `"0.1234567890123"`, assignmentSource: "global_default", revision: "rev-30"},
+		{name: "thirteen fractional digits", defaultProfit: `"30"`, assignmentProfit: `"0.1234567890123"`, assignmentSource: "product_override", revision: "rev-30"},
+		{name: "missing default revision", defaultProfit: `"30"`, assignmentProfit: `"30"`, assignmentSource: "global_default", revision: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var batchRequests, singleRequests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/integration/catalog":
+					fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
+				case "/pricing-assignments/batch":
+					batchRequests++
+					fmt.Fprintf(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"type":"percentage","profit_percent":%s,"source":"global_default","revision":%q},"results":[{"code":"A","status":"ok","assignment":{"code":"A","import_freight_method_id":"air","profit_percent":%s,"profit_percent_source":"%s","pricing_warnings":[]}}]}}`, test.defaultProfit, test.revision, test.assignmentProfit, test.assignmentSource)
+				default:
+					singleRequests++
+				}
+			}))
+			defer server.Close()
+
+			provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+			scoped := provider.Prefetch(context.Background(), []string{"A"})
+			resolved := scoped.Resolve(context.Background(), "A")
+			if batchRequests != 1 || singleRequests != 0 || !contains(resolved.Warnings, "pricing_assignment_batch_contract_invalid") {
+				t.Fatalf("invalid exact decimal did not fail closed: batch=%d single=%d resolution=%+v", batchRequests, singleRequests, resolved)
+			}
+		})
+	}
+}
+
+func TestHTTPProviderCommitsChunksAtomicallyAfterDefaultRevisionAgreement(t *testing.T) {
+	var batchRequests, singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			batchRequests++
+			var request struct {
+				Codes []string `json:"codes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			code := request.Codes[0]
+			profit := "30"
+			revision := "rev-30"
+			if code == "B" {
+				revision = "rev-31"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"schema": "digitalogic.pricing-assignment-batch", "schema_version": "1.0.0",
+				"requested_count": 1, "resolved_count": 1, "error_count": 0, "maximum_codes": 500,
+				"default_percentage_markup": map[string]interface{}{
+					"schema": "digitalogic.default-percentage-markup", "schema_version": "1.0.0", "configured": true, "type": "percentage", "profit_percent": profit, "source": "global_default", "revision": revision,
+				},
+				"results": []map[string]interface{}{{
+					"code": code, "status": "ok", "assignment": map[string]interface{}{
+						"code": code, "import_freight_method_id": "air", "profit_percent": profit, "profit_percent_source": "global_default", "pricing_warnings": []string{},
+					},
+				}},
+			}})
+		default:
+			singleRequests++
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, BatchSize: 1, MaxEntries: 10}, server.Client(), time.Now)
+	scoped := provider.Prefetch(context.Background(), []string{"A", "B"})
+	provider.mu.Lock()
+	committedAssignments := len(provider.assignments)
+	provider.mu.Unlock()
+	if committedAssignments != 0 {
+		t.Fatalf("first chunk became visible before default agreement: assignments=%d", committedAssignments)
+	}
+	for _, code := range []string{"A", "B"} {
+		resolved := scoped.Resolve(context.Background(), code)
+		if resolved.MethodID != "" || !contains(resolved.Warnings, "pricing_assignment_batch_contract_invalid") {
+			t.Fatalf("mixed default revisions did not fail atomically for %s: %+v", code, resolved)
+		}
+	}
+	if batchRequests != 2 || singleRequests != 0 {
+		t.Fatalf("mixed revision handling made unsafe requests: batch=%d single=%d", batchRequests, singleRequests)
 	}
 }
 
@@ -402,6 +593,62 @@ func TestHTTPProviderMalformedBatchFailsClosedWithoutSingleRequests(t *testing.T
 	}
 }
 
+func TestHTTPProviderFreshFailClosedDiagnosticBacksOffAcrossPrefetchRuns(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		warning string
+	}{
+		{name: "authentication", mode: "auth", warning: "pricing_assignment_batch_auth_failed"},
+		{name: "transport", mode: "transport", warning: "pricing_assignment_batch_transport_failed"},
+		{name: "malformed contract", mode: "malformed", warning: "pricing_assignment_batch_contract_invalid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var batchRequests, singleRequests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/integration/catalog":
+					fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
+				case "/pricing-assignments/batch":
+					batchRequests++
+					switch test.mode {
+					case "auth":
+						http.Error(w, "forbidden", http.StatusForbidden)
+					case "transport":
+						connection, _, err := w.(http.Hijacker).Hijack()
+						if err != nil {
+							t.Errorf("hijack batch connection: %v", err)
+							return
+						}
+						_ = connection.Close()
+					case "malformed":
+						fmt.Fprint(w, `{"data":{"schema":"wrong","schema_version":"1.0.0","results":[]}}`)
+					}
+				default:
+					singleRequests++
+				}
+			}))
+			defer server.Close()
+
+			provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, FreshFor: "5m", MaxEntries: 1}, server.Client(), time.Now)
+			for run := 0; run < 2; run++ {
+				scoped := provider.Prefetch(context.Background(), []string{"A", "B", "C"})
+				for _, code := range []string{"A", "B", "C"} {
+					resolved := scoped.Resolve(context.Background(), code)
+					if !contains(resolved.Warnings, test.warning) {
+						t.Fatalf("run %d Code %s lost fail-closed diagnostic %q: %+v", run, code, test.warning, resolved)
+					}
+				}
+			}
+			if batchRequests != 1 || singleRequests != 0 {
+				t.Fatalf("fresh fail-closed diagnostic did not back off: batch=%d single=%d", batchRequests, singleRequests)
+			}
+		})
+	}
+}
+
 func TestHTTPProviderBatchAmbiguityIsAuthoritative(t *testing.T) {
 	var singleRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -410,7 +657,7 @@ func TestHTTPProviderBatchAmbiguityIsAuthoritative(t *testing.T) {
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
 		case "/pricing-assignments/batch":
-			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"source":"unset"},"results":[{"code":"COLLISION","status":"error","error":{"code":"digitalogic_product_code_ambiguous","http_status":409,"retryable":false}}]}}`)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"type":"percentage","source":"unset","revision":"rev-unset"},"results":[{"code":"COLLISION","status":"error","error":{"code":"digitalogic_product_code_ambiguous","http_status":409,"retryable":false}}]}}`)
 		default:
 			singleRequests++
 		}

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -165,6 +165,40 @@ func TestHTTPProviderUsesCacheOnlyInsideExplicitMaxStale(t *testing.T) {
 	}
 }
 
+func TestHTTPProviderBacksOffCatalogFailureAcrossPrefetchAndResolve(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.Error(w, "offline", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	now := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL, FreshFor: "1m"}, server.Client(), func() time.Time { return now })
+	provider.Prefetch(context.Background(), []string{"A", "B"})
+	for _, code := range []string{"A", "B"} {
+		resolved := provider.Resolve(context.Background(), code)
+		if !contains(resolved.Warnings, "pricing_catalog_fetch_failed") || !contains(resolved.Warnings, "pricing_catalog_unavailable") {
+			t.Fatalf("catalog failure diagnostics were lost for %s: %+v", code, resolved)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("one catalog failure caused %d requests inside the freshness backoff", requests)
+	}
+}
+
+func TestHTTPProviderBoundsPrefetchDiagnosticCache(t *testing.T) {
+	now := time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: "http://localhost", MaxEntries: 2}, &http.Client{}, func() time.Time { return now })
+	provider.storePrefetchDiagnostic([]string{"A", "B", "C"}, []string{"test_diagnostic"}, now, false)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.diagnostics) != 2 || provider.diagnosticLRU.Len() != 2 || provider.diagnostics["A"] != nil || provider.diagnostics["B"] == nil || provider.diagnostics["C"] == nil {
+		t.Fatalf("diagnostic cache exceeded/did not honor its LRU bound: map=%d lru=%d keys=%v", len(provider.diagnostics), provider.diagnosticLRU.Len(), provider.diagnostics)
+	}
+}
+
 func TestHTTPProviderBoundsAssignmentCache(t *testing.T) {
 	counts := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +255,7 @@ func TestHTTPProviderBatchPrefetchUsesGoldenContractAndSharedAuth(t *testing.T) 
 	if batchRequests != 1 || singleRequests != 0 {
 		t.Fatalf("requests: batch=%d single=%d, want 1/0", batchRequests, singleRequests)
 	}
-	if resolved.MethodID != "air_express" || decimalText(resolved.MarkupPercent) != "30" || decimalText(resolved.FreightCNYPerKg) != "120" {
+	if resolved.MethodID != "air_express" || decimalText(resolved.MarkupPercent) != "30" || resolved.MarkupPercentSource != "global_default" || decimalText(resolved.FreightCNYPerKg) != "120" {
 		t.Fatalf("golden assignment did not resolve exactly: %+v", resolved)
 	}
 	if !contains(missing.Warnings, "product_pricing_assignment_not_found") {
@@ -231,6 +265,75 @@ func TestHTTPProviderBatchPrefetchUsesGoldenContractAndSharedAuth(t *testing.T) 
 		if header != "Bearer read-only-token" {
 			t.Fatalf("shared auth header = %q", header)
 		}
+	}
+}
+
+func TestHTTPProviderBatchPreservesExactProductOverrideSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":120}]}}`)
+		case "/pricing-assignments/batch":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"profit_percent":"30","source":"global_default"},"results":[{"code":"EXACT","status":"ok","assignment":{"code":"EXACT","import_freight_method_id":"air","profit_percent":"12.500000000001","profit_percent_source":"product_override","pricing_warnings":[]}}]}}`)
+		default:
+			t.Fatalf("unexpected single-Code request: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"EXACT"})
+	resolved := provider.Resolve(context.Background(), "EXACT")
+	if decimalText(resolved.MarkupPercent) != "12.500000000001" || resolved.MarkupPercentSource != "product_override" {
+		t.Fatalf("exact override/source changed: %+v", resolved)
+	}
+}
+
+func TestHTTPProviderRetryableBatchResultFallsBackToSingleResolver(t *testing.T) {
+	var singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"source":"unset"},"results":[{"code":"A","status":"error","error":{"code":"digitalogic_pricing_temporarily_unavailable","http_status":503,"retryable":true}}]}}`)
+		default:
+			singleRequests++
+			fmt.Fprint(w, `{"data":{"code":"A","import_freight_method_id":"air","profit_percent":"7.25","profit_percent_source":"product_override","pricing_warnings":[]}}`)
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"A"})
+	resolved := provider.Resolve(context.Background(), "A")
+	if singleRequests != 1 || decimalText(resolved.MarkupPercent) != "7.25" || resolved.MarkupPercentSource != "product_override" || !contains(resolved.Warnings, "product_pricing_assignment_batch_result_retryable") {
+		t.Fatalf("retryable result did not use the bounded single resolver: requests=%d resolution=%+v", singleRequests, resolved)
+	}
+}
+
+func TestHTTPProviderRejectsInconsistentBatchMarkupSource(t *testing.T) {
+	var singleRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":1}]}}`)
+		case "/pricing-assignments/batch":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"profit_percent":"30","source":"global_default"},"results":[{"code":"A","status":"ok","assignment":{"code":"A","import_freight_method_id":"air","profit_percent":"31","profit_percent_source":"global_default","pricing_warnings":[]}}]}}`)
+		default:
+			singleRequests++
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{BaseURL: server.URL}, server.Client(), time.Now)
+	provider.Prefetch(context.Background(), []string{"A"})
+	resolved := provider.Resolve(context.Background(), "A")
+	if singleRequests != 0 || !contains(resolved.Warnings, "pricing_assignment_batch_contract_invalid") {
+		t.Fatalf("inconsistent source/default semantics did not fail closed: requests=%d resolution=%+v", singleRequests, resolved)
 	}
 }
 
@@ -290,7 +393,7 @@ func TestHTTPProviderBatchAmbiguityIsAuthoritative(t *testing.T) {
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[]}}`)
 		case "/pricing-assignments/batch":
-			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false},"results":[{"code":"COLLISION","status":"error","error":{"code":"digitalogic_product_code_ambiguous","http_status":409,"retryable":false}}]}}`)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":0,"error_count":1,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":false,"source":"unset"},"results":[{"code":"COLLISION","status":"error","error":{"code":"digitalogic_product_code_ambiguous","http_status":409,"retryable":false}}]}}`)
 		default:
 			singleRequests++
 		}

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -47,6 +47,7 @@ type assignmentWire struct {
 	Code            string   `json:"code"`
 	MethodID        string   `json:"import_freight_method_id"`
 	ProfitPercent   *Decimal `json:"profit_percent"`
+	ProfitSource    string   `json:"profit_percent_source"`
 	PricingWarnings []string `json:"pricing_warnings"`
 	Markup          struct {
 		ProfitPercent *Decimal `json:"profit_percent"`

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,9 +28,10 @@ type catalogSnapshot struct {
 }
 
 type assignmentSnapshot struct {
-	assignment Assignment
-	warnings   []string
-	fetchedAt  time.Time
+	assignment   Assignment
+	profitSource string
+	warnings     []string
+	fetchedAt    time.Time
 }
 
 type assignmentEntry struct {
@@ -41,6 +43,11 @@ type prefetchDiagnostic struct {
 	warnings    []string
 	fetchedAt   time.Time
 	allowSingle bool
+}
+
+type prefetchDiagnosticEntry struct {
+	code       string
+	diagnostic prefetchDiagnostic
 }
 
 type assignmentWire struct {
@@ -55,10 +62,20 @@ type assignmentWire struct {
 	} `json:"markup"`
 }
 
+type batchAssignmentWire struct {
+	Code            string          `json:"code"`
+	MethodID        string          `json:"import_freight_method_id"`
+	ProfitPercent   *Decimal        `json:"profit_percent"`
+	ProfitSource    string          `json:"profit_percent_source"`
+	PricingWarnings []string        `json:"pricing_warnings"`
+	LegacyMarkup    json.RawMessage `json:"markup"`
+}
+
 type batchAssignmentResult struct {
-	code     string
-	snapshot *assignmentSnapshot
-	warnings []string
+	code        string
+	snapshot    *assignmentSnapshot
+	warnings    []string
+	allowSingle bool
 }
 
 type remoteStatusError struct {
@@ -78,8 +95,9 @@ func (e *contractError) Error() string {
 }
 
 var (
-	errRequestTooLarge  = errors.New("request exceeds configured limit")
-	errResponseTooLarge = errors.New("response exceeds configured limit")
+	errCredentialUnavailable = errors.New("configured credential is unavailable")
+	errRequestTooLarge       = errors.New("request exceeds configured limit")
+	errResponseTooLarge      = errors.New("response exceeds configured limit")
 )
 
 type httpProvider struct {
@@ -93,9 +111,11 @@ type httpProvider struct {
 	catalogFetchMu sync.Mutex
 	prefetchMu     sync.Mutex
 	catalog        *catalogSnapshot
+	catalogFailure time.Time
 	assignments    map[string]*list.Element
-	diagnostics    map[string]prefetchDiagnostic
+	diagnostics    map[string]*list.Element
 	lru            *list.List
+	diagnosticLRU  *list.List
 	configError    string
 }
 
@@ -113,14 +133,15 @@ func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time
 		}
 	}
 	provider := &httpProvider{
-		config:      normalized,
-		client:      client,
-		now:         now,
-		freshFor:    parseDuration(normalized.FreshFor, defaultFreshFor),
-		maxStale:    parseDuration(normalized.MaxStale, defaultMaxStale),
-		assignments: make(map[string]*list.Element),
-		diagnostics: make(map[string]prefetchDiagnostic),
-		lru:         list.New(),
+		config:        normalized,
+		client:        client,
+		now:           now,
+		freshFor:      parseDuration(normalized.FreshFor, defaultFreshFor),
+		maxStale:      parseDuration(normalized.MaxStale, defaultMaxStale),
+		assignments:   make(map[string]*list.Element),
+		diagnostics:   make(map[string]*list.Element),
+		lru:           list.New(),
+		diagnosticLRU: list.New(),
 	}
 	provider.configError = validateBaseURL(normalized.BaseURL)
 	if provider.configError == "" {
@@ -212,7 +233,7 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) {
 				p.storeAssignment(result.code, snapshot)
 				continue
 			}
-			p.storePrefetchDiagnostic([]string{result.code}, result.warnings, now, false)
+			p.storePrefetchDiagnostic([]string{result.code}, result.warnings, now, result.allowSingle)
 		}
 	}
 }
@@ -248,6 +269,7 @@ func (p *httpProvider) Resolve(ctx context.Context, code string) Resolution {
 
 	resolution.MethodID = strings.TrimSpace(assignment.assignment.MethodID)
 	resolution.MarkupPercent = cloneDecimal(assignment.assignment.ProfitPercent)
+	resolution.MarkupPercentSource = assignment.profitSource
 	method, exists := catalog.methods[resolution.MethodID]
 	if !exists {
 		resolution.Warnings = append(resolution.Warnings, "import_freight_method_unknown")
@@ -269,6 +291,15 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 		p.mu.Unlock()
 		return copy, "fresh", nil
 	}
+	if withinAge(now, p.catalogFailure, p.freshFor) {
+		if cached != nil && withinAge(now, cached.fetchedAt, p.maxStale) {
+			copy := cloneCatalog(cached)
+			p.mu.Unlock()
+			return copy, "stale", []string{"pricing_catalog_stale"}
+		}
+		p.mu.Unlock()
+		return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
+	}
 	p.mu.Unlock()
 	p.catalogFetchMu.Lock()
 	defer p.catalogFetchMu.Unlock()
@@ -282,6 +313,15 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 		p.mu.Unlock()
 		return copy, "fresh", nil
 	}
+	if withinAge(now, p.catalogFailure, p.freshFor) {
+		if cached != nil && withinAge(now, cached.fetchedAt, p.maxStale) {
+			copy := cloneCatalog(cached)
+			p.mu.Unlock()
+			return copy, "stale", []string{"pricing_catalog_stale"}
+		}
+		p.mu.Unlock()
+		return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
+	}
 	p.mu.Unlock()
 
 	fetched, err := p.fetchCatalog(ctx)
@@ -289,10 +329,15 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 		fetched.fetchedAt = now
 		p.mu.Lock()
 		p.catalog = cloneCatalog(fetched)
+		p.catalogFailure = time.Time{}
 		p.mu.Unlock()
 		return fetched, "fresh", nil
 	}
 
+	p.mu.Lock()
+	p.catalogFailure = now
+	cached = p.catalog
+	p.mu.Unlock()
 	if cached != nil && withinAge(now, cached.fetchedAt, p.maxStale) {
 		return cloneCatalog(cached), "stale", []string{"pricing_catalog_stale"}
 	}
@@ -303,8 +348,10 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 	now := p.now().UTC()
 	prefetchWarnings := []string(nil)
 	p.mu.Lock()
-	if diagnostic, ok := p.diagnostics[code]; ok {
+	if diagnosticElement, ok := p.diagnostics[code]; ok {
+		diagnostic := diagnosticElement.Value.(*prefetchDiagnosticEntry).diagnostic
 		if withinAge(now, diagnostic.fetchedAt, p.freshFor) {
+			p.diagnosticLRU.MoveToFront(diagnosticElement)
 			prefetchWarnings = append(prefetchWarnings, diagnostic.warnings...)
 			if !diagnostic.allowSingle {
 				if element := p.assignments[code]; element != nil {
@@ -321,7 +368,7 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 				return nil, "unavailable", normalizedStrings(prefetchWarnings)
 			}
 		} else {
-			delete(p.diagnostics, code)
+			p.removeDiagnosticLocked(code)
 		}
 	}
 	if element, ok := p.assignments[code]; ok {
@@ -366,7 +413,7 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 func (p *httpProvider) storeAssignment(code string, snapshot assignmentSnapshot) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	delete(p.diagnostics, code)
+	p.removeDiagnosticLocked(code)
 	if element, exists := p.assignments[code]; exists {
 		element.Value.(*assignmentEntry).snapshot = snapshot
 		p.lru.MoveToFront(element)
@@ -389,12 +436,36 @@ func (p *httpProvider) storePrefetchDiagnostic(codes, warnings []string, fetched
 	defer p.mu.Unlock()
 	warnings = normalizedStrings(warnings)
 	for _, code := range codes {
-		p.diagnostics[code] = prefetchDiagnostic{
+		diagnostic := prefetchDiagnostic{
 			warnings:    append([]string(nil), warnings...),
 			fetchedAt:   fetchedAt,
 			allowSingle: allowSingle,
 		}
+		if element := p.diagnostics[code]; element != nil {
+			element.Value.(*prefetchDiagnosticEntry).diagnostic = diagnostic
+			p.diagnosticLRU.MoveToFront(element)
+			continue
+		}
+		element := p.diagnosticLRU.PushFront(&prefetchDiagnosticEntry{code: code, diagnostic: diagnostic})
+		p.diagnostics[code] = element
+		for p.diagnosticLRU.Len() > p.config.MaxEntries {
+			oldest := p.diagnosticLRU.Back()
+			if oldest == nil {
+				break
+			}
+			delete(p.diagnostics, oldest.Value.(*prefetchDiagnosticEntry).code)
+			p.diagnosticLRU.Remove(oldest)
+		}
 	}
+}
+
+func (p *httpProvider) removeDiagnosticLocked(code string) {
+	element := p.diagnostics[code]
+	if element == nil {
+		return
+	}
+	delete(p.diagnostics, code)
+	p.diagnosticLRU.Remove(element)
 }
 
 func (p *httpProvider) fetchCatalog(ctx context.Context) (*catalogSnapshot, error) {
@@ -500,8 +571,9 @@ func assignmentSnapshotFromWire(wire assignmentWire) assignmentSnapshot {
 		warnings = append(warnings, wire.Markup.Warning)
 	}
 	return assignmentSnapshot{
-		assignment: Assignment{MethodID: strings.TrimSpace(wire.MethodID), ProfitPercent: cloneDecimal(profit)},
-		warnings:   normalizedStrings(warnings),
+		assignment:   Assignment{MethodID: strings.TrimSpace(wire.MethodID), ProfitPercent: cloneDecimal(profit)},
+		profitSource: strings.TrimSpace(wire.ProfitSource),
+		warnings:     normalizedStrings(warnings),
 	}
 }
 
@@ -518,6 +590,7 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 			SchemaVersion string   `json:"schema_version"`
 			Configured    bool     `json:"configured"`
 			ProfitPercent *Decimal `json:"profit_percent"`
+			Source        string   `json:"source"`
 		} `json:"default_percentage_markup"`
 		Results []struct {
 			Code       string          `json:"code"`
@@ -541,8 +614,8 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 	if wire.DefaultMarkup.Schema != "digitalogic.default-percentage-markup" || majorVersion(wire.DefaultMarkup.SchemaVersion) != "1" {
 		return nil, &contractError{reason: "incompatible default-markup schema"}
 	}
-	if wire.DefaultMarkup.Configured && wire.DefaultMarkup.ProfitPercent == nil {
-		return nil, &contractError{reason: "configured default markup is missing its decimal"}
+	if err := validateBatchDefaultMarkup(wire.DefaultMarkup.Configured, wire.DefaultMarkup.ProfitPercent, wire.DefaultMarkup.Source); err != nil {
+		return nil, err
 	}
 	if wire.RequestedCount != len(codes) || len(wire.Results) != len(codes) || wire.MaximumCodes < len(codes) || wire.MaximumCodes > maximumBatchSize {
 		return nil, &contractError{reason: "batch cardinality does not match the request"}
@@ -564,27 +637,64 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 			if len(result.Assignment) == 0 || bytes.Equal(bytes.TrimSpace(result.Assignment), []byte("null")) {
 				return nil, &contractError{reason: "successful batch result omitted its assignment"}
 			}
-			var assignment assignmentWire
+			var assignment batchAssignmentWire
 			if err := json.Unmarshal(result.Assignment, &assignment); err != nil {
 				return nil, &contractError{reason: "successful batch assignment is malformed"}
 			}
 			if strings.TrimSpace(assignment.Code) != result.Code {
 				return nil, &contractError{reason: "successful batch assignment Code mismatch"}
 			}
-			snapshot := assignmentSnapshotFromWire(assignment)
+			if len(assignment.LegacyMarkup) > 0 && !bytes.Equal(bytes.TrimSpace(assignment.LegacyMarkup), []byte("null")) {
+				return nil, &contractError{reason: "successful batch assignment used the legacy nested markup projection"}
+			}
+			if err := validateBatchAssignmentMarkup(assignment, wire.DefaultMarkup.Configured, wire.DefaultMarkup.ProfitPercent); err != nil {
+				return nil, err
+			}
+			snapshot := assignmentSnapshot{
+				assignment: Assignment{
+					MethodID:      strings.TrimSpace(assignment.MethodID),
+					ProfitPercent: cloneDecimal(assignment.ProfitPercent),
+				},
+				profitSource: strings.TrimSpace(assignment.ProfitSource),
+				warnings:     normalizedStrings(assignment.PricingWarnings),
+			}
 			results = append(results, batchAssignmentResult{code: result.Code, snapshot: &snapshot})
 		case "error":
 			errorCount++
+			if len(result.Assignment) > 0 && !bytes.Equal(bytes.TrimSpace(result.Assignment), []byte("null")) {
+				return nil, &contractError{reason: "failed batch result included an assignment"}
+			}
+			result.Error.Code = strings.TrimSpace(result.Error.Code)
+			if result.Error.Code == "" || result.Error.HTTPStatus < 100 || result.Error.HTTPStatus > 599 {
+				return nil, &contractError{reason: "failed batch result omitted its typed error"}
+			}
 			warning := "product_pricing_assignment_batch_result_failed"
 			switch result.Error.Code {
 			case "digitalogic_product_code_not_found":
+				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusNotFound {
+					return nil, &contractError{reason: "not-found batch result changed its error semantics"}
+				}
 				warning = "product_pricing_assignment_not_found"
 			case "digitalogic_product_code_ambiguous":
+				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusConflict {
+					return nil, &contractError{reason: "ambiguous batch result changed its error semantics"}
+				}
 				warning = "product_pricing_assignment_ambiguous"
 			case "digitalogic_invalid_product_code":
+				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusBadRequest {
+					return nil, &contractError{reason: "invalid-Code batch result changed its error semantics"}
+				}
 				warning = "product_pricing_assignment_invalid"
 			default:
-				results = append(results, batchAssignmentResult{code: result.Code, warnings: []string{warning}})
+				if result.Error.Retryable {
+					if result.Error.HTTPStatus < 500 {
+						return nil, &contractError{reason: "retryable batch result used a non-server error status"}
+					}
+					warning = "product_pricing_assignment_batch_result_retryable"
+				}
+				results = append(results, batchAssignmentResult{
+					code: result.Code, warnings: []string{warning}, allowSingle: result.Error.Retryable,
+				})
 				continue
 			}
 			snapshot := assignmentSnapshot{warnings: []string{warning}}
@@ -597,6 +707,51 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 		return nil, &contractError{reason: "batch status counts do not match the envelope"}
 	}
 	return results, nil
+}
+
+func validateBatchDefaultMarkup(configured bool, profit *Decimal, source string) error {
+	source = strings.TrimSpace(source)
+	if configured {
+		if source != "global_default" || !validBatchPercentage(profit) {
+			return &contractError{reason: "configured default markup has inconsistent decimal/source semantics"}
+		}
+		return nil
+	}
+	if profit != nil || (source != "unset" && source != "invalid_storage") {
+		return &contractError{reason: "unconfigured default markup has inconsistent decimal/source semantics"}
+	}
+	return nil
+}
+
+func validateBatchAssignmentMarkup(assignment batchAssignmentWire, defaultConfigured bool, defaultProfit *Decimal) error {
+	source := strings.TrimSpace(assignment.ProfitSource)
+	warnings := normalizedStrings(assignment.PricingWarnings)
+	switch source {
+	case "global_default":
+		if !defaultConfigured || !validBatchPercentage(assignment.ProfitPercent) || !decimalEqual(assignment.ProfitPercent, defaultProfit) {
+			return &contractError{reason: "global-default assignment does not match the shared default decimal"}
+		}
+	case "product_override":
+		if !validBatchPercentage(assignment.ProfitPercent) {
+			return &contractError{reason: "product override has an invalid exact percentage"}
+		}
+	case "unset":
+		if assignment.ProfitPercent != nil || len(warnings) == 0 {
+			return &contractError{reason: "unset assignment omitted its diagnostic or included a decimal"}
+		}
+	case "":
+		if assignment.ProfitPercent != nil || len(warnings) == 0 {
+			return &contractError{reason: "invalid assignment markup omitted its diagnostic or included a decimal"}
+		}
+	default:
+		return &contractError{reason: "assignment markup source is unsupported"}
+	}
+	return nil
+}
+
+func validBatchPercentage(value *Decimal) bool {
+	parsed, ok := decimalRat(value)
+	return ok && parsed.Sign() >= 0 && parsed.Cmp(big.NewRat(1000, 1)) <= 0
 }
 
 func (p *httpProvider) getJSON(ctx context.Context, path string, target interface{}) error {
@@ -635,14 +790,14 @@ func (p *httpProvider) doJSON(ctx context.Context, method, path string, body []b
 	if p.config.BearerTokenEnv != "" {
 		token := strings.TrimSpace(os.Getenv(p.config.BearerTokenEnv))
 		if token == "" {
-			return errors.New("configured bearer credential is unavailable")
+			return errCredentialUnavailable
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	} else if p.config.UsernameEnv != "" || p.config.PasswordEnv != "" {
 		username := os.Getenv(p.config.UsernameEnv)
 		password := os.Getenv(p.config.PasswordEnv)
 		if p.config.UsernameEnv == "" || p.config.PasswordEnv == "" || username == "" || password == "" {
-			return errors.New("configured basic credential is unavailable")
+			return errCredentialUnavailable
 		}
 		req.SetBasicAuth(username, password)
 	}
@@ -689,6 +844,8 @@ func batchFailureWarning(err error) string {
 	var contract *contractError
 	switch {
 	case errors.As(err, &status) && (status.status == http.StatusUnauthorized || status.status == http.StatusForbidden):
+		return "pricing_assignment_batch_auth_failed"
+	case errors.Is(err, errCredentialUnavailable):
 		return "pricing_assignment_batch_auth_failed"
 	case errors.As(err, &status):
 		return "pricing_assignment_batch_http_failed"

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -50,6 +51,24 @@ type prefetchDiagnosticEntry struct {
 	diagnostic prefetchDiagnostic
 }
 
+// prefetchRun is a transform-scoped result barrier. It may temporarily hold
+// more entries than the persistent LRU, but is bounded by the caller's unique
+// Code slice and releases each outcome as that Code is resolved.
+type prefetchRun struct {
+	mu       sync.Mutex
+	outcomes map[string]prefetchOutcome
+}
+
+type prefetchOutcome struct {
+	snapshot   *assignmentSnapshot
+	diagnostic *prefetchDiagnostic
+}
+
+type prefetchedProvider struct {
+	parent *httpProvider
+	run    *prefetchRun
+}
+
 type assignmentWire struct {
 	Code            string   `json:"code"`
 	MethodID        string   `json:"import_freight_method_id"`
@@ -65,10 +84,29 @@ type assignmentWire struct {
 type batchAssignmentWire struct {
 	Code            string          `json:"code"`
 	MethodID        string          `json:"import_freight_method_id"`
-	ProfitPercent   *Decimal        `json:"profit_percent"`
+	ProfitPercent   *batchDecimal   `json:"profit_percent"`
 	ProfitSource    string          `json:"profit_percent_source"`
 	PricingWarnings []string        `json:"pricing_warnings"`
 	LegacyMarkup    json.RawMessage `json:"markup"`
+}
+
+type batchDecimal struct {
+	value Decimal
+}
+
+type batchDefaultMarkup struct {
+	schema        string
+	schemaVersion string
+	configured    bool
+	typeName      string
+	profit        *Decimal
+	source        string
+	revision      string
+}
+
+type batchAssignmentPage struct {
+	defaultMarkup batchDefaultMarkup
+	results       []batchAssignmentResult
 }
 
 type batchAssignmentResult struct {
@@ -100,6 +138,56 @@ var (
 	errResponseTooLarge      = errors.New("response exceeds configured limit")
 )
 
+func (d *batchDecimal) UnmarshalJSON(data []byte) error {
+	if d == nil {
+		return errors.New("nil batch decimal receiver")
+	}
+	data = bytes.TrimSpace(data)
+	if len(data) < 2 || data[0] != '"' {
+		return errors.New("batch decimal must be a quoted canonical string")
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if strings.TrimSpace(value) != value {
+		return errors.New("batch decimal must not contain surrounding whitespace")
+	}
+	parsed, err := NewDecimal(value)
+	if err != nil {
+		return err
+	}
+	if parsed.String() != value {
+		return errors.New("batch decimal must use canonical base-10 text")
+	}
+	if point := strings.IndexByte(value, '.'); point >= 0 && len(value)-point-1 > 12 {
+		return errors.New("batch decimal exceeds 12 fractional digits")
+	}
+	d.value = *parsed
+	return nil
+}
+
+func (d *batchDecimal) decimal() *Decimal {
+	if d == nil {
+		return nil
+	}
+	value := d.value
+	return &value
+}
+
+func (r *prefetchRun) take(code string) (prefetchOutcome, bool) {
+	if r == nil {
+		return prefetchOutcome{}, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	outcome, ok := r.outcomes[code]
+	if ok {
+		delete(r.outcomes, code)
+	}
+	return clonePrefetchOutcome(outcome), ok
+}
+
 type httpProvider struct {
 	config   DigitalogicConfig
 	client   *http.Client
@@ -112,6 +200,7 @@ type httpProvider struct {
 	prefetchMu     sync.Mutex
 	catalog        *catalogSnapshot
 	catalogFailure time.Time
+	batchFailure   *prefetchDiagnostic
 	assignments    map[string]*list.Element
 	diagnostics    map[string]*list.Element
 	lru            *list.List
@@ -170,24 +259,24 @@ func validateBaseURL(value string) string {
 	return ""
 }
 
-// Prefetch resolves uncached assignments in bounded request-order chunks. A
-// server that does not yet expose the versioned endpoint falls back to the
-// existing per-Code resolver. Authentication, transport, response-limit, and
-// malformed-contract failures are retained as per-Code diagnostics and block
-// an unsafe second request path for the current freshness window.
-func (p *httpProvider) Prefetch(ctx context.Context, codes []string) {
+// Prefetch stages uncached assignments in bounded request-order chunks and
+// returns a transform-scoped result barrier. Pages become visible only after
+// their shared default-markup contract agrees. Fresh failure backoff blocks an
+// unsafe repeat batch/single path for the current freshness window.
+func (p *httpProvider) Prefetch(ctx context.Context, codes []string) Provider {
 	if p.configError != "" || len(codes) == 0 {
-		return
+		return p
 	}
 	p.prefetchMu.Lock()
 	defer p.prefetchMu.Unlock()
 	if catalog, _, _ := p.resolveCatalog(ctx); catalog == nil {
-		return
+		return p
 	}
 
 	now := p.now().UTC()
 	seen := make(map[string]struct{}, len(codes))
 	pending := make([]string, 0, len(codes))
+	outcomes := make(map[string]prefetchOutcome, len(codes))
 	p.mu.Lock()
 	for _, code := range codes {
 		code = strings.TrimSpace(code)
@@ -198,10 +287,16 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) {
 			continue
 		}
 		seen[code] = struct{}{}
+		if diagnostic, ok := p.freshPrefetchDiagnosticLocked(code, now); ok {
+			outcomes[code] = prefetchOutcome{diagnostic: &diagnostic}
+			continue
+		}
 		if element := p.assignments[code]; element != nil {
 			cached := element.Value.(*assignmentEntry).snapshot
 			if withinAge(now, cached.fetchedAt, p.freshFor) {
 				p.lru.MoveToFront(element)
+				copy := cloneAssignmentSnapshot(cached)
+				outcomes[code] = prefetchOutcome{snapshot: &copy}
 				continue
 			}
 		}
@@ -209,36 +304,77 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) {
 	}
 	p.mu.Unlock()
 
+	pendingOutcomes := make(map[string]prefetchOutcome, len(pending))
+	var expectedDefault *batchDefaultMarkup
+	var batchErr error
 	for offset := 0; offset < len(pending); offset += p.config.BatchSize {
 		end := offset + p.config.BatchSize
 		if end > len(pending) {
 			end = len(pending)
 		}
 		chunk := pending[offset:end]
-		results, err := p.fetchAssignmentBatch(ctx, chunk)
+		page, err := p.fetchAssignmentBatch(ctx, chunk)
 		if err != nil {
-			remaining := pending[offset:]
-			if isUnsupportedBatchEndpoint(err) {
-				p.storePrefetchDiagnostic(remaining, []string{"pricing_assignment_batch_unsupported"}, now, true)
-				return
-			}
-			p.storePrefetchDiagnostic(remaining, []string{batchFailureWarning(err)}, now, false)
-			return
+			batchErr = err
+			break
 		}
-
-		for _, result := range results {
+		if expectedDefault == nil {
+			copy := cloneBatchDefaultMarkup(page.defaultMarkup)
+			expectedDefault = &copy
+		} else if !equalBatchDefaultMarkup(*expectedDefault, page.defaultMarkup) {
+			batchErr = &contractError{reason: "default-markup contract changed between batch chunks"}
+			break
+		}
+		for _, result := range page.results {
 			if result.snapshot != nil {
-				snapshot := *result.snapshot
+				snapshot := cloneAssignmentSnapshot(*result.snapshot)
 				snapshot.fetchedAt = now
-				p.storeAssignment(result.code, snapshot)
+				pendingOutcomes[result.code] = prefetchOutcome{snapshot: &snapshot}
 				continue
 			}
-			p.storePrefetchDiagnostic([]string{result.code}, result.warnings, now, result.allowSingle)
+			diagnostic := prefetchDiagnostic{
+				warnings: normalizedStrings(result.warnings), fetchedAt: now, allowSingle: result.allowSingle,
+			}
+			pendingOutcomes[result.code] = prefetchOutcome{diagnostic: &diagnostic}
 		}
 	}
+
+	var batchBackoff *prefetchDiagnostic
+	if batchErr != nil {
+		pendingOutcomes = make(map[string]prefetchOutcome, len(pending))
+		warning := batchFailureWarning(batchErr)
+		allowSingle := false
+		if isUnsupportedBatchEndpoint(batchErr) {
+			warning = "pricing_assignment_batch_unsupported"
+			allowSingle = true
+		}
+		backoff := prefetchDiagnostic{warnings: []string{warning}, fetchedAt: now, allowSingle: allowSingle}
+		batchBackoff = &backoff
+		for _, code := range pending {
+			diagnostic := clonePrefetchDiagnostic(backoff)
+			pendingOutcomes[code] = prefetchOutcome{diagnostic: &diagnostic}
+		}
+	}
+
+	p.commitPrefetchOutcomes(pendingOutcomes, batchBackoff, batchErr == nil && len(pending) > 0)
+	for code, outcome := range pendingOutcomes {
+		outcomes[code] = clonePrefetchOutcome(outcome)
+	}
+	if len(outcomes) == 0 {
+		return p
+	}
+	return &prefetchedProvider{parent: p, run: &prefetchRun{outcomes: outcomes}}
 }
 
 func (p *httpProvider) Resolve(ctx context.Context, code string) Resolution {
+	return p.resolve(ctx, code, nil)
+}
+
+func (p *prefetchedProvider) Resolve(ctx context.Context, code string) Resolution {
+	return p.parent.resolve(ctx, code, p.run)
+}
+
+func (p *httpProvider) resolve(ctx context.Context, code string, run *prefetchRun) Resolution {
 	code = strings.TrimSpace(code)
 	if p.configError != "" {
 		return finishResolution(Resolution{CatalogStatus: "unavailable", Warnings: []string{p.configError}})
@@ -257,7 +393,7 @@ func (p *httpProvider) Resolve(ctx context.Context, code string) Resolution {
 	resolution.IRTPerCNY = cloneDecimal(catalog.irtPerCNY)
 	resolution.Warnings = append(resolution.Warnings, catalog.warnings...)
 
-	assignment, assignmentStatus, assignmentWarnings := p.resolveAssignment(ctx, code)
+	assignment, assignmentStatus, assignmentWarnings := p.resolveAssignment(ctx, code, run)
 	resolution.Warnings = append(resolution.Warnings, assignmentWarnings...)
 	if assignmentStatus == "stale" {
 		resolution.Warnings = append(resolution.Warnings, "product_pricing_assignment_stale")
@@ -344,22 +480,27 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 	return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
 }
 
-func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*assignmentSnapshot, string, []string) {
+func (p *httpProvider) resolveAssignment(ctx context.Context, code string, run *prefetchRun) (*assignmentSnapshot, string, []string) {
 	now := p.now().UTC()
 	prefetchWarnings := []string(nil)
-	p.mu.Lock()
-	if diagnosticElement, ok := p.diagnostics[code]; ok {
-		diagnostic := diagnosticElement.Value.(*prefetchDiagnosticEntry).diagnostic
-		if withinAge(now, diagnostic.fetchedAt, p.freshFor) {
-			p.diagnosticLRU.MoveToFront(diagnosticElement)
+	skipPersistentDiagnostic := false
+	if outcome, ok := run.take(code); ok {
+		if outcome.snapshot != nil {
+			copy := cloneAssignmentSnapshot(*outcome.snapshot)
+			return &copy, "fresh", append([]string(nil), copy.warnings...)
+		}
+		if outcome.diagnostic != nil {
+			diagnostic := clonePrefetchDiagnostic(*outcome.diagnostic)
 			prefetchWarnings = append(prefetchWarnings, diagnostic.warnings...)
+			skipPersistentDiagnostic = true
 			if !diagnostic.allowSingle {
+				p.mu.Lock()
 				if element := p.assignments[code]; element != nil {
 					cached := element.Value.(*assignmentEntry).snapshot
 					if withinAge(now, cached.fetchedAt, p.maxStale) {
 						p.lru.MoveToFront(element)
 						p.mu.Unlock()
-						copy := cached
+						copy := cloneAssignmentSnapshot(cached)
 						warnings := append(append([]string(nil), cached.warnings...), prefetchWarnings...)
 						return &copy, "stale", normalizedStrings(warnings)
 					}
@@ -367,8 +508,26 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 				p.mu.Unlock()
 				return nil, "unavailable", normalizedStrings(prefetchWarnings)
 			}
-		} else {
-			p.removeDiagnosticLocked(code)
+		}
+	}
+	p.mu.Lock()
+	if !skipPersistentDiagnostic {
+		if diagnostic, ok := p.freshPrefetchDiagnosticLocked(code, now); ok {
+			prefetchWarnings = append(prefetchWarnings, diagnostic.warnings...)
+			if !diagnostic.allowSingle {
+				if element := p.assignments[code]; element != nil {
+					cached := element.Value.(*assignmentEntry).snapshot
+					if withinAge(now, cached.fetchedAt, p.maxStale) {
+						p.lru.MoveToFront(element)
+						p.mu.Unlock()
+						copy := cloneAssignmentSnapshot(cached)
+						warnings := append(append([]string(nil), cached.warnings...), prefetchWarnings...)
+						return &copy, "stale", normalizedStrings(warnings)
+					}
+				}
+				p.mu.Unlock()
+				return nil, "unavailable", normalizedStrings(prefetchWarnings)
+			}
 		}
 	}
 	if element, ok := p.assignments[code]; ok {
@@ -413,13 +572,17 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 func (p *httpProvider) storeAssignment(code string, snapshot assignmentSnapshot) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.storeAssignmentLocked(code, snapshot)
+}
+
+func (p *httpProvider) storeAssignmentLocked(code string, snapshot assignmentSnapshot) {
 	p.removeDiagnosticLocked(code)
 	if element, exists := p.assignments[code]; exists {
-		element.Value.(*assignmentEntry).snapshot = snapshot
+		element.Value.(*assignmentEntry).snapshot = cloneAssignmentSnapshot(snapshot)
 		p.lru.MoveToFront(element)
 		return
 	}
-	element := p.lru.PushFront(&assignmentEntry{code: code, snapshot: snapshot})
+	element := p.lru.PushFront(&assignmentEntry{code: code, snapshot: cloneAssignmentSnapshot(snapshot)})
 	p.assignments[code] = element
 	for p.lru.Len() > p.config.MaxEntries {
 		oldest := p.lru.Back()
@@ -441,20 +604,55 @@ func (p *httpProvider) storePrefetchDiagnostic(codes, warnings []string, fetched
 			fetchedAt:   fetchedAt,
 			allowSingle: allowSingle,
 		}
-		if element := p.diagnostics[code]; element != nil {
-			element.Value.(*prefetchDiagnosticEntry).diagnostic = diagnostic
-			p.diagnosticLRU.MoveToFront(element)
+		p.storePrefetchDiagnosticLocked(code, diagnostic)
+	}
+}
+
+func (p *httpProvider) storePrefetchDiagnosticLocked(code string, diagnostic prefetchDiagnostic) {
+	diagnostic = clonePrefetchDiagnostic(diagnostic)
+	if element := p.diagnostics[code]; element != nil {
+		element.Value.(*prefetchDiagnosticEntry).diagnostic = diagnostic
+		p.diagnosticLRU.MoveToFront(element)
+		return
+	}
+	element := p.diagnosticLRU.PushFront(&prefetchDiagnosticEntry{code: code, diagnostic: diagnostic})
+	p.diagnostics[code] = element
+	for p.diagnosticLRU.Len() > p.config.MaxEntries {
+		oldest := p.diagnosticLRU.Back()
+		if oldest == nil {
+			break
+		}
+		delete(p.diagnostics, oldest.Value.(*prefetchDiagnosticEntry).code)
+		p.diagnosticLRU.Remove(oldest)
+	}
+}
+
+func (p *httpProvider) commitPrefetchOutcomes(outcomes map[string]prefetchOutcome, batchFailure *prefetchDiagnostic, clearBatchFailure bool) {
+	if len(outcomes) == 0 && batchFailure == nil && !clearBatchFailure {
+		return
+	}
+	keys := make([]string, 0, len(outcomes))
+	for code := range outcomes {
+		keys = append(keys, code)
+	}
+	sort.Strings(keys)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if clearBatchFailure {
+		p.batchFailure = nil
+	}
+	if batchFailure != nil {
+		copy := clonePrefetchDiagnostic(*batchFailure)
+		p.batchFailure = &copy
+	}
+	for _, code := range keys {
+		outcome := outcomes[code]
+		if outcome.snapshot != nil {
+			p.storeAssignmentLocked(code, *outcome.snapshot)
 			continue
 		}
-		element := p.diagnosticLRU.PushFront(&prefetchDiagnosticEntry{code: code, diagnostic: diagnostic})
-		p.diagnostics[code] = element
-		for p.diagnosticLRU.Len() > p.config.MaxEntries {
-			oldest := p.diagnosticLRU.Back()
-			if oldest == nil {
-				break
-			}
-			delete(p.diagnostics, oldest.Value.(*prefetchDiagnosticEntry).code)
-			p.diagnosticLRU.Remove(oldest)
+		if outcome.diagnostic != nil {
+			p.storePrefetchDiagnosticLocked(code, *outcome.diagnostic)
 		}
 	}
 }
@@ -466,6 +664,63 @@ func (p *httpProvider) removeDiagnosticLocked(code string) {
 	}
 	delete(p.diagnostics, code)
 	p.diagnosticLRU.Remove(element)
+}
+
+func (p *httpProvider) freshPrefetchDiagnosticLocked(code string, now time.Time) (prefetchDiagnostic, bool) {
+	if p.batchFailure != nil {
+		if withinAge(now, p.batchFailure.fetchedAt, p.freshFor) {
+			return clonePrefetchDiagnostic(*p.batchFailure), true
+		}
+		p.batchFailure = nil
+	}
+	if element := p.diagnostics[code]; element != nil {
+		diagnostic := element.Value.(*prefetchDiagnosticEntry).diagnostic
+		if withinAge(now, diagnostic.fetchedAt, p.freshFor) {
+			p.diagnosticLRU.MoveToFront(element)
+			return clonePrefetchDiagnostic(diagnostic), true
+		}
+		p.removeDiagnosticLocked(code)
+	}
+	return prefetchDiagnostic{}, false
+}
+
+func cloneAssignmentSnapshot(value assignmentSnapshot) assignmentSnapshot {
+	value.assignment.ProfitPercent = cloneDecimal(value.assignment.ProfitPercent)
+	value.warnings = append([]string(nil), value.warnings...)
+	return value
+}
+
+func clonePrefetchDiagnostic(value prefetchDiagnostic) prefetchDiagnostic {
+	value.warnings = append([]string(nil), value.warnings...)
+	return value
+}
+
+func clonePrefetchOutcome(value prefetchOutcome) prefetchOutcome {
+	copy := prefetchOutcome{}
+	if value.snapshot != nil {
+		snapshot := cloneAssignmentSnapshot(*value.snapshot)
+		copy.snapshot = &snapshot
+	}
+	if value.diagnostic != nil {
+		diagnostic := clonePrefetchDiagnostic(*value.diagnostic)
+		copy.diagnostic = &diagnostic
+	}
+	return copy
+}
+
+func cloneBatchDefaultMarkup(value batchDefaultMarkup) batchDefaultMarkup {
+	value.profit = cloneDecimal(value.profit)
+	return value
+}
+
+func equalBatchDefaultMarkup(left, right batchDefaultMarkup) bool {
+	if left.schema != right.schema || left.schemaVersion != right.schemaVersion || left.configured != right.configured || left.typeName != right.typeName || left.source != right.source || left.revision != right.revision {
+		return false
+	}
+	if left.profit == nil || right.profit == nil {
+		return left.profit == nil && right.profit == nil
+	}
+	return left.profit.String() == right.profit.String()
 }
 
 func (p *httpProvider) fetchCatalog(ctx context.Context) (*catalogSnapshot, error) {
@@ -577,7 +832,7 @@ func assignmentSnapshotFromWire(wire assignmentWire) assignmentSnapshot {
 	}
 }
 
-func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string) ([]batchAssignmentResult, error) {
+func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string) (batchAssignmentPage, error) {
 	var wire struct {
 		Schema         string `json:"schema"`
 		SchemaVersion  string `json:"schema_version"`
@@ -586,11 +841,13 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 		ErrorCount     int    `json:"error_count"`
 		MaximumCodes   int    `json:"maximum_codes"`
 		DefaultMarkup  struct {
-			Schema        string   `json:"schema"`
-			SchemaVersion string   `json:"schema_version"`
-			Configured    bool     `json:"configured"`
-			ProfitPercent *Decimal `json:"profit_percent"`
-			Source        string   `json:"source"`
+			Schema        string        `json:"schema"`
+			SchemaVersion string        `json:"schema_version"`
+			Configured    bool          `json:"configured"`
+			Type          string        `json:"type"`
+			ProfitPercent *batchDecimal `json:"profit_percent"`
+			Source        string        `json:"source"`
+			Revision      string        `json:"revision"`
 		} `json:"default_percentage_markup"`
 		Results []struct {
 			Code       string          `json:"code"`
@@ -606,22 +863,31 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 	if err := p.postJSON(ctx, p.config.BatchAssignmentPath, struct {
 		Codes []string `json:"codes"`
 	}{Codes: codes}, &wire); err != nil {
-		return nil, err
+		return batchAssignmentPage{}, err
 	}
 	if wire.Schema != "digitalogic.pricing-assignment-batch" || majorVersion(wire.SchemaVersion) != "1" {
-		return nil, &contractError{reason: "incompatible batch schema"}
+		return batchAssignmentPage{}, &contractError{reason: "incompatible batch schema"}
 	}
 	if wire.DefaultMarkup.Schema != "digitalogic.default-percentage-markup" || majorVersion(wire.DefaultMarkup.SchemaVersion) != "1" {
-		return nil, &contractError{reason: "incompatible default-markup schema"}
+		return batchAssignmentPage{}, &contractError{reason: "incompatible default-markup schema"}
 	}
-	if err := validateBatchDefaultMarkup(wire.DefaultMarkup.Configured, wire.DefaultMarkup.ProfitPercent, wire.DefaultMarkup.Source); err != nil {
-		return nil, err
+	defaultMarkup := batchDefaultMarkup{
+		schema:        wire.DefaultMarkup.Schema,
+		schemaVersion: wire.DefaultMarkup.SchemaVersion,
+		configured:    wire.DefaultMarkup.Configured,
+		typeName:      wire.DefaultMarkup.Type,
+		profit:        wire.DefaultMarkup.ProfitPercent.decimal(),
+		source:        wire.DefaultMarkup.Source,
+		revision:      wire.DefaultMarkup.Revision,
+	}
+	if err := validateBatchDefaultMarkup(defaultMarkup); err != nil {
+		return batchAssignmentPage{}, err
 	}
 	if wire.RequestedCount != len(codes) || len(wire.Results) != len(codes) || wire.MaximumCodes < len(codes) || wire.MaximumCodes > maximumBatchSize {
-		return nil, &contractError{reason: "batch cardinality does not match the request"}
+		return batchAssignmentPage{}, &contractError{reason: "batch cardinality does not match the request"}
 	}
 	if wire.ResolvedCount < 0 || wire.ErrorCount < 0 || wire.ResolvedCount+wire.ErrorCount != wire.RequestedCount {
-		return nil, &contractError{reason: "batch result counts are inconsistent"}
+		return batchAssignmentPage{}, &contractError{reason: "batch result counts are inconsistent"}
 	}
 
 	resolvedCount := 0
@@ -629,31 +895,32 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 	results := make([]batchAssignmentResult, 0, len(codes))
 	for index, result := range wire.Results {
 		if result.Code != codes[index] {
-			return nil, &contractError{reason: "batch result order or Code changed"}
+			return batchAssignmentPage{}, &contractError{reason: "batch result order or Code changed"}
 		}
 		switch result.Status {
 		case "ok":
 			resolvedCount++
 			if len(result.Assignment) == 0 || bytes.Equal(bytes.TrimSpace(result.Assignment), []byte("null")) {
-				return nil, &contractError{reason: "successful batch result omitted its assignment"}
+				return batchAssignmentPage{}, &contractError{reason: "successful batch result omitted its assignment"}
 			}
 			var assignment batchAssignmentWire
 			if err := json.Unmarshal(result.Assignment, &assignment); err != nil {
-				return nil, &contractError{reason: "successful batch assignment is malformed"}
+				return batchAssignmentPage{}, &contractError{reason: "successful batch assignment is malformed"}
 			}
 			if assignment.Code != result.Code {
-				return nil, &contractError{reason: "successful batch assignment Code mismatch"}
+				return batchAssignmentPage{}, &contractError{reason: "successful batch assignment Code mismatch"}
 			}
 			if len(assignment.LegacyMarkup) > 0 && !bytes.Equal(bytes.TrimSpace(assignment.LegacyMarkup), []byte("null")) {
-				return nil, &contractError{reason: "successful batch assignment used the legacy nested markup projection"}
+				return batchAssignmentPage{}, &contractError{reason: "successful batch assignment used the legacy nested markup projection"}
 			}
-			if err := validateBatchAssignmentMarkup(assignment, wire.DefaultMarkup.Configured, wire.DefaultMarkup.ProfitPercent); err != nil {
-				return nil, err
+			if err := validateBatchAssignmentMarkup(assignment, defaultMarkup); err != nil {
+				return batchAssignmentPage{}, err
 			}
+			profit := assignment.ProfitPercent.decimal()
 			snapshot := assignmentSnapshot{
 				assignment: Assignment{
 					MethodID:      strings.TrimSpace(assignment.MethodID),
-					ProfitPercent: cloneDecimal(assignment.ProfitPercent),
+					ProfitPercent: cloneDecimal(profit),
 				},
 				profitSource: strings.TrimSpace(assignment.ProfitSource),
 				warnings:     normalizedStrings(assignment.PricingWarnings),
@@ -662,33 +929,33 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 		case "error":
 			errorCount++
 			if len(result.Assignment) > 0 && !bytes.Equal(bytes.TrimSpace(result.Assignment), []byte("null")) {
-				return nil, &contractError{reason: "failed batch result included an assignment"}
+				return batchAssignmentPage{}, &contractError{reason: "failed batch result included an assignment"}
 			}
 			result.Error.Code = strings.TrimSpace(result.Error.Code)
 			if result.Error.Code == "" || result.Error.HTTPStatus < 100 || result.Error.HTTPStatus > 599 {
-				return nil, &contractError{reason: "failed batch result omitted its typed error"}
+				return batchAssignmentPage{}, &contractError{reason: "failed batch result omitted its typed error"}
 			}
 			warning := "product_pricing_assignment_batch_result_failed"
 			switch result.Error.Code {
 			case "digitalogic_product_code_not_found":
 				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusNotFound {
-					return nil, &contractError{reason: "not-found batch result changed its error semantics"}
+					return batchAssignmentPage{}, &contractError{reason: "not-found batch result changed its error semantics"}
 				}
 				warning = "product_pricing_assignment_not_found"
 			case "digitalogic_product_code_ambiguous":
 				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusConflict {
-					return nil, &contractError{reason: "ambiguous batch result changed its error semantics"}
+					return batchAssignmentPage{}, &contractError{reason: "ambiguous batch result changed its error semantics"}
 				}
 				warning = "product_pricing_assignment_ambiguous"
 			case "digitalogic_invalid_product_code":
 				if result.Error.Retryable || result.Error.HTTPStatus != http.StatusBadRequest {
-					return nil, &contractError{reason: "invalid-Code batch result changed its error semantics"}
+					return batchAssignmentPage{}, &contractError{reason: "invalid-Code batch result changed its error semantics"}
 				}
 				warning = "product_pricing_assignment_invalid"
 			default:
 				if result.Error.Retryable {
 					if result.Error.HTTPStatus < 500 {
-						return nil, &contractError{reason: "retryable batch result used a non-server error status"}
+						return batchAssignmentPage{}, &contractError{reason: "retryable batch result used a non-server error status"}
 					}
 					warning = "product_pricing_assignment_batch_result_retryable"
 				}
@@ -700,47 +967,56 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 			snapshot := assignmentSnapshot{warnings: []string{warning}}
 			results = append(results, batchAssignmentResult{code: result.Code, snapshot: &snapshot})
 		default:
-			return nil, &contractError{reason: "batch result status is invalid"}
+			return batchAssignmentPage{}, &contractError{reason: "batch result status is invalid"}
 		}
 	}
 	if resolvedCount != wire.ResolvedCount || errorCount != wire.ErrorCount {
-		return nil, &contractError{reason: "batch status counts do not match the envelope"}
+		return batchAssignmentPage{}, &contractError{reason: "batch status counts do not match the envelope"}
 	}
-	return results, nil
+	return batchAssignmentPage{defaultMarkup: defaultMarkup, results: results}, nil
 }
 
-func validateBatchDefaultMarkup(configured bool, profit *Decimal, source string) error {
-	source = strings.TrimSpace(source)
-	if configured {
-		if source != "global_default" || !validBatchPercentage(profit) {
+func validateBatchDefaultMarkup(markup batchDefaultMarkup) error {
+	if markup.typeName != strings.TrimSpace(markup.typeName) || markup.source != strings.TrimSpace(markup.source) || markup.revision != strings.TrimSpace(markup.revision) {
+		return &contractError{reason: "default markup fields are not canonical strings"}
+	}
+	if markup.typeName != "percentage" || markup.revision == "" {
+		return &contractError{reason: "default markup omitted its type or revision"}
+	}
+	if markup.configured {
+		if markup.source != "global_default" || !validBatchPercentage(markup.profit) {
 			return &contractError{reason: "configured default markup has inconsistent decimal/source semantics"}
 		}
 		return nil
 	}
-	if profit != nil || (source != "unset" && source != "invalid_storage") {
+	if markup.profit != nil || (markup.source != "unset" && markup.source != "invalid_storage") {
 		return &contractError{reason: "unconfigured default markup has inconsistent decimal/source semantics"}
 	}
 	return nil
 }
 
-func validateBatchAssignmentMarkup(assignment batchAssignmentWire, defaultConfigured bool, defaultProfit *Decimal) error {
+func validateBatchAssignmentMarkup(assignment batchAssignmentWire, defaultMarkup batchDefaultMarkup) error {
 	source := strings.TrimSpace(assignment.ProfitSource)
+	if source != assignment.ProfitSource {
+		return &contractError{reason: "assignment markup source is not canonical"}
+	}
 	warnings := normalizedStrings(assignment.PricingWarnings)
+	profit := assignment.ProfitPercent.decimal()
 	switch source {
 	case "global_default":
-		if !defaultConfigured || !validBatchPercentage(assignment.ProfitPercent) || !decimalEqual(assignment.ProfitPercent, defaultProfit) {
+		if !defaultMarkup.configured || !validBatchPercentage(profit) || !decimalEqual(profit, defaultMarkup.profit) {
 			return &contractError{reason: "global-default assignment does not match the shared default decimal"}
 		}
 	case "product_override":
-		if !validBatchPercentage(assignment.ProfitPercent) {
+		if !validBatchPercentage(profit) {
 			return &contractError{reason: "product override has an invalid exact percentage"}
 		}
 	case "unset":
-		if assignment.ProfitPercent != nil || len(warnings) == 0 {
+		if profit != nil || len(warnings) == 0 {
 			return &contractError{reason: "unset assignment omitted its diagnostic or included a decimal"}
 		}
 	case "":
-		if assignment.ProfitPercent != nil || len(warnings) == 0 {
+		if profit != nil || len(warnings) == 0 {
 			return &contractError{reason: "invalid assignment markup omitted its diagnostic or included a decimal"}
 		}
 	default:

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -1,9 +1,11 @@
 package pricingcatalog
 
 import (
+	"bytes"
 	"container/list"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,6 +37,50 @@ type assignmentEntry struct {
 	snapshot assignmentSnapshot
 }
 
+type prefetchDiagnostic struct {
+	warnings    []string
+	fetchedAt   time.Time
+	allowSingle bool
+}
+
+type assignmentWire struct {
+	Code            string   `json:"code"`
+	MethodID        string   `json:"import_freight_method_id"`
+	ProfitPercent   *Decimal `json:"profit_percent"`
+	PricingWarnings []string `json:"pricing_warnings"`
+	Markup          struct {
+		ProfitPercent *Decimal `json:"profit_percent"`
+		Warning       string   `json:"warning"`
+	} `json:"markup"`
+}
+
+type batchAssignmentResult struct {
+	code     string
+	snapshot *assignmentSnapshot
+	warnings []string
+}
+
+type remoteStatusError struct {
+	status int
+}
+
+func (e *remoteStatusError) Error() string {
+	return fmt.Sprintf("HTTP status %d", e.status)
+}
+
+type contractError struct {
+	reason string
+}
+
+func (e *contractError) Error() string {
+	return "invalid JSON contract: " + e.reason
+}
+
+var (
+	errRequestTooLarge  = errors.New("request exceeds configured limit")
+	errResponseTooLarge = errors.New("response exceeds configured limit")
+)
+
 type httpProvider struct {
 	config   DigitalogicConfig
 	client   *http.Client
@@ -44,13 +90,15 @@ type httpProvider struct {
 
 	mu             sync.Mutex
 	catalogFetchMu sync.Mutex
+	prefetchMu     sync.Mutex
 	catalog        *catalogSnapshot
 	assignments    map[string]*list.Element
+	diagnostics    map[string]prefetchDiagnostic
 	lru            *list.List
 	configError    string
 }
 
-func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time.Time) Provider {
+func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time.Time) *httpProvider {
 	normalized := Normalize(Config{Mode: ModeDigitalogic, Digitalogic: cfg}).Digitalogic
 	if now == nil {
 		now = time.Now
@@ -70,6 +118,7 @@ func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time
 		freshFor:    parseDuration(normalized.FreshFor, defaultFreshFor),
 		maxStale:    parseDuration(normalized.MaxStale, defaultMaxStale),
 		assignments: make(map[string]*list.Element),
+		diagnostics: make(map[string]prefetchDiagnostic),
 		lru:         list.New(),
 	}
 	provider.configError = validateBaseURL(normalized.BaseURL)
@@ -80,6 +129,8 @@ func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time
 			provider.configError = "pricing_assignment_path_invalid"
 		} else if _, err := joinURL(normalized.BaseURL, strings.ReplaceAll(normalized.AssignmentPath, "{code}", "probe")); err != nil {
 			provider.configError = "pricing_assignment_path_invalid"
+		} else if _, err := joinURL(normalized.BaseURL, normalized.BatchAssignmentPath); err != nil {
+			provider.configError = "pricing_assignment_batch_path_invalid"
 		}
 	}
 	return provider
@@ -95,6 +146,74 @@ func validateBaseURL(value string) string {
 		return "pricing_catalog_https_required"
 	}
 	return ""
+}
+
+// Prefetch resolves uncached assignments in bounded request-order chunks. A
+// server that does not yet expose the versioned endpoint falls back to the
+// existing per-Code resolver. Authentication, transport, response-limit, and
+// malformed-contract failures are retained as per-Code diagnostics and block
+// an unsafe second request path for the current freshness window.
+func (p *httpProvider) Prefetch(ctx context.Context, codes []string) {
+	if p.configError != "" || len(codes) == 0 {
+		return
+	}
+	p.prefetchMu.Lock()
+	defer p.prefetchMu.Unlock()
+	if catalog, _, _ := p.resolveCatalog(ctx); catalog == nil {
+		return
+	}
+
+	now := p.now().UTC()
+	seen := make(map[string]struct{}, len(codes))
+	pending := make([]string, 0, len(codes))
+	p.mu.Lock()
+	for _, code := range codes {
+		code = strings.TrimSpace(code)
+		if code == "" {
+			continue
+		}
+		if _, exists := seen[code]; exists {
+			continue
+		}
+		seen[code] = struct{}{}
+		if element := p.assignments[code]; element != nil {
+			cached := element.Value.(*assignmentEntry).snapshot
+			if withinAge(now, cached.fetchedAt, p.freshFor) {
+				p.lru.MoveToFront(element)
+				continue
+			}
+		}
+		pending = append(pending, code)
+	}
+	p.mu.Unlock()
+
+	for offset := 0; offset < len(pending); offset += p.config.BatchSize {
+		end := offset + p.config.BatchSize
+		if end > len(pending) {
+			end = len(pending)
+		}
+		chunk := pending[offset:end]
+		results, err := p.fetchAssignmentBatch(ctx, chunk)
+		if err != nil {
+			remaining := pending[offset:]
+			if isUnsupportedBatchEndpoint(err) {
+				p.storePrefetchDiagnostic(remaining, []string{"pricing_assignment_batch_unsupported"}, now, true)
+				return
+			}
+			p.storePrefetchDiagnostic(remaining, []string{batchFailureWarning(err)}, now, false)
+			return
+		}
+
+		for _, result := range results {
+			if result.snapshot != nil {
+				snapshot := *result.snapshot
+				snapshot.fetchedAt = now
+				p.storeAssignment(result.code, snapshot)
+				continue
+			}
+			p.storePrefetchDiagnostic([]string{result.code}, result.warnings, now, false)
+		}
+	}
 }
 
 func (p *httpProvider) Resolve(ctx context.Context, code string) Resolution {
@@ -181,14 +300,37 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 
 func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*assignmentSnapshot, string, []string) {
 	now := p.now().UTC()
+	prefetchWarnings := []string(nil)
 	p.mu.Lock()
+	if diagnostic, ok := p.diagnostics[code]; ok {
+		if withinAge(now, diagnostic.fetchedAt, p.freshFor) {
+			prefetchWarnings = append(prefetchWarnings, diagnostic.warnings...)
+			if !diagnostic.allowSingle {
+				if element := p.assignments[code]; element != nil {
+					cached := element.Value.(*assignmentEntry).snapshot
+					if withinAge(now, cached.fetchedAt, p.maxStale) {
+						p.lru.MoveToFront(element)
+						p.mu.Unlock()
+						copy := cached
+						warnings := append(append([]string(nil), cached.warnings...), prefetchWarnings...)
+						return &copy, "stale", normalizedStrings(warnings)
+					}
+				}
+				p.mu.Unlock()
+				return nil, "unavailable", normalizedStrings(prefetchWarnings)
+			}
+		} else {
+			delete(p.diagnostics, code)
+		}
+	}
 	if element, ok := p.assignments[code]; ok {
 		p.lru.MoveToFront(element)
 		cached := element.Value.(*assignmentEntry).snapshot
 		if withinAge(now, cached.fetchedAt, p.freshFor) {
 			p.mu.Unlock()
 			copy := cached
-			return &copy, "fresh", append([]string(nil), cached.warnings...)
+			warnings := append(append([]string(nil), cached.warnings...), prefetchWarnings...)
+			return &copy, "fresh", normalizedStrings(warnings)
 		}
 	}
 	p.mu.Unlock()
@@ -198,7 +340,8 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 		fetched.fetchedAt = now
 		p.storeAssignment(code, fetched)
 		copy := fetched
-		return &copy, "fresh", append([]string(nil), fetched.warnings...)
+		warnings := append(append([]string(nil), fetched.warnings...), prefetchWarnings...)
+		return &copy, "fresh", normalizedStrings(warnings)
 	}
 
 	p.mu.Lock()
@@ -209,16 +352,20 @@ func (p *httpProvider) resolveAssignment(ctx context.Context, code string) (*ass
 			p.lru.MoveToFront(element)
 			p.mu.Unlock()
 			copy := cached
-			return &copy, "stale", append(append([]string(nil), cached.warnings...), "product_pricing_assignment_fetch_failed")
+			warnings := append(append([]string(nil), cached.warnings...), prefetchWarnings...)
+			warnings = append(warnings, "product_pricing_assignment_fetch_failed")
+			return &copy, "stale", normalizedStrings(warnings)
 		}
 	}
 	p.mu.Unlock()
-	return nil, "unavailable", []string{"product_pricing_assignment_fetch_failed"}
+	prefetchWarnings = append(prefetchWarnings, "product_pricing_assignment_fetch_failed")
+	return nil, "unavailable", normalizedStrings(prefetchWarnings)
 }
 
 func (p *httpProvider) storeAssignment(code string, snapshot assignmentSnapshot) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	delete(p.diagnostics, code)
 	if element, exists := p.assignments[code]; exists {
 		element.Value.(*assignmentEntry).snapshot = snapshot
 		p.lru.MoveToFront(element)
@@ -233,6 +380,19 @@ func (p *httpProvider) storeAssignment(code string, snapshot assignmentSnapshot)
 		}
 		delete(p.assignments, oldest.Value.(*assignmentEntry).code)
 		p.lru.Remove(oldest)
+	}
+}
+
+func (p *httpProvider) storePrefetchDiagnostic(codes, warnings []string, fetchedAt time.Time, allowSingle bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	warnings = normalizedStrings(warnings)
+	for _, code := range codes {
+		p.diagnostics[code] = prefetchDiagnostic{
+			warnings:    append([]string(nil), warnings...),
+			fetchedAt:   fetchedAt,
+			allowSingle: allowSingle,
+		}
 	}
 }
 
@@ -322,18 +482,14 @@ func withinAge(now, fetchedAt time.Time, limit time.Duration) bool {
 
 func (p *httpProvider) fetchAssignment(ctx context.Context, code string) (assignmentSnapshot, error) {
 	path := strings.ReplaceAll(p.config.AssignmentPath, "{code}", url.PathEscape(code))
-	var wire struct {
-		MethodID        string   `json:"import_freight_method_id"`
-		ProfitPercent   *Decimal `json:"profit_percent"`
-		PricingWarnings []string `json:"pricing_warnings"`
-		Markup          struct {
-			ProfitPercent *Decimal `json:"profit_percent"`
-			Warning       string   `json:"warning"`
-		} `json:"markup"`
-	}
+	var wire assignmentWire
 	if err := p.getJSON(ctx, path, &wire); err != nil {
 		return assignmentSnapshot{}, err
 	}
+	return assignmentSnapshotFromWire(wire), nil
+}
+
+func assignmentSnapshotFromWire(wire assignmentWire) assignmentSnapshot {
 	profit := wire.ProfitPercent
 	if wire.Markup.ProfitPercent != nil {
 		profit = wire.Markup.ProfitPercent
@@ -345,24 +501,149 @@ func (p *httpProvider) fetchAssignment(ctx context.Context, code string) (assign
 	return assignmentSnapshot{
 		assignment: Assignment{MethodID: strings.TrimSpace(wire.MethodID), ProfitPercent: cloneDecimal(profit)},
 		warnings:   normalizedStrings(warnings),
-	}, nil
+	}
+}
+
+func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string) ([]batchAssignmentResult, error) {
+	var wire struct {
+		Schema         string `json:"schema"`
+		SchemaVersion  string `json:"schema_version"`
+		RequestedCount int    `json:"requested_count"`
+		ResolvedCount  int    `json:"resolved_count"`
+		ErrorCount     int    `json:"error_count"`
+		MaximumCodes   int    `json:"maximum_codes"`
+		DefaultMarkup  struct {
+			Schema        string   `json:"schema"`
+			SchemaVersion string   `json:"schema_version"`
+			Configured    bool     `json:"configured"`
+			ProfitPercent *Decimal `json:"profit_percent"`
+		} `json:"default_percentage_markup"`
+		Results []struct {
+			Code       string          `json:"code"`
+			Status     string          `json:"status"`
+			Assignment json.RawMessage `json:"assignment"`
+			Error      struct {
+				Code       string `json:"code"`
+				HTTPStatus int    `json:"http_status"`
+				Retryable  bool   `json:"retryable"`
+			} `json:"error"`
+		} `json:"results"`
+	}
+	if err := p.postJSON(ctx, p.config.BatchAssignmentPath, struct {
+		Codes []string `json:"codes"`
+	}{Codes: codes}, &wire); err != nil {
+		return nil, err
+	}
+	if wire.Schema != "digitalogic.pricing-assignment-batch" || majorVersion(wire.SchemaVersion) != "1" {
+		return nil, &contractError{reason: "incompatible batch schema"}
+	}
+	if wire.DefaultMarkup.Schema != "digitalogic.default-percentage-markup" || majorVersion(wire.DefaultMarkup.SchemaVersion) != "1" {
+		return nil, &contractError{reason: "incompatible default-markup schema"}
+	}
+	if wire.DefaultMarkup.Configured && wire.DefaultMarkup.ProfitPercent == nil {
+		return nil, &contractError{reason: "configured default markup is missing its decimal"}
+	}
+	if wire.RequestedCount != len(codes) || len(wire.Results) != len(codes) || wire.MaximumCodes < len(codes) || wire.MaximumCodes > maximumBatchSize {
+		return nil, &contractError{reason: "batch cardinality does not match the request"}
+	}
+	if wire.ResolvedCount < 0 || wire.ErrorCount < 0 || wire.ResolvedCount+wire.ErrorCount != wire.RequestedCount {
+		return nil, &contractError{reason: "batch result counts are inconsistent"}
+	}
+
+	resolvedCount := 0
+	errorCount := 0
+	results := make([]batchAssignmentResult, 0, len(codes))
+	for index, result := range wire.Results {
+		if result.Code != codes[index] {
+			return nil, &contractError{reason: "batch result order or Code changed"}
+		}
+		switch result.Status {
+		case "ok":
+			resolvedCount++
+			if len(result.Assignment) == 0 || bytes.Equal(bytes.TrimSpace(result.Assignment), []byte("null")) {
+				return nil, &contractError{reason: "successful batch result omitted its assignment"}
+			}
+			var assignment assignmentWire
+			if err := json.Unmarshal(result.Assignment, &assignment); err != nil {
+				return nil, &contractError{reason: "successful batch assignment is malformed"}
+			}
+			if strings.TrimSpace(assignment.Code) != result.Code {
+				return nil, &contractError{reason: "successful batch assignment Code mismatch"}
+			}
+			snapshot := assignmentSnapshotFromWire(assignment)
+			results = append(results, batchAssignmentResult{code: result.Code, snapshot: &snapshot})
+		case "error":
+			errorCount++
+			warning := "product_pricing_assignment_batch_result_failed"
+			switch result.Error.Code {
+			case "digitalogic_product_code_not_found":
+				warning = "product_pricing_assignment_not_found"
+			case "digitalogic_product_code_ambiguous":
+				warning = "product_pricing_assignment_ambiguous"
+			case "digitalogic_invalid_product_code":
+				warning = "product_pricing_assignment_invalid"
+			default:
+				results = append(results, batchAssignmentResult{code: result.Code, warnings: []string{warning}})
+				continue
+			}
+			snapshot := assignmentSnapshot{warnings: []string{warning}}
+			results = append(results, batchAssignmentResult{code: result.Code, snapshot: &snapshot})
+		default:
+			return nil, &contractError{reason: "batch result status is invalid"}
+		}
+	}
+	if resolvedCount != wire.ResolvedCount || errorCount != wire.ErrorCount {
+		return nil, &contractError{reason: "batch status counts do not match the envelope"}
+	}
+	return results, nil
 }
 
 func (p *httpProvider) getJSON(ctx context.Context, path string, target interface{}) error {
+	return p.doJSON(ctx, http.MethodGet, path, nil, target)
+}
+
+func (p *httpProvider) postJSON(ctx context.Context, path string, payload, target interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if int64(len(body)) > p.config.MaxResponseBytes {
+		return errRequestTooLarge
+	}
+	return p.doJSON(ctx, http.MethodPost, path, body, target)
+}
+
+func (p *httpProvider) doJSON(ctx context.Context, method, path string, body []byte, target interface{}) error {
 	endpoint, err := joinURL(p.config.BaseURL, path)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "patris-export")
-	if token := strings.TrimSpace(os.Getenv(p.config.BearerTokenEnv)); p.config.BearerTokenEnv != "" && token != "" {
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if p.config.BearerTokenEnv != "" {
+		token := strings.TrimSpace(os.Getenv(p.config.BearerTokenEnv))
+		if token == "" {
+			return errors.New("configured bearer credential is unavailable")
+		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	} else if p.config.UsernameEnv != "" || p.config.PasswordEnv != "" {
-		req.SetBasicAuth(os.Getenv(p.config.UsernameEnv), os.Getenv(p.config.PasswordEnv))
+		username := os.Getenv(p.config.UsernameEnv)
+		password := os.Getenv(p.config.PasswordEnv)
+		if p.config.UsernameEnv == "" || p.config.PasswordEnv == "" || username == "" || password == "" {
+			return errors.New("configured basic credential is unavailable")
+		}
+		req.SetBasicAuth(username, password)
 	}
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -371,15 +652,15 @@ func (p *httpProvider) getJSON(ctx context.Context, path string, target interfac
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("HTTP status %d", resp.StatusCode)
+		return &remoteStatusError{status: resp.StatusCode}
 	}
-	reader := io.LimitReader(resp.Body, p.config.MaxResponseBytes+1)
-	data, err := io.ReadAll(reader)
+	responseReader := io.LimitReader(resp.Body, p.config.MaxResponseBytes+1)
+	data, err := io.ReadAll(responseReader)
 	if err != nil {
 		return err
 	}
 	if int64(len(data)) > p.config.MaxResponseBytes {
-		return fmt.Errorf("response exceeds configured limit")
+		return errResponseTooLarge
 	}
 	var envelope struct {
 		Success *bool           `json:"success"`
@@ -387,14 +668,38 @@ func (p *httpProvider) getJSON(ctx context.Context, path string, target interfac
 	}
 	if err := json.Unmarshal(data, &envelope); err == nil && len(envelope.Data) > 0 {
 		if envelope.Success != nil && !*envelope.Success {
-			return fmt.Errorf("remote API reported failure")
+			return &contractError{reason: "remote API reported failure"}
 		}
 		data = envelope.Data
 	}
 	if err := json.Unmarshal(data, target); err != nil {
-		return fmt.Errorf("invalid JSON contract: %w", err)
+		return &contractError{reason: "JSON decode failed"}
 	}
 	return nil
+}
+
+func isUnsupportedBatchEndpoint(err error) bool {
+	var status *remoteStatusError
+	return errors.As(err, &status) && (status.status == http.StatusNotFound || status.status == http.StatusMethodNotAllowed || status.status == http.StatusNotImplemented)
+}
+
+func batchFailureWarning(err error) string {
+	var status *remoteStatusError
+	var contract *contractError
+	switch {
+	case errors.As(err, &status) && (status.status == http.StatusUnauthorized || status.status == http.StatusForbidden):
+		return "pricing_assignment_batch_auth_failed"
+	case errors.As(err, &status):
+		return "pricing_assignment_batch_http_failed"
+	case errors.Is(err, errRequestTooLarge):
+		return "pricing_assignment_batch_request_too_large"
+	case errors.Is(err, errResponseTooLarge):
+		return "pricing_assignment_batch_response_too_large"
+	case errors.As(err, &contract):
+		return "pricing_assignment_batch_contract_invalid"
+	default:
+		return "pricing_assignment_batch_transport_failed"
+	}
 }
 
 func joinURL(base, path string) (string, error) {

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -641,7 +641,7 @@ func (p *httpProvider) fetchAssignmentBatch(ctx context.Context, codes []string)
 			if err := json.Unmarshal(result.Assignment, &assignment); err != nil {
 				return nil, &contractError{reason: "successful batch assignment is malformed"}
 			}
-			if strings.TrimSpace(assignment.Code) != result.Code {
+			if assignment.Code != result.Code {
 				return nil, &contractError{reason: "successful batch assignment Code mismatch"}
 			}
 			if len(assignment.LegacyMarkup) > 0 && !bytes.Equal(bytes.TrimSpace(assignment.LegacyMarkup), []byte("null")) {

--- a/testdata/digitalogic-pricing-assignment-batch-v1.golden.json
+++ b/testdata/digitalogic-pricing-assignment-batch-v1.golden.json
@@ -12,9 +12,9 @@
     "type": "percentage",
     "profit_percent": "30",
     "source": "global_default",
-    "revision": "sha256:fixture-default-markup",
+    "revision": "sha256:e1d7fcacade8a8c44486ae63e7ab3188205ac8135c1cb5c60d8e71e715b9f87e",
     "updated_at": "2026-07-16 12:00:00",
-    "updated_by": 1,
+    "updated_by": 0,
     "storage_present": true,
     "bounds": {
       "minimum": "0",
@@ -31,11 +31,8 @@
         "code": "113007045",
         "import_freight_method_id": "air_express",
         "profit_percent": "30",
-        "pricing_warnings": [],
-        "markup": {
-          "profit_percent": "30",
-          "warning": null
-        }
+        "profit_percent_source": "global_default",
+        "pricing_warnings": []
       }
     },
     {
@@ -43,7 +40,6 @@
       "status": "error",
       "error": {
         "code": "digitalogic_product_code_not_found",
-        "message": "No product has that exact Patris Code or SKU.",
         "http_status": 404,
         "retryable": false
       }

--- a/testdata/digitalogic-pricing-assignment-batch-v1.golden.json
+++ b/testdata/digitalogic-pricing-assignment-batch-v1.golden.json
@@ -1,0 +1,52 @@
+{
+  "schema": "digitalogic.pricing-assignment-batch",
+  "schema_version": "1.0.0",
+  "requested_count": 2,
+  "resolved_count": 1,
+  "error_count": 1,
+  "maximum_codes": 500,
+  "default_percentage_markup": {
+    "schema": "digitalogic.default-percentage-markup",
+    "schema_version": "1.0.0",
+    "configured": true,
+    "type": "percentage",
+    "profit_percent": "30",
+    "source": "global_default",
+    "revision": "sha256:fixture-default-markup",
+    "updated_at": "2026-07-16 12:00:00",
+    "updated_by": 1,
+    "storage_present": true,
+    "bounds": {
+      "minimum": "0",
+      "maximum": "1000",
+      "maximum_fraction_digits": 12
+    },
+    "warnings": []
+  },
+  "results": [
+    {
+      "code": "113007045",
+      "status": "ok",
+      "assignment": {
+        "code": "113007045",
+        "import_freight_method_id": "air_express",
+        "profit_percent": "30",
+        "pricing_warnings": [],
+        "markup": {
+          "profit_percent": "30",
+          "warning": null
+        }
+      }
+    },
+    {
+      "code": "MISSING",
+      "status": "error",
+      "error": {
+        "code": "digitalogic_product_code_not_found",
+        "message": "No product has that exact Patris Code or SKU.",
+        "http_status": 404,
+        "retryable": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #142.

Current server shape: atomicdeploy/digitalogic-wp#62 (merged). Least-privilege bearer scope: atomicdeploy/digitalogic-wp#60 (pending production prerequisite).

## Summary
- extends the existing `pricingcatalog` HTTP provider with an optional `Prefetcher` capability; static/disabled providers remain standalone and make no remote calls
- collects unique non-quarantined canonical Codes before row workers run and chunks them at a hard maximum of 500
- returns a transform-scoped, Code-bounded result barrier so the current run cannot lose successes or diagnostics when the persistent assignment/diagnostic LRUs are deliberately smaller than the transform; each scoped outcome is released after Resolve consumes it
- stages every chunk locally, validates one identical non-empty default-markup revision and full schema/configured/type/source/value contract across all pages, and commits results under one cache lock only after every page agrees
- requires batch pricing decimals to be quoted canonical base-10 strings with at most 12 fractional digits; unquoted numbers, exponent notation, redundant formatting, and over-scale values fail closed
- validates the single current `digitalogic.pricing-assignment-batch` shape: cardinality, order, exact Code correspondence, minimal assignment projection, typed error semantics, and exact `profit_percent` / `profit_percent_source` consistency; unavailable source/reference keys are omitted and JSON `null` is preserved only when explicitly supplied upstream
- consults fresh fail-closed diagnostics before cached assignments and keeps request-level batch backoff independently of the bounded per-Code diagnostic LRU, preventing repeated auth/transport/malformed requests across transforms
- uses one `bearer_token_env` for the integration-catalog GET and batch-assignment POST through the existing HTTPS/origin/redirect/client/timeout/body-limit path
- accepts only the current batch endpoint and response shape; 404/405/501, auth, transport, malformed responses, collisions, and non-retryable errors fail closed, while explicitly retryable per-Code 5xx results remain bounded retry cases

## Exact request proof
For 1,002 unique Codes at `batch_size: 500`, with the persistent cache adversarially reduced to `max_entries: 1`:

- integration catalog GET: **1**
- batch assignment POSTs: **3** (`500 + 500 + 2`)
- single-Code assignment GETs: **0**
- total pricing-input HTTP requests: **4**
- all 1,002 scoped assignments remain available to the concurrent row workers

## Verification
Final local tree at `38b675f`:

- CGO-aware `go test ./... -count=1`: pass
- CGO-aware `go vet ./...`: pass
- CGO-aware `go test -race ./pkg/pricingcatalog -count=1`: pass
- CGO-aware concurrent 1,002-Code canonical race proof: pass
- focused adversarial tests for auth/transport/malformed backoff, one-entry LRU barrier, revision-only page drift/atomic discard, and invalid decimal JSON/scale: pass
- frontend clean `npm ci`, `npm audit --audit-level=high`, `npm test`, and `npm run build`: pass (0 vulnerabilities; 10 tests)
- `go mod verify`: pass
- `git diff --check`: pass
- shared fixture SHA-256: `f56e4ce23c4e461e3676b79f743a5dc3182086cf40caa27fab325fc03750daa0`
- `govulncheck` could not query the official index from this host because `https://vuln.go.dev/index/modules.json.gz` returned HTTP 403; the merged #140 dependency/security update and networked CI remain authoritative

## Rollout sequencing
Do not enable the default batch path in production until the merged Digitalogic endpoint is deployed and the pending least-privilege read credential in atomicdeploy/digitalogic-wp#60 is implemented and deployed. Patris continues to work in static mode without Digitalogic; remote pricing uses only the current provider shape with no alternate response parser. This PR does not deploy, mutate WordPress data, or enable outbound delivery.
