### PR TITLE
Surface deferred reconciliation without retrying terminal delivery

### DIFF
--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -884,7 +884,7 @@ func sendConvertUpdate(cfg appconfig.Config, source string, result recordpipe.Re
 		return
 	}
 	if delivery.Status != "" {
-		infoColor.Printf("Send update delivered: status=%s event_id=%s attempts=%d pending_products=%d\n", delivery.Status, delivery.EventID, delivery.Attempts, delivery.PendingProducts)
+		infoColor.Printf("Send update delivered: %s\n", delivery.DiagnosticSummary())
 	}
 }
 

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -181,14 +181,37 @@ headers, and secret for every attempt. Network failures, HTTP 408/425/429 and
 selected 5xx transients, and receiver responses with `retryable: true`,
 `partially_applied`, or `retry_pending` are retried. The receiver's
 `accepted`, `already_current`, `replayed`, or `recovered` state is surfaced in
-the CLI/server log. Exhaustion reports only sanitized endpoint and structured
-status/attempt/pending counts; query strings, response bodies, request headers,
-and credential values are never included.
+the CLI/server log. Those terminal states may also report a bounded,
+non-negative `deferred_products` count for Codes that require later catalog
+reconciliation (for example, a product that does not exist in WooCommerce or
+an exact Code/SKU collision that must not be guessed). Deferred reconciliation
+is durable receiver work, not a delivery failure: it is logged as a count only
+and does not cause another HTTP attempt. A missing `deferred_products` field is
+treated as zero for compatibility with existing receivers.
+
+The receiver may include a sibling `deferred_reconciliation` summary containing
+native integer `missing`, `ambiguous`, and `details_truncated` counts plus at
+most 100 detail objects. Patris validates that missing plus ambiguous, and the
+detail count plus truncated count, both equal `deferred_products`; it then
+discards the detail objects. The summary is optional for replaceable receivers,
+and neither its product Codes nor reason details enter logs or delivery errors.
+
+Only `pending_products` represents transient apply work and causes a retry.
+A mixed response may carry both counts, but it remains partial only while the
+pending count is positive. Once pending work recovers, the receiver returns a
+terminal state with `retryable: false` and `pending_products: 0`, even if a
+nonzero deferred count remains. Exhaustion reports only the sanitized endpoint
+and structured status/attempt/pending/deferred counts; query strings, response
+bodies, product identities, request headers, and credential values are never
+included. This distinction is paired with the bounded reconciliation state in
+`atomicdeploy/digitalogic-wp#64`.
 
 Typed receiver responses fail closed unless their state is internally
 consistent: terminal states require zero pending products and
 `retryable: false`; partial/pending states require a positive pending count and
-`retryable: true`. Unknown states and a mismatched or missing event ID are not
+`retryable: true`. The deferred count must be an integer from zero through
+2,147,483,647; negative, fractional, null, overflowing, or otherwise malformed
+counts fail closed. Unknown states and a mismatched or missing event ID are not
 treated as delivery success.
 
 Equivalent environment-only configuration uses

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1368,7 +1368,7 @@ func (s *Server) dispatchUpdateEvent(event updateout.Event) {
 			return
 		}
 		if result.Status != "" {
-			log.Printf("Sent update event: status=%s event_id=%s attempts=%d pending_products=%d", result.Status, result.EventID, result.Attempts, result.PendingProducts)
+			log.Printf("Sent update event: %s", result.DiagnosticSummary())
 		}
 	}()
 }

--- a/pkg/updateout/updateout.go
+++ b/pkg/updateout/updateout.go
@@ -39,6 +39,13 @@ type Config struct {
 
 const productSyncSecretHeader = "X-Digitalogic-Product-Sync-Secret"
 
+// Receiver-reported product counts use a stable, architecture-independent
+// bound. The Digitalogic receiver may enforce a lower storage bound, but a
+// response above this limit is never safe to accept as delivery state.
+const maxReceiverReportedProducts uint64 = 1<<31 - 1
+
+const maxReceiverDeferredDetails = 100
+
 var (
 	errReceiverRejected         = errors.New("receiver rejected request")
 	errReceiverHTTPStatus       = errors.New("receiver returned non-success HTTP status")
@@ -54,24 +61,37 @@ var (
 // its response body or any credential material. Generic webhooks leave Status
 // and EventID empty.
 type DeliveryResult struct {
-	HTTPStatus      int
-	Status          string
-	EventID         string
-	Retryable       bool
-	PendingProducts int
-	Attempts        int
+	HTTPStatus       int
+	Status           string
+	EventID          string
+	Retryable        bool
+	PendingProducts  int
+	DeferredProducts int
+	Attempts         int
+}
+
+// DiagnosticSummary returns only sanitized receiver state. It deliberately
+// has no access to response bodies, product identities, endpoint query
+// strings, request headers, or credentials.
+func (result DeliveryResult) DiagnosticSummary() string {
+	return fmt.Sprintf(
+		"status=%s event_id=%s attempts=%d pending_products=%d deferred_products=%d",
+		safeToken(result.Status), safeToken(result.EventID), result.Attempts,
+		result.PendingProducts, result.DeferredProducts,
+	)
 }
 
 // DeliveryError is safe to print. Endpoint query strings, response bodies,
 // request headers, and transport error strings are deliberately excluded.
 type DeliveryError struct {
-	Endpoint        string
-	HTTPStatus      int
-	Status          string
-	Attempts        int
-	PendingProducts int
-	Retryable       bool
-	Reason          string
+	Endpoint         string
+	HTTPStatus       int
+	Status           string
+	Attempts         int
+	PendingProducts  int
+	DeferredProducts int
+	Retryable        bool
+	Reason           string
 }
 
 func (e *DeliveryError) Error() string {
@@ -87,6 +107,9 @@ func (e *DeliveryError) Error() string {
 	}
 	if e.PendingProducts > 0 {
 		parts = append(parts, fmt.Sprintf("pending_products=%d", e.PendingProducts))
+	}
+	if e.DeferredProducts > 0 {
+		parts = append(parts, fmt.Sprintf("deferred_products=%d", e.DeferredProducts))
 	}
 	if e.Attempts > 0 {
 		parts = append(parts, fmt.Sprintf("attempts=%d", e.Attempts))
@@ -371,10 +394,12 @@ type receiverResponse struct {
 	Success *bool  `json:"success"`
 	Code    string `json:"code"`
 	Data    struct {
-		Status          string `json:"status"`
-		EventID         string `json:"event_id"`
-		Retryable       bool   `json:"retryable"`
-		PendingProducts int    `json:"pending_products"`
+		Status                 string          `json:"status"`
+		EventID                string          `json:"event_id"`
+		Retryable              bool            `json:"retryable"`
+		PendingProducts        int             `json:"pending_products"`
+		DeferredProducts       json.RawMessage `json:"deferred_products"`
+		DeferredReconciliation json.RawMessage `json:"deferred_reconciliation"`
 	} `json:"data"`
 	Details struct {
 		Retryable bool `json:"retryable"`
@@ -386,25 +411,35 @@ func classifyHTTPResponse(result DeliveryResult, body []byte, contract *canonica
 	isProductSync := contract != nil && contract.Schema == canonical.ContractName
 	decodedOK := isProductSync && len(bytes.TrimSpace(body)) > 0 && json.Unmarshal(body, &decoded) == nil && decoded.Success != nil
 	receiverRejected := false
+	var receiverStateError error
 	if decodedOK {
-		result.Status = safeToken(decoded.Data.Status)
-		result.EventID = safeToken(decoded.Data.EventID)
-		result.PendingProducts = decoded.Data.PendingProducts
-		result.Retryable = decoded.Data.Retryable
-		if contract != nil && result.EventID != "" && result.EventID != contract.EventID {
-			result.Retryable = false
-			return result, errReceiverIdentityMismatch
+		deferredProducts, err := receiverProductCount(decoded.Data.DeferredProducts)
+		if err == nil {
+			err = validateDeferredReconciliation(decoded.Data.DeferredReconciliation, deferredProducts)
 		}
-		if *decoded.Success {
-			if err := validateReceiverState(result); err != nil {
-				result.Retryable = false
-				return result, err
-			}
+		if err != nil {
+			receiverStateError = err
 		} else {
-			receiverRejected = true
-			result.Retryable = decoded.Data.Retryable || decoded.Details.Retryable
-			if result.Status == "" {
-				result.Status = safeToken(decoded.Code)
+			result.Status = safeToken(decoded.Data.Status)
+			result.EventID = safeToken(decoded.Data.EventID)
+			result.PendingProducts = decoded.Data.PendingProducts
+			result.DeferredProducts = deferredProducts
+			result.Retryable = decoded.Data.Retryable
+			if contract != nil && result.EventID != "" && result.EventID != contract.EventID {
+				result.Retryable = false
+				return result, errReceiverIdentityMismatch
+			}
+			if *decoded.Success {
+				if err := validateReceiverState(result); err != nil {
+					result.Retryable = false
+					return result, err
+				}
+			} else {
+				receiverRejected = true
+				result.Retryable = decoded.Data.Retryable || decoded.Details.Retryable
+				if result.Status == "" {
+					result.Status = safeToken(decoded.Code)
+				}
 			}
 		}
 	}
@@ -413,6 +448,10 @@ func classifyHTTPResponse(result DeliveryResult, body []byte, contract *canonica
 			result.Retryable = true
 		}
 		return result, errReceiverHTTPStatus
+	}
+	if receiverStateError != nil {
+		result.Retryable = false
+		return result, receiverStateError
 	}
 	if receiverRejected {
 		return result, errReceiverRejected
@@ -424,6 +463,75 @@ func classifyHTTPResponse(result DeliveryResult, body []byte, contract *canonica
 		}
 	}
 	return result, nil
+}
+
+func receiverProductCount(raw json.RawMessage) (int, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	if bytes.Equal(raw, []byte("null")) {
+		return 0, errReceiverStateInvalid
+	}
+	var count uint64
+	if err := json.Unmarshal(raw, &count); err != nil || count > maxReceiverReportedProducts {
+		return 0, errReceiverStateInvalid
+	}
+	return int(count), nil
+}
+
+type receiverDeferredReconciliation struct {
+	Missing          json.RawMessage   `json:"missing"`
+	Ambiguous        json.RawMessage   `json:"ambiguous"`
+	Details          []json.RawMessage `json:"details"`
+	DetailsTruncated json.RawMessage   `json:"details_truncated"`
+}
+
+func validateDeferredReconciliation(raw json.RawMessage, total int) error {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil
+	}
+	if bytes.Equal(raw, []byte("null")) {
+		return errReceiverStateInvalid
+	}
+	var summary receiverDeferredReconciliation
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return errReceiverStateInvalid
+	}
+	missing, err := requiredReceiverProductCount(summary.Missing)
+	if err != nil {
+		return err
+	}
+	ambiguous, err := requiredReceiverProductCount(summary.Ambiguous)
+	if err != nil {
+		return err
+	}
+	truncated, err := requiredReceiverProductCount(summary.DetailsTruncated)
+	if err != nil {
+		return err
+	}
+	if summary.Details == nil || len(summary.Details) > maxReceiverDeferredDetails {
+		return errReceiverStateInvalid
+	}
+	for _, detail := range summary.Details {
+		detail = bytes.TrimSpace(detail)
+		if len(detail) < 2 || detail[0] != '{' || detail[len(detail)-1] != '}' {
+			return errReceiverStateInvalid
+		}
+	}
+	deferred := uint64(total)
+	if uint64(missing)+uint64(ambiguous) != deferred || uint64(len(summary.Details))+uint64(truncated) != deferred {
+		return errReceiverStateInvalid
+	}
+	return nil
+}
+
+func requiredReceiverProductCount(raw json.RawMessage) (int, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return 0, errReceiverStateInvalid
+	}
+	return receiverProductCount(raw)
 }
 
 func validateReceiverState(result DeliveryResult) error {
@@ -498,7 +606,7 @@ func waitForRetry(ctx context.Context, delay time.Duration) error {
 func deliveryError(endpoint string, result DeliveryResult, retryable bool, reason string) error {
 	return &DeliveryError{
 		Endpoint: endpoint, HTTPStatus: result.HTTPStatus, Status: result.Status,
-		Attempts: result.Attempts, PendingProducts: result.PendingProducts,
+		Attempts: result.Attempts, PendingProducts: result.PendingProducts, DeferredProducts: result.DeferredProducts,
 		Retryable: retryable, Reason: reason,
 	}
 }

--- a/pkg/updateout/updateout_test.go
+++ b/pkg/updateout/updateout_test.go
@@ -255,9 +255,9 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 			w.WriteHeader(http.StatusServiceUnavailable)
 			fmt.Fprintf(w, `{"success":false,"code":"digitalogic_product_sync_busy","details":{"retryable":true}}`)
 		case 2:
-			fmt.Fprintf(w, `{"success":true,"data":{"status":"partially_applied","event_id":%q,"retryable":true,"pending_products":1}}`, contract.EventID)
+			fmt.Fprintf(w, `{"success":true,"data":{"status":"partially_applied","event_id":%q,"retryable":true,"pending_products":1,"deferred_products":2}}`, contract.EventID)
 		default:
-			fmt.Fprintf(w, `{"success":true,"data":{"status":"recovered","event_id":%q,"retryable":false,"pending_products":0}}`, contract.EventID)
+			fmt.Fprintf(w, `{"success":true,"data":{"status":"recovered","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":2}}`, contract.EventID)
 		}
 	}))
 	defer server.Close()
@@ -277,7 +277,7 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 	if err != nil {
 		t.Fatalf("product-sync dispatch failed: %v", err)
 	}
-	if result.Status != "recovered" || result.EventID != contract.EventID || result.Attempts != 3 || result.Retryable || result.PendingProducts != 0 {
+	if result.Status != "recovered" || result.EventID != contract.EventID || result.Attempts != 3 || result.Retryable || result.PendingProducts != 0 || result.DeferredProducts != 2 {
 		t.Fatalf("unexpected recovery result: %+v", result)
 	}
 	if attempts != 3 || len(bodies) != 3 || !bytes.Equal(bodies[0], bodies[1]) || !bytes.Equal(bodies[1], bodies[2]) {
@@ -292,13 +292,39 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 	}
 }
 
+func TestDispatchDigitalogicTerminalDeferredProductsDoNotRetry(t *testing.T) {
+	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", "terminal-deferred")
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":781,"deferred_reconciliation":{"missing":780,"ambiguous":1,"details":[{"product_code":"MISSING-SENSITIVE","reason":"missing","code":"not_found"},{"product_code":"AMBIGUOUS-SENSITIVE","reason":"ambiguous","code":"collision"}],"details_truncated":779}}}`, contract.EventID)
+	}))
+	defer server.Close()
+
+	result, err := DispatchWithResult(t.Context(), Config{
+		Enabled: true, URL: server.URL, Format: "json", RequireContract: true,
+		RetryAttempts: 3, RetryBackoff: "1ns", ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+	}, Event{Type: "initial", Source: "kala.db", Contract: contract})
+	if err != nil {
+		t.Fatalf("terminal deferred reconciliation was rejected: %v", err)
+	}
+	if attempts != 1 || result.Attempts != 1 || result.Retryable || result.PendingProducts != 0 || result.DeferredProducts != 781 {
+		t.Fatalf("terminal deferred reconciliation triggered a retry: attempts=%d result=%+v", attempts, result)
+	}
+	if summary := result.DiagnosticSummary(); !strings.Contains(summary, "deferred_products=781") || strings.Contains(summary, "kala.db") || strings.Contains(summary, "SENSITIVE") {
+		t.Fatalf("diagnostic summary was incomplete or exposed source data: %s", summary)
+	}
+}
+
 func TestDispatchDigitalogicPartialExhaustionIsSafeToLog(t *testing.T) {
 	const secret = "must-never-appear-in-errors"
 	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", secret)
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"success":true,"data":{"status":"retry_pending","event_id":%q,"retryable":true,"pending_products":2}}`, contract.EventID)
+		fmt.Fprintf(w, `{"success":true,"data":{"status":"retry_pending","event_id":%q,"retryable":true,"pending_products":2,"deferred_products":4,"deferred_product_codes":["SENSITIVE-CODE"]}}`, contract.EventID)
 	}))
 	defer server.Close()
 
@@ -309,16 +335,16 @@ func TestDispatchDigitalogicPartialExhaustionIsSafeToLog(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected retry exhaustion")
 	}
-	if result.Status != "retry_pending" || result.Attempts != 2 || result.PendingProducts != 2 || !result.Retryable {
+	if result.Status != "retry_pending" || result.Attempts != 2 || result.PendingProducts != 2 || result.DeferredProducts != 4 || !result.Retryable {
 		t.Fatalf("retry state was not surfaced: %+v", result)
 	}
 	text := err.Error()
-	for _, forbidden := range []string{secret, productSyncSecretHeader} {
+	for _, forbidden := range []string{secret, productSyncSecretHeader, "SENSITIVE-CODE"} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("safe delivery error leaked %q: %s", forbidden, text)
 		}
 	}
-	for _, expected := range []string{"status=retry_pending", "pending_products=2", "attempts=2", "retryable=true"} {
+	for _, expected := range []string{"status=retry_pending", "pending_products=2", "deferred_products=4", "attempts=2", "retryable=true"} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("delivery error did not surface %q: %s", expected, text)
 		}
@@ -380,14 +406,15 @@ func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
 		status    string
 		retryable bool
 		pending   int
+		deferred  int
 		wantError bool
 	}{
-		{name: "accepted", status: "accepted"},
-		{name: "already current", status: "already_current"},
-		{name: "replayed", status: "replayed"},
-		{name: "recovered", status: "recovered"},
-		{name: "partial", status: "partially_applied", retryable: true, pending: 1},
-		{name: "retry pending", status: "retry_pending", retryable: true, pending: 2},
+		{name: "accepted", status: "accepted", deferred: 4},
+		{name: "already current", status: "already_current", deferred: 3},
+		{name: "replayed", status: "replayed", deferred: 2},
+		{name: "recovered", status: "recovered", deferred: 1},
+		{name: "partial", status: "partially_applied", retryable: true, pending: 1, deferred: 4},
+		{name: "retry pending", status: "retry_pending", retryable: true, pending: 2, deferred: 3},
 		{name: "unknown", status: "queued", wantError: true},
 		{name: "terminal retryable", status: "accepted", retryable: true, wantError: true},
 		{name: "terminal pending", status: "recovered", pending: 1, wantError: true},
@@ -396,7 +423,7 @@ func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			body := fmt.Appendf(nil, `{"success":true,"data":{"status":%q,"event_id":%q,"retryable":%t,"pending_products":%d}}`, test.status, contract.EventID, test.retryable, test.pending)
+			body := fmt.Appendf(nil, `{"success":true,"data":{"status":%q,"event_id":%q,"retryable":%t,"pending_products":%d,"deferred_products":%d}}`, test.status, contract.EventID, test.retryable, test.pending, test.deferred)
 			result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
 			if test.wantError {
 				if !errors.Is(err, errReceiverStateInvalid) || result.Retryable {
@@ -404,10 +431,91 @@ func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
 				}
 				return
 			}
-			if err != nil || result.Status != test.status || result.Retryable != test.retryable || result.PendingProducts != test.pending {
+			if err != nil || result.Status != test.status || result.Retryable != test.retryable || result.PendingProducts != test.pending || result.DeferredProducts != test.deferred {
 				t.Fatalf("valid receiver state changed: result=%+v err=%v", result, err)
 			}
 		})
+	}
+}
+
+func TestClassifyDigitalogicReceiverDefaultsOmittedDeferredProductsToZero(t *testing.T) {
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0}}`, contract.EventID)
+	result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
+	if err != nil || result.DeferredProducts != 0 {
+		t.Fatalf("omitted deferred count was not compatible: result=%+v err=%v", result, err)
+	}
+
+	body = fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":%d}}`, contract.EventID, maxReceiverReportedProducts)
+	result, err = classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
+	if err != nil || uint64(result.DeferredProducts) != maxReceiverReportedProducts {
+		t.Fatalf("maximum bounded deferred count was not accepted: result=%+v err=%v", result, err)
+	}
+}
+
+func TestClassifyDigitalogicReceiverRejectsInvalidDeferredProductCounts(t *testing.T) {
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "negative", value: "-1"},
+		{name: "above bound", value: "2147483648"},
+		{name: "uint64 overflow", value: "18446744073709551616"},
+		{name: "fractional", value: "1.5"},
+		{name: "quoted", value: `"1"`},
+		{name: "null", value: "null"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":%s}}`, contract.EventID, test.value)
+			result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
+			if !errors.Is(err, errReceiverStateInvalid) || result.Retryable || result.DeferredProducts != 0 {
+				t.Fatalf("invalid deferred count was not rejected fail-closed: result=%+v err=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestClassifyDigitalogicReceiverRejectsInconsistentDeferredReconciliation(t *testing.T) {
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	detailObjects := strings.TrimSuffix(strings.Repeat(`{},`, maxReceiverDeferredDetails+1), ",")
+	tests := []struct {
+		name    string
+		total   int
+		summary string
+	}{
+		{name: "reason totals", total: 2, summary: `{"missing":1,"ambiguous":0,"details":[],"details_truncated":2}`},
+		{name: "detail totals", total: 2, summary: `{"missing":2,"ambiguous":0,"details":[{}],"details_truncated":0}`},
+		{name: "negative count", total: 1, summary: `{"missing":-1,"ambiguous":2,"details":[],"details_truncated":1}`},
+		{name: "overflowing reason sum", total: 1, summary: `{"missing":2147483647,"ambiguous":1,"details":[],"details_truncated":1}`},
+		{name: "missing typed field", total: 0, summary: `{"missing":0,"ambiguous":0,"details":[]}`},
+		{name: "null summary", total: 0, summary: `null`},
+		{name: "null details", total: 0, summary: `{"missing":0,"ambiguous":0,"details":null,"details_truncated":0}`},
+		{name: "non-object detail", total: 1, summary: `{"missing":1,"ambiguous":0,"details":["CODE-MUST-NOT-BE-RETAINED"],"details_truncated":0}`},
+		{name: "too many details", total: maxReceiverDeferredDetails + 1, summary: fmt.Sprintf(`{"missing":%d,"ambiguous":0,"details":[%s],"details_truncated":0}`, maxReceiverDeferredDetails+1, detailObjects)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":%d,"deferred_reconciliation":%s}}`, contract.EventID, test.total, test.summary)
+			result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
+			if !errors.Is(err, errReceiverStateInvalid) || result.Retryable || result.DeferredProducts != 0 {
+				t.Fatalf("inconsistent deferred summary was not rejected fail-closed: result=%+v err=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestDispatchGenericWebhookIgnoresProductSyncReceiverFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"status":"accepted","retryable":false,"pending_products":0,"deferred_products":-1}}`)
+	}))
+	defer server.Close()
+
+	result, err := DispatchWithResult(t.Context(), Config{Enabled: true, URL: server.URL, Format: "json"}, Event{Type: "update"})
+	if err != nil || result.Status != "" || result.DeferredProducts != 0 {
+		t.Fatalf("generic webhook semantics changed: result=%+v err=%v", result, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- extend the existing `patris.product-sync` receiver response/result path with a bounded non-negative `deferred_products` count
- keep terminal receiver states non-retryable when only deferred reconciliation remains, while preserving the existing partial/pending retry state machine
- validate the optional bounded `deferred_reconciliation` summary without retaining or logging product identities
- centralize sanitized CLI/server delivery diagnostics and include only the deferred count
- document terminal deferred reconciliation versus transient pending work

## Contract alignment

This matches the current receiver behavior:

- `data.deferred_products` is a native JSON integer (omitted means zero)
- terminal `accepted`, `already_current`, `replayed`, and `recovered` require `retryable:false` and `pending_products:0`
- `partially_applied` and `retry_pending` keep the existing `retryable:true` and positive pending-count requirements
- the optional summary requires `missing + ambiguous == deferred_products` and `details + details_truncated == deferred_products`
- Patris accepts counts through MaxInt32; the receiver's bounded server state (10,000) is within that wire limit

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 go test -count=1 ./...`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 go vet ./...`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Invoke-CGO.ps1 go test -race -count=1 ./pkg/updateout`
- `npm.cmd test` (10/10)
- `git diff --check`

The integration tests prove a terminal response with 781 deferred products makes one HTTP attempt, mixed transient/deferred work retries only while pending work remains, malformed counts/summaries fail closed, omitted fields follow the current sparse response semantics, no synthetic null placeholders are generated, and generic webhooks are unchanged, and detail identities do not enter diagnostics.

No screenshot is needed because this changes receiver parsing and structured logs only. This PR intentionally does not rebuild or deploy the Windows executable; production outbound delivery remains disabled until #64 is merged and deployed.

Closes #147
