### PR TITLE
Complete safe batched SQL sink core

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,16 @@ patris-export convert kala.db -f xlsx -o output/
 patris-export convert kala.db \
   -f sqlite \
   --sqlite-path output/patris-products.sqlite \
-  --sqlite-table products
+  --sqlite-table products \
+  --batch-size 250
+
+# Preview authoritative reconciliation; upsert_only is the safe default.
+patris-export convert kala.db \
+  -f sqlite \
+  --sqlite-path output/patris-products.sqlite \
+  --sqlite-table products \
+  --reconciliation delete_missing \
+  --dry-run
 
 # Watch and send canonical JSON changes to the Digitalogic v1 receiver.
 # DIGITALOGIC_PRODUCT_SYNC_SECRET is injected into the process environment by

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -67,6 +67,8 @@ var (
 	mysqlDSN        string
 	mysqlTable      string
 	exportBatchSize int
+	exportReconcile string
+	exportDryRun    bool
 	sendURL         string
 	sendFormat      string
 	sendMode        string
@@ -146,7 +148,9 @@ Supports Persian/Farsi encoding conversion and file watching.
 	convertCmd.Flags().StringVar(&sqliteTable, "sqlite-table", "", "SQLite table name for --format sqlite")
 	convertCmd.Flags().StringVar(&mysqlDSN, "mysql-dsn", "", "MySQL DSN for --format mysql (or PATRIS_EXPORT_MYSQL_DSN)")
 	convertCmd.Flags().StringVar(&mysqlTable, "mysql-table", "", "MySQL table name for --format mysql")
-	convertCmd.Flags().IntVar(&exportBatchSize, "batch-size", 0, "Batch size hint for SQL exports")
+	convertCmd.Flags().IntVar(&exportBatchSize, "batch-size", 0, "Maximum rows per prepared SQL batch")
+	convertCmd.Flags().StringVar(&exportReconcile, "reconciliation", "", "SQL reconciliation mode: upsert_only (safe default) or delete_missing")
+	convertCmd.Flags().BoolVar(&exportDryRun, "dry-run", false, "Preview SQL insert/update/delete counts without changing the destination")
 	convertCmd.Flags().StringVar(&sendURL, "send-url", "", "Webhook/API URL that receives initial and watch update payloads")
 	convertCmd.Flags().StringVar(&sendFormat, "send-format", "", "Send update format: json or csv")
 	convertCmd.Flags().StringVar(&sendMode, "send-mode", "", "Send update mode: changes or full")
@@ -623,7 +627,7 @@ func runConvert(cmd *cobra.Command, args []string) {
 		infoColor.Println("ℹ️  Using embedded character mapping (Patris81 default)")
 	}
 
-	if !useStdout && outputFormat != "mysql" {
+	if !useStdout && outputFormat != "mysql" && !(outputFormat == "sqlite" && cfg.Export.DryRun) {
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
 			errorColor.Printf("❌ Failed to create output directory: %v\n", err)
 			os.Exit(1)
@@ -718,6 +722,12 @@ func applyConvertFlagOverrides(cmd *cobra.Command, cfg *appconfig.Config) {
 	if cmd.Flags().Changed("batch-size") {
 		cfg.Export.BatchSize = exportBatchSize
 	}
+	if cmd.Flags().Changed("reconciliation") {
+		cfg.Export.Reconciliation = exportReconcile
+	}
+	if cmd.Flags().Changed("dry-run") {
+		cfg.Export.DryRun = exportDryRun
+	}
 	if cmd.Flags().Changed("send-url") {
 		cfg.SendUpdates.URL = sendURL
 		cfg.SendUpdates.Enabled = strings.TrimSpace(sendURL) != ""
@@ -798,6 +808,7 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 	}
 	tableName := firstNonEmpty(cfg.Convert.Table, cfg.Export.SQLiteTable, cfg.Export.MySQLTable, recordpipe.SourceTableName(dbFile))
 	var outputFile string
+	var sqlResult *recordsink.SQLResult
 	switch outputFormat {
 	case "json":
 		outputFile = filepath.Join(outputDir, baseName+".json")
@@ -830,9 +841,18 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 		if outputFile == "" {
 			outputFile = filepath.Join(outputDir, baseName+".sqlite")
 		}
-		if err := recordsink.WriteSQLite(outputFile, tableName, result.KeyField, result.Rows, recordsink.SnapshotOptions{ProtectedKeys: quarantinedCodes(result)}); err != nil {
+		syncResult, err := recordsink.SyncSQLite(context.Background(), outputFile, recordsink.SQLOptions{
+			Table:          tableName,
+			KeyField:       result.KeyField,
+			Batch:          cfg.Export.BatchSize,
+			Reconciliation: recordsink.ReconciliationMode(cfg.Export.Reconciliation),
+			DryRun:         cfg.Export.DryRun,
+			ProtectedKeys:  quarantinedCodes(result),
+		}, result.Rows)
+		if err != nil {
 			return err
 		}
+		sqlResult = &syncResult
 	case "mysql":
 		dsn := firstNonEmpty(cfg.Export.MySQLDSN, mysqlDSN)
 		if dsn == "" {
@@ -840,10 +860,38 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		if err := recordsink.SyncSQL(ctx, recordsink.SQLOptions{Driver: "mysql", DSN: dsn, Table: tableName, KeyField: result.KeyField, Batch: cfg.Export.BatchSize, ProtectedKeys: quarantinedCodes(result)}, result.Rows); err != nil {
+		syncResult, err := recordsink.SyncSQLWithResult(ctx, recordsink.SQLOptions{
+			Driver:         "mysql",
+			DSN:            dsn,
+			Table:          tableName,
+			KeyField:       result.KeyField,
+			Batch:          cfg.Export.BatchSize,
+			Reconciliation: recordsink.ReconciliationMode(cfg.Export.Reconciliation),
+			DryRun:         cfg.Export.DryRun,
+			ProtectedKeys:  quarantinedCodes(result),
+		}, result.Rows)
+		if err != nil {
 			return err
 		}
+		sqlResult = &syncResult
 		outputFile = "mysql:" + tableName
+	}
+	if sqlResult != nil {
+		infoColor.Printf(
+			"SQL result: inserted=%d updated=%d unchanged=%d deleted=%d failed=%d elapsed=%dms reconciliation=%s dry_run=%t\n",
+			sqlResult.Inserted,
+			sqlResult.Updated,
+			sqlResult.Unchanged,
+			sqlResult.Deleted,
+			sqlResult.Failed,
+			sqlResult.ElapsedMS,
+			sqlResult.Reconciliation,
+			sqlResult.DryRun,
+		)
+		if sqlResult.DryRun {
+			successColor.Printf("SQL dry-run preview completed for: %s\n", outputFile)
+			return nil
+		}
 	}
 	successColor.Printf("✅ Successfully exported to: %s\n", outputFile)
 	return nil

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -69,17 +69,77 @@ patris-export convert C:\Patris\data4\kala.db -f xlsx -o exports
 patris-export --mapping .\mapping.kala.json convert C:\Patris\data4\kala.db `
   -f sqlite `
   --sqlite-path .\exports\patris-products.sqlite `
-  --sqlite-table products
+  --sqlite-table products `
+  --batch-size 250
 
-$env:PATRIS_EXPORT_MYSQL_DSN = "user:password@tcp(127.0.0.1:3306)/shop?parseTime=true"
+# Keep credentials in the process secret environment, not a committed config.
+# The timeout parameters bound connection and I/O waits; tls=true verifies the
+# server with the system trust store.
+$env:PATRIS_EXPORT_MYSQL_DSN = "user:password@tcp(db.example:3306)/shop?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s&tls=true"
 patris-export --mapping .\mapping.kala.json convert C:\Patris\data4\kala.db `
   -f mysql `
-  --mysql-table products
+  --mysql-table products `
+  --batch-size 250
 ```
 
 SQLite and MySQL exports create the destination table when needed, add new
 columns on later exports, preserve canonical numeric types, and upsert by the
-configured key field.
+configured key field. `batch_size` is the maximum number of rows in each
+prepared multi-row statement (and is reduced only when required by the
+driver's parameter limit).
+
+SQL reconciliation is explicit and non-destructive by default:
+
+```yaml
+export:
+  batch_size: 250
+  reconciliation: upsert_only
+  dry_run: false
+```
+
+`upsert_only` inserts and updates supplied Codes but preserves destination rows
+that are absent from the current input. Use `delete_missing` only for a known
+complete authoritative snapshot. Canonical quarantine/protected Codes remain
+preserved even in `delete_missing` mode.
+
+Preview the exact operation counts without changing the destination:
+
+```powershell
+patris-export convert C:\Patris\data4\kala.db -f sqlite `
+  --sqlite-path .\exports\patris-products.sqlite `
+  --sqlite-table products `
+  --reconciliation delete_missing `
+  --dry-run
+```
+
+The result line reports `inserted`, `updated`, `unchanged`, `deleted`, `failed`,
+and `elapsed` milliseconds; it never includes the DSN. A dry run against a
+missing SQLite path does not create the file or its parent directory.
+
+Watch mode uses this same `recordpipe` -> `recordsink` route for its initial
+write and every debounced update; there is no separate live SQL implementation:
+
+```powershell
+patris-export convert C:\Patris\data4\kala.db -f sqlite -w `
+  --sqlite-path .\exports\patris-products.sqlite `
+  --sqlite-table products
+```
+
+Reproduce the SQLite initial-write/update proof locally, and optionally run the
+same proof against a disposable MariaDB/MySQL database:
+
+```powershell
+go test ./pkg/recordsink -run TestSQLiteSyncInitialUpdateDryRunAndProtectedDelete -v
+
+$env:PATRIS_EXPORT_TEST_MYSQL_DSN = "test_user:test_password@tcp(127.0.0.1:3306)/patris_test?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s"
+go test ./pkg/recordsink -run TestMariaDBSyncInitialWriteAndUpdate -v
+Remove-Item Env:PATRIS_EXPORT_TEST_MYSQL_DSN
+```
+
+The MariaDB test is skipped unless its dedicated test DSN is present and drops
+only the uniquely named table it creates. A browser connection test, manual UI
+sync controls, custom-CA TLS registration, and `soft_delete_missing` remain
+separate follow-up work.
 
 ## Watch and Send Updates
 

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -86,11 +86,13 @@ type ConvertConfig struct {
 }
 
 type ExportConfig struct {
-	SQLitePath  string `json:"sqlite_path,omitempty" yaml:"sqlite_path,omitempty" toml:"sqlite_path,omitempty"`
-	SQLiteTable string `json:"sqlite_table,omitempty" yaml:"sqlite_table,omitempty" toml:"sqlite_table,omitempty"`
-	MySQLDSN    string `json:"mysql_dsn,omitempty" yaml:"mysql_dsn,omitempty" toml:"mysql_dsn,omitempty"`
-	MySQLTable  string `json:"mysql_table,omitempty" yaml:"mysql_table,omitempty" toml:"mysql_table,omitempty"`
-	BatchSize   int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
+	SQLitePath     string `json:"sqlite_path,omitempty" yaml:"sqlite_path,omitempty" toml:"sqlite_path,omitempty"`
+	SQLiteTable    string `json:"sqlite_table,omitempty" yaml:"sqlite_table,omitempty" toml:"sqlite_table,omitempty"`
+	MySQLDSN       string `json:"mysql_dsn,omitempty" yaml:"mysql_dsn,omitempty" toml:"mysql_dsn,omitempty"`
+	MySQLTable     string `json:"mysql_table,omitempty" yaml:"mysql_table,omitempty" toml:"mysql_table,omitempty"`
+	BatchSize      int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
+	Reconciliation string `json:"reconciliation,omitempty" yaml:"reconciliation,omitempty" toml:"reconciliation,omitempty"`
+	DryRun         bool   `json:"dry_run,omitempty" yaml:"dry_run,omitempty" toml:"dry_run,omitempty"`
 }
 
 type EdgeConfig struct {
@@ -186,6 +188,10 @@ func Default() Config {
 			Output:   ".",
 			Format:   "json",
 			Debounce: "1s",
+		},
+		Export: ExportConfig{
+			BatchSize:      500,
+			Reconciliation: "upsert_only",
 		},
 		Canonical: canonical.DefaultConfig(),
 		SendUpdates: updateout.Config{
@@ -777,6 +783,12 @@ func ApplyEnv(cfg *Config) {
 			cfg.Export.BatchSize = batch
 		}
 	}
+	if value := os.Getenv("PATRIS_EXPORT_SQL_RECONCILIATION"); strings.TrimSpace(value) != "" {
+		cfg.Export.Reconciliation = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_SQL_DRY_RUN"); strings.TrimSpace(value) != "" {
+		cfg.Export.DryRun = parseBool(value, cfg.Export.DryRun)
+	}
 	if value := os.Getenv("PATRIS_EXPORT_CONVERT_WATCH"); strings.TrimSpace(value) != "" {
 		cfg.Convert.Watch = parseBool(value, cfg.Convert.Watch)
 	}
@@ -928,6 +940,16 @@ func normalize(cfg *Config) {
 	}
 	if cfg.Export.BatchSize <= 0 {
 		cfg.Export.BatchSize = 500
+	}
+	cfg.Export.Reconciliation = strings.ToLower(strings.TrimSpace(cfg.Export.Reconciliation))
+	switch cfg.Export.Reconciliation {
+	case "", "upsert_only":
+		cfg.Export.Reconciliation = "upsert_only"
+	case "delete_missing":
+	default:
+		// Unknown modes fail toward the non-destructive behavior. The sink also
+		// validates direct API use rather than silently deleting records.
+		cfg.Export.Reconciliation = "upsert_only"
 	}
 	cfg.Canonical = canonical.NormalizeConfig(cfg.Canonical)
 	cfg.SendUpdates = updateout.Normalize(cfg.SendUpdates)

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -187,6 +187,27 @@ func TestApplyEnvRuntimeTempPolicy(t *testing.T) {
 	}
 }
 
+func TestSQLExportDefaultsAndEnvironmentOverrides(t *testing.T) {
+	cfg := Default()
+	if cfg.Export.BatchSize != 500 || cfg.Export.Reconciliation != "upsert_only" || cfg.Export.DryRun {
+		t.Fatalf("unsafe SQL export defaults: %+v", cfg.Export)
+	}
+
+	t.Setenv("PATRIS_EXPORT_BATCH_SIZE", "17")
+	t.Setenv("PATRIS_EXPORT_SQL_RECONCILIATION", "DELETE_MISSING")
+	t.Setenv("PATRIS_EXPORT_SQL_DRY_RUN", "true")
+	ApplyEnv(&cfg)
+	if cfg.Export.BatchSize != 17 || cfg.Export.Reconciliation != "delete_missing" || !cfg.Export.DryRun {
+		t.Fatalf("SQL export environment was not applied: %+v", cfg.Export)
+	}
+
+	cfg.Export.Reconciliation = "typo_that_must_not_delete"
+	normalize(&cfg)
+	if cfg.Export.Reconciliation != "upsert_only" {
+		t.Fatalf("invalid reconciliation did not fail safe: %q", cfg.Export.Reconciliation)
+	}
+}
+
 func TestCanonicalKalaProfileAndPricingProviderDefaults(t *testing.T) {
 	cfg := Default()
 	profile, exists := cfg.Canonical.Profiles["kala.db"]

--- a/pkg/recordsink/quarantine_test.go
+++ b/pkg/recordsink/quarantine_test.go
@@ -15,7 +15,7 @@ func TestSQLiteSnapshotPreservesProtectedQuarantineKeys(t *testing.T) {
 	if err := WriteSQLite(path, "products", "product_code", initial); err != nil {
 		t.Fatal(err)
 	}
-	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{ProtectedKeys: []string{"A"}}); err != nil {
+	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{Reconciliation: DeleteMissing, ProtectedKeys: []string{"A"}}); err != nil {
 		t.Fatal(err)
 	}
 	db, err := sql.Open("sqlite3", path)
@@ -31,7 +31,7 @@ func TestSQLiteSnapshotPreservesProtectedQuarantineKeys(t *testing.T) {
 	if count != 1 || name != "last-known-good" {
 		t.Fatalf("quarantine reconciliation changed protected row: count=%d name=%q", count, name)
 	}
-	if err := WriteSQLite(path, "products", "product_code", nil); err != nil {
+	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{Reconciliation: DeleteMissing}); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.QueryRow(`SELECT COUNT(*) FROM products`).Scan(&count); err != nil || count != 0 {

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,19 +24,47 @@ import (
 )
 
 type SQLOptions struct {
-	Driver        string
-	DSN           string
-	Table         string
-	KeyField      string
-	Batch         int
-	ProtectedKeys []string
+	Driver         string
+	DSN            string
+	Table          string
+	KeyField       string
+	Batch          int
+	Reconciliation ReconciliationMode
+	DryRun         bool
+	ProtectedKeys  []string
 }
 
-// SnapshotOptions controls authoritative snapshot reconciliation. ProtectedKeys
-// are retained when absent from rows, which lets callers quarantine uncertain
-// records without turning them into destructive deletions.
+// ReconciliationMode controls what happens to destination rows that are not
+// present in the supplied records. UpsertOnly is intentionally the zero-value
+// behavior so a missing or newly introduced setting cannot delete user data.
+type ReconciliationMode string
+
+const (
+	UpsertOnly    ReconciliationMode = "upsert_only"
+	DeleteMissing ReconciliationMode = "delete_missing"
+)
+
+// SQLResult is safe to return to callers and UI layers: it contains operation
+// diagnostics only and never includes the destination DSN.
+type SQLResult struct {
+	Inserted       int                `json:"inserted"`
+	Updated        int                `json:"updated"`
+	Unchanged      int                `json:"unchanged"`
+	Deleted        int                `json:"deleted"`
+	Failed         int                `json:"failed"`
+	ElapsedMS      int64              `json:"elapsed_ms"`
+	DryRun         bool               `json:"dry_run"`
+	Reconciliation ReconciliationMode `json:"reconciliation"`
+}
+
+// SnapshotOptions configures the compatibility WriteSQLite/SyncSnapshotSQL
+// wrappers. WriteSQLite remains upsert_only unless Reconciliation is explicitly
+// DeleteMissing. ProtectedKeys are retained during that opt-in reconciliation.
 type SnapshotOptions struct {
-	ProtectedKeys []string
+	ProtectedKeys  []string
+	Batch          int
+	DryRun         bool
+	Reconciliation ReconciliationMode
 }
 
 func WriteJSON(writer io.Writer, payload interface{}) error {
@@ -74,165 +104,236 @@ func CSVBytes(rows []map[string]interface{}, keyField string) ([]byte, error) {
 }
 
 func WriteSQLite(path, table, keyField string, rows []map[string]interface{}, options ...SnapshotOptions) error {
+	snapshot := mergeSnapshotOptions(options)
+	_, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table:          table,
+		KeyField:       keyField,
+		Batch:          snapshot.Batch,
+		DryRun:         snapshot.DryRun,
+		Reconciliation: snapshot.Reconciliation,
+		ProtectedKeys:  snapshot.ProtectedKeys,
+	}, rows)
+	return err
+}
+
+// SyncSQLite runs the shared SQL sink against a SQLite file and returns
+// operation counts. It is used by both one-shot and watch conversions.
+func SyncSQLite(ctx context.Context, path string, options SQLOptions, rows []map[string]interface{}) (SQLResult, error) {
 	if path == "" {
-		return fmt.Errorf("sqlite output path is required")
+		return SQLResult{}, fmt.Errorf("sqlite output path is required")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && filepath.Dir(path) != "." {
-		return err
+	dsn := path
+	if options.DryRun {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			dsn = ":memory:"
+		} else if err != nil {
+			return SQLResult{}, err
+		}
+	} else {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && filepath.Dir(path) != "." {
+			return SQLResult{}, err
+		}
 	}
-	db, err := sql.Open("sqlite3", path)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
-		return err
+		return SQLResult{}, err
 	}
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	return SyncSnapshotSQL(ctx, db, "sqlite", table, keyField, rows, options...)
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+	options.Driver = "sqlite"
+	return SyncSQLDB(ctx, db, options, rows)
 }
 
 func SyncSQL(ctx context.Context, options SQLOptions, rows []map[string]interface{}) error {
+	_, err := SyncSQLWithResult(ctx, options, rows)
+	return err
+}
+
+// SyncSQLWithResult opens a configured SQL destination and reports the shared
+// sink result. The returned value deliberately has no connection fields.
+func SyncSQLWithResult(ctx context.Context, options SQLOptions, rows []map[string]interface{}) (SQLResult, error) {
 	driver := strings.ToLower(strings.TrimSpace(options.Driver))
 	if driver == "" {
 		driver = "mysql"
 	}
 	if options.DSN == "" {
-		return fmt.Errorf("%s DSN is required", driver)
+		return SQLResult{}, fmt.Errorf("%s DSN is required", driver)
 	}
 	db, err := sql.Open(driver, options.DSN)
 	if err != nil {
-		return err
+		return SQLResult{}, err
 	}
 	defer db.Close()
-	if options.Batch <= 0 {
-		options.Batch = 500
+	if err := db.PingContext(ctx); err != nil {
+		return SQLResult{}, fmt.Errorf("connect to %s destination: %w", driver, err)
 	}
-	return SyncSnapshotSQL(ctx, db, driver, options.Table, options.KeyField, rows, SnapshotOptions{ProtectedKeys: options.ProtectedKeys})
+	options.Driver = driver
+	return SyncSQLDB(ctx, db, options, rows)
 }
 
 // UpsertSQL writes a partial set of rows without deleting records that are not
 // present in the supplied slice. Use SyncSnapshotSQL only when rows represent a
 // complete authoritative snapshot.
 func UpsertSQL(ctx context.Context, db *sql.DB, driver, table, keyField string, rows []map[string]interface{}) error {
-	return writeSQL(ctx, db, driver, table, keyField, rows, false, SnapshotOptions{})
+	_, err := SyncSQLDB(ctx, db, SQLOptions{
+		Driver: driver, Table: table, KeyField: keyField, Reconciliation: UpsertOnly,
+	}, rows)
+	return err
 }
 
 // SyncSnapshotSQL writes a complete authoritative snapshot. Row upserts and
 // removal of keys absent from the snapshot share one transaction. An empty
 // snapshot clears an existing table but does not create a table by itself.
 func SyncSnapshotSQL(ctx context.Context, db *sql.DB, driver, table, keyField string, rows []map[string]interface{}, options ...SnapshotOptions) error {
-	return writeSQL(ctx, db, driver, table, keyField, rows, true, mergeSnapshotOptions(options))
+	snapshot := mergeSnapshotOptions(options)
+	_, err := SyncSQLDB(ctx, db, SQLOptions{
+		Driver:         driver,
+		Table:          table,
+		KeyField:       keyField,
+		Batch:          snapshot.Batch,
+		DryRun:         snapshot.DryRun,
+		Reconciliation: DeleteMissing,
+		ProtectedKeys:  snapshot.ProtectedKeys,
+	}, rows)
+	return err
 }
 
-func writeSQL(ctx context.Context, db *sql.DB, driver, table, keyField string, rows []map[string]interface{}, reconcile bool, snapshot SnapshotOptions) error {
-	table = sanitizeIdentifier(table)
+// SyncSQLDB executes the common SQLite/MySQL sink against an already-open
+// database. Data writes and delete_missing reconciliation share one
+// transaction; schema evolution remains additive and is performed before it.
+func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[string]interface{}) (result SQLResult, err error) {
+	started := time.Now()
+	result.DryRun = options.DryRun
+	result.Reconciliation, err = normalizeReconciliation(options.Reconciliation)
+	defer func() {
+		result.ElapsedMS = time.Since(started).Milliseconds()
+		if err != nil && result.Failed == 0 {
+			result.Failed = len(rows)
+		}
+	}()
+	if err != nil {
+		return result, err
+	}
+
+	driver := strings.ToLower(strings.TrimSpace(options.Driver))
+	if driver == "" {
+		driver = "mysql"
+	}
+	table := sanitizeIdentifier(options.Table)
 	if table == "" {
 		table = "patris_export"
 	}
-	if len(rows) == 0 {
-		if reconcile {
-			if len(snapshot.ProtectedKeys) == 0 {
-				return clearSnapshotTable(ctx, db, driver, table)
-			}
-			return reconcileProtectedOnlySnapshot(ctx, db, driver, table, keyField, snapshot.ProtectedKeys)
-		}
-		return nil
+	batch := effectiveBatchSize(driver, options.Batch, 1)
+	tableExists, err := sqlTableExists(ctx, db, driver, table)
+	if err != nil {
+		return result, err
 	}
-	fields := recordmap.Fields(rows, keyField)
-	if len(fields) == 0 {
-		return nil
-	}
+
+	fields := recordmap.Fields(rows, options.KeyField)
+	keyField := strings.TrimSpace(options.KeyField)
 	if keyField == "" {
-		keyField = fields[0]
-	}
-	if reconcile {
-		if _, err := snapshotKeys(rows, keyField, snapshot.ProtectedKeys); err != nil {
-			return err
+		if len(fields) > 0 {
+			keyField = fields[0]
+		} else if len(options.ProtectedKeys) > 0 || result.Reconciliation == DeleteMissing {
+			return result, fmt.Errorf("SQL key field is required for reconciliation")
 		}
 	}
-	if err := createTable(ctx, db, driver, table, fields, keyField, rows); err != nil {
-		return err
-	}
-	if err := ensureColumns(ctx, db, driver, table, fields, keyField, rows); err != nil {
-		return err
-	}
-	tx, err := db.BeginTx(ctx, nil)
+	keys, err := snapshotKeys(rows, keyField, nil)
 	if err != nil {
-		return err
+		return result, err
 	}
-	stmtText := upsertStatement(driver, table, fields, keyField)
-	stmt, err := tx.PrepareContext(ctx, stmtText)
-	if err != nil {
-		_ = tx.Rollback()
-		return err
+	if result.Reconciliation == UpsertOnly && len(rows) == 0 {
+		return result, nil
 	}
-	defer stmt.Close()
-	for _, row := range rows {
-		values := make([]interface{}, len(fields))
-		for i, field := range fields {
-			values[i] = sqlValue(row[field])
-		}
-		if _, err := stmt.ExecContext(ctx, values...); err != nil {
-			_ = tx.Rollback()
-			return err
-		}
+	if !tableExists && len(rows) == 0 {
+		return result, nil
 	}
-	if reconcile {
-		keys, err := snapshotKeys(rows, keyField, snapshot.ProtectedKeys)
+
+	var beforeColumns map[string]bool
+	if tableExists {
+		beforeColumns, err = existingColumns(ctx, db, driver, table)
 		if err != nil {
-			_ = tx.Rollback()
-			return err
+			return result, err
 		}
-		if err := deleteRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keys); err != nil {
-			_ = tx.Rollback()
-			return err
+		if keyField != "" && !beforeColumns[strings.ToLower(keyField)] {
+			return result, fmt.Errorf("existing table %q has no key column %q", table, keyField)
 		}
 	}
-	return tx.Commit()
-}
 
-func clearSnapshotTable(ctx context.Context, db *sql.DB, driver, table string) error {
-	exists, err := sqlTableExists(ctx, db, driver, table)
-	if err != nil {
-		return err
+	if !options.DryRun && len(rows) > 0 {
+		if err := createTable(ctx, db, driver, table, fields, keyField, rows); err != nil {
+			return result, err
+		}
+		if err := ensureColumns(ctx, db, driver, table, fields, keyField, rows); err != nil {
+			return result, err
+		}
+		tableExists = true
+		beforeColumns = make(map[string]bool, len(fields))
+		for _, field := range fields {
+			beforeColumns[strings.ToLower(field)] = true
+		}
 	}
-	if !exists {
-		return nil
+	if !tableExists {
+		result.Inserted = len(rows)
+		return result, nil
 	}
+
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return result, err
 	}
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", quoteIdent(driver, table))); err != nil {
-		_ = tx.Rollback()
-		return err
-	}
-	return tx.Commit()
-}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
 
-func reconcileProtectedOnlySnapshot(ctx context.Context, db *sql.DB, driver, table, keyField string, protected []string) error {
-	if strings.TrimSpace(keyField) == "" {
-		return fmt.Errorf("snapshot key field is required when protected keys are present")
-	}
-	keys, err := snapshotKeys(nil, keyField, protected)
+	toWrite, counts, err := classifyRows(ctx, tx, driver, table, keyField, fields, rows, beforeColumns, batch)
 	if err != nil {
-		return err
+		return result, err
 	}
-	exists, err := sqlTableExists(ctx, db, driver, table)
-	if err != nil {
-		return err
+	result.Inserted = counts.Inserted
+	result.Updated = counts.Updated
+	result.Unchanged = counts.Unchanged
+
+	keepKeys := keys
+	if result.Reconciliation == DeleteMissing {
+		keepKeys, err = appendProtectedKeys(keys, options.ProtectedKeys)
+		if err != nil {
+			return result, err
+		}
+		if options.DryRun {
+			result.Deleted, err = countRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keepKeys)
+			if err != nil {
+				return result, err
+			}
+		}
 	}
-	if !exists {
-		return nil
+	if options.DryRun {
+		return result, nil
 	}
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
+
+	if len(toWrite) > 0 {
+		if err := upsertRows(ctx, tx, driver, table, keyField, fields, toWrite, options.Batch); err != nil {
+			return result, err
+		}
 	}
-	if err := deleteRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keys); err != nil {
-		_ = tx.Rollback()
-		return err
+	if result.Reconciliation == DeleteMissing {
+		result.Deleted, err = deleteRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keepKeys, options.Batch)
+		if err != nil {
+			return result, err
+		}
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return result, err
+	}
+	committed = true
+	return result, nil
 }
 
 func sqlTableExists(ctx context.Context, db *sql.DB, driver, table string) (bool, error) {
@@ -251,10 +352,316 @@ func sqlTableExists(ctx context.Context, db *sql.DB, driver, table string) (bool
 	return exists == 1, nil
 }
 
+func normalizeReconciliation(value ReconciliationMode) (ReconciliationMode, error) {
+	switch ReconciliationMode(strings.ToLower(strings.TrimSpace(string(value)))) {
+	case "", UpsertOnly:
+		return UpsertOnly, nil
+	case DeleteMissing:
+		return DeleteMissing, nil
+	default:
+		return UpsertOnly, fmt.Errorf("unsupported SQL reconciliation mode %q", value)
+	}
+}
+
+func effectiveBatchSize(driver string, requested, fieldCount int) int {
+	if requested <= 0 {
+		requested = 500
+	}
+	if fieldCount <= 0 {
+		fieldCount = 1
+	}
+	parameterLimit := 65535
+	if isSQLite(driver) {
+		// Stay compatible with SQLite builds that retain the traditional 999
+		// host-parameter limit rather than assuming a newer compile-time value.
+		parameterLimit = 999
+	}
+	if maxRows := parameterLimit / fieldCount; requested > maxRows {
+		requested = maxRows
+	}
+	if requested < 1 {
+		return 1
+	}
+	return requested
+}
+
+func appendProtectedKeys(keys, protected []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(keys)+len(protected))
+	result := append([]string(nil), keys...)
+	for _, key := range result {
+		seen[key] = struct{}{}
+	}
+	for index, value := range protected {
+		key := strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("protected snapshot key %d is empty", index)
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+type sqlCounts struct {
+	Inserted  int
+	Updated   int
+	Unchanged int
+}
+
+func classifyRows(
+	ctx context.Context,
+	tx *sql.Tx,
+	driver, table, keyField string,
+	fields []string,
+	rows []map[string]interface{},
+	existingColumns map[string]bool,
+	batch int,
+) ([]map[string]interface{}, sqlCounts, error) {
+	counts := sqlCounts{}
+	if len(rows) == 0 {
+		return nil, counts, nil
+	}
+	queryFields := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if existingColumns[strings.ToLower(field)] {
+			queryFields = append(queryFields, field)
+		}
+	}
+	if len(queryFields) == 0 || !existingColumns[strings.ToLower(keyField)] {
+		counts.Inserted = len(rows)
+		return append([]map[string]interface{}(nil), rows...), counts, nil
+	}
+
+	batch = effectiveBatchSize(driver, batch, 1)
+	toWrite := make([]map[string]interface{}, 0, len(rows))
+	for start := 0; start < len(rows); start += batch {
+		end := start + batch
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+		quotedFields := make([]string, len(queryFields))
+		for i, field := range queryFields {
+			quotedFields[i] = quoteIdent(driver, field)
+		}
+		query := fmt.Sprintf(
+			"SELECT %s FROM %s WHERE %s IN (%s)",
+			strings.Join(quotedFields, ", "),
+			quoteIdent(driver, table),
+			quoteIdent(driver, keyField),
+			placeholders,
+		)
+		args := make([]interface{}, len(chunk))
+		for i, row := range chunk {
+			args[i] = sqlValue(row[keyField])
+		}
+		found, err := queryExistingRows(ctx, tx, query, queryFields, keyField, args)
+		if err != nil {
+			return nil, counts, err
+		}
+		for _, row := range chunk {
+			key := databaseKey(row[keyField])
+			existing, exists := found[key]
+			if !exists {
+				counts.Inserted++
+				toWrite = append(toWrite, row)
+				continue
+			}
+			if rowMatchesExisting(row, existing, fields, existingColumns) {
+				counts.Unchanged++
+				continue
+			}
+			counts.Updated++
+			toWrite = append(toWrite, row)
+		}
+	}
+	return toWrite, counts, nil
+}
+
+func queryExistingRows(ctx context.Context, tx *sql.Tx, query string, fields []string, keyField string, args []interface{}) (map[string]map[string]interface{}, error) {
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]map[string]interface{})
+	for rows.Next() {
+		values := make([]interface{}, len(fields))
+		destinations := make([]interface{}, len(fields))
+		for i := range values {
+			destinations[i] = &values[i]
+		}
+		if err := rows.Scan(destinations...); err != nil {
+			return nil, err
+		}
+		record := make(map[string]interface{}, len(fields))
+		for i, field := range fields {
+			record[field] = values[i]
+		}
+		result[databaseKey(record[keyField])] = record
+	}
+	return result, rows.Err()
+}
+
+func rowMatchesExisting(row, existing map[string]interface{}, fields []string, existingColumns map[string]bool) bool {
+	for _, field := range fields {
+		if !existingColumns[strings.ToLower(field)] {
+			if row[field] != nil {
+				return false
+			}
+			continue
+		}
+		if !sqlValuesEquivalent(field, row[field], existing[field]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sqlValuesEquivalent(field string, expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == nil && actual == nil
+	}
+	kind := mergeValueKind(canonicalFieldKind(field), classifyValue(expected))
+	if kind == valueKindBoolean {
+		return booleanText(expected) == booleanText(actual)
+	}
+	if kind == valueKindInteger || kind == valueKindReal || kind == valueKindDecimal {
+		expectedNumber, expectedOK := rationalValue(expected)
+		actualNumber, actualOK := rationalValue(actual)
+		if expectedOK && actualOK {
+			return expectedNumber.Cmp(actualNumber) == 0
+		}
+	}
+	return databaseText(expected) == databaseText(actual)
+}
+
+func rationalValue(value interface{}) (*big.Rat, bool) {
+	text := databaseText(value)
+	if text == "" {
+		return nil, false
+	}
+	result := new(big.Rat)
+	if _, ok := result.SetString(text); ok {
+		return result, true
+	}
+	// big.Rat does not accept every exponent spelling used by float drivers.
+	parsed, err := strconv.ParseFloat(text, 64)
+	if err != nil {
+		return nil, false
+	}
+	result.SetFloat64(parsed)
+	return result, true
+}
+
+func booleanText(value interface{}) string {
+	switch typed := value.(type) {
+	case bool:
+		if typed {
+			return "1"
+		}
+		return "0"
+	}
+	text := strings.ToLower(strings.TrimSpace(databaseText(value)))
+	if text == "true" {
+		return "1"
+	}
+	if text == "false" {
+		return "0"
+	}
+	return text
+}
+
+func databaseText(value interface{}) string {
+	switch typed := value.(type) {
+	case []byte:
+		return string(typed)
+	case float32:
+		return strconv.FormatFloat(float64(typed), 'g', -1, 32)
+	case float64:
+		return strconv.FormatFloat(typed, 'g', -1, 64)
+	case json.Number:
+		return typed.String()
+	default:
+		return cell(value)
+	}
+}
+
+func databaseKey(value interface{}) string {
+	return databaseText(value)
+}
+
+func upsertRows(ctx context.Context, tx *sql.Tx, driver, table, keyField string, fields []string, rows []map[string]interface{}, requestedBatch int) error {
+	batch := effectiveBatchSize(driver, requestedBatch, len(fields))
+	for start := 0; start < len(rows); start += batch {
+		end := start + batch
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[start:end]
+		stmt, err := tx.PrepareContext(ctx, upsertStatement(driver, table, fields, keyField, len(chunk)))
+		if err != nil {
+			return err
+		}
+		values := make([]interface{}, 0, len(fields)*len(chunk))
+		for _, row := range chunk {
+			for _, field := range fields {
+				values = append(values, sqlValue(row[field]))
+			}
+		}
+		_, execErr := stmt.ExecContext(ctx, values...)
+		closeErr := stmt.Close()
+		if execErr != nil {
+			return execErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	return nil
+}
+
+func countRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string) (int, error) {
+	keep := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keep[key] = struct{}{}
+	}
+	query := fmt.Sprintf("SELECT %s FROM %s", quoteIdent(driver, keyField), quoteIdent(driver, table))
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		var value interface{}
+		if err := rows.Scan(&value); err != nil {
+			return 0, err
+		}
+		if _, exists := keep[databaseKey(value)]; !exists {
+			count++
+		}
+	}
+	return count, rows.Err()
+}
+
 func mergeSnapshotOptions(values []SnapshotOptions) SnapshotOptions {
 	merged := SnapshotOptions{}
 	for _, value := range values {
 		merged.ProtectedKeys = append(merged.ProtectedKeys, value.ProtectedKeys...)
+		if value.Batch != 0 {
+			merged.Batch = value.Batch
+		}
+		if value.DryRun {
+			merged.DryRun = true
+		}
+		if value.Reconciliation != "" {
+			merged.Reconciliation = value.Reconciliation
+		}
 	}
 	return merged
 }
@@ -288,14 +695,22 @@ func snapshotKeys(rows []map[string]interface{}, keyField string, protected []st
 	return keys, nil
 }
 
-func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string) error {
+func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string, requestedBatch int) (int, error) {
+	if len(keys) == 0 {
+		result, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s", quoteIdent(driver, table)))
+		if err != nil {
+			return 0, err
+		}
+		count, err := result.RowsAffected()
+		return int(count), err
+	}
 	tempTable := "_patris_snapshot_keys"
 	drop := fmt.Sprintf("DROP TEMPORARY TABLE IF EXISTS %s", quoteIdent(driver, tempTable))
 	if isSQLite(driver) {
 		drop = fmt.Sprintf("DROP TABLE IF EXISTS temp.%s", quoteIdent(driver, tempTable))
 	}
 	if _, err := tx.ExecContext(ctx, drop); err != nil {
-		return err
+		return 0, err
 	}
 	createPrefix := "CREATE TEMP TABLE"
 	if !isSQLite(driver) {
@@ -309,27 +724,40 @@ func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table
 		columnType(driver, keyField, keyField, nil),
 	)
 	if _, err := tx.ExecContext(ctx, create); err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _, _ = tx.ExecContext(context.Background(), drop) }()
 
-	insert := fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (?)",
-		quoteIdent(driver, tempTable),
-		quoteIdent(driver, "snapshot_key"),
-	)
-	stmt, err := tx.PrepareContext(ctx, insert)
-	if err != nil {
-		return err
-	}
-	for _, key := range keys {
-		if _, err := stmt.ExecContext(ctx, key); err != nil {
-			_ = stmt.Close()
-			return err
+	batch := effectiveBatchSize(driver, requestedBatch, 1)
+	for start := 0; start < len(keys); start += batch {
+		end := start + batch
+		if end > len(keys) {
+			end = len(keys)
 		}
-	}
-	if err := stmt.Close(); err != nil {
-		return err
+		chunk := keys[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("(?),", len(chunk)), ",")
+		insert := fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES %s",
+			quoteIdent(driver, tempTable),
+			quoteIdent(driver, "snapshot_key"),
+			placeholders,
+		)
+		stmt, err := tx.PrepareContext(ctx, insert)
+		if err != nil {
+			return 0, err
+		}
+		values := make([]interface{}, len(chunk))
+		for i, key := range chunk {
+			values[i] = key
+		}
+		_, execErr := stmt.ExecContext(ctx, values...)
+		closeErr := stmt.Close()
+		if execErr != nil {
+			return 0, execErr
+		}
+		if closeErr != nil {
+			return 0, closeErr
+		}
 	}
 
 	target := quoteIdent(driver, table)
@@ -340,10 +768,12 @@ func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table
 		"DELETE FROM %s WHERE NOT EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.%s)",
 		target, temp, temp, tempKey, target, targetKey,
 	)
-	if _, err := tx.ExecContext(ctx, remove); err != nil {
-		return err
+	result, err := tx.ExecContext(ctx, remove)
+	if err != nil {
+		return 0, err
 	}
-	return nil
+	count, err := result.RowsAffected()
+	return int(count), err
 }
 
 func createTable(ctx context.Context, db *sql.DB, driver, table string, fields []string, keyField string, rows []map[string]interface{}) error {
@@ -356,6 +786,9 @@ func createTable(ctx context.Context, db *sql.DB, driver, table string, fields [
 		cols = append(cols, def)
 	}
 	query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", quoteIdent(driver, table), strings.Join(cols, ", "))
+	if !isSQLite(driver) {
+		query += " ENGINE=InnoDB"
+	}
 	_, err := db.ExecContext(ctx, query)
 	return err
 }
@@ -519,20 +952,19 @@ func isSQLite(driver string) bool {
 	return driver == "sqlite3" || driver == "sqlite"
 }
 
-func upsertStatement(driver, table string, fields []string, keyField string) string {
+func upsertStatement(driver, table string, fields []string, keyField string, rowCount int) string {
 	quoted := make([]string, len(fields))
-	placeholders := make([]string, len(fields))
+	rowPlaceholders := make([]string, len(fields))
 	for i, field := range fields {
 		quoted[i] = quoteIdent(driver, field)
-		placeholders[i] = "?"
+		rowPlaceholders[i] = "?"
 	}
-	if isSQLite(driver) {
-		return fmt.Sprintf(
-			"INSERT OR REPLACE INTO %s (%s) VALUES (%s)",
-			quoteIdent(driver, table),
-			strings.Join(quoted, ", "),
-			strings.Join(placeholders, ", "),
-		)
+	if rowCount < 1 {
+		rowCount = 1
+	}
+	valueGroups := make([]string, rowCount)
+	for i := range valueGroups {
+		valueGroups[i] = "(" + strings.Join(rowPlaceholders, ", ") + ")"
 	}
 	updates := []string{}
 	for _, field := range fields {
@@ -540,16 +972,34 @@ func upsertStatement(driver, table string, fields []string, keyField string) str
 			continue
 		}
 		q := quoteIdent(driver, field)
-		updates = append(updates, fmt.Sprintf("%s=VALUES(%s)", q, q))
+		if isSQLite(driver) {
+			updates = append(updates, fmt.Sprintf("%s=excluded.%s", q, q))
+		} else {
+			updates = append(updates, fmt.Sprintf("%s=VALUES(%s)", q, q))
+		}
+	}
+	if isSQLite(driver) {
+		conflictAction := "DO NOTHING"
+		if len(updates) > 0 {
+			conflictAction = "DO UPDATE SET " + strings.Join(updates, ", ")
+		}
+		return fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES %s ON CONFLICT (%s) %s",
+			quoteIdent(driver, table),
+			strings.Join(quoted, ", "),
+			strings.Join(valueGroups, ", "),
+			quoteIdent(driver, keyField),
+			conflictAction,
+		)
 	}
 	if len(updates) == 0 {
 		updates = append(updates, fmt.Sprintf("%s=VALUES(%s)", quoteIdent(driver, keyField), quoteIdent(driver, keyField)))
 	}
 	return fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s",
+		"INSERT INTO %s (%s) VALUES %s ON DUPLICATE KEY UPDATE %s",
 		quoteIdent(driver, table),
 		strings.Join(quoted, ", "),
-		strings.Join(placeholders, ", "),
+		strings.Join(valueGroups, ", "),
 		strings.Join(updates, ", "),
 	)
 }

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -211,7 +211,14 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	result.Reconciliation, err = normalizeReconciliation(options.Reconciliation)
 	defer func() {
 		result.ElapsedMS = time.Since(started).Milliseconds()
-		if err != nil && result.Failed == 0 {
+		if err != nil {
+			// Inserted/updated/unchanged/deleted are committed-result counts, not
+			// a plan. Never report successes for an operation that rolled back or
+			// whose commit outcome was not confirmed.
+			result.Inserted = 0
+			result.Updated = 0
+			result.Unchanged = 0
+			result.Deleted = 0
 			result.Failed = len(rows)
 		}
 	}()
@@ -255,6 +262,9 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 
 	var beforeColumns map[string]bool
 	if tableExists {
+		if err := requireTransactionalTable(ctx, db, driver, table); err != nil {
+			return result, err
+		}
 		beforeColumns, err = existingColumns(ctx, db, driver, table)
 		if err != nil {
 			return result, err
@@ -266,6 +276,11 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 
 	if !options.DryRun && len(rows) > 0 {
 		if err := createTable(ctx, db, driver, table, fields, keyField, rows); err != nil {
+			return result, err
+		}
+		// Re-check after CREATE IF NOT EXISTS so a concurrently created or
+		// pre-existing non-transactional table cannot bypass the earlier probe.
+		if err := requireTransactionalTable(ctx, db, driver, table); err != nil {
 			return result, err
 		}
 		if err := ensureColumns(ctx, db, driver, table, fields, keyField, rows); err != nil {
@@ -350,6 +365,28 @@ func sqlTableExists(ctx context.Context, db *sql.DB, driver, table string) (bool
 		return false, err
 	}
 	return exists == 1, nil
+}
+
+func requireTransactionalTable(ctx context.Context, db *sql.DB, driver, table string) error {
+	if isSQLite(driver) {
+		return nil
+	}
+	query := "SELECT ENGINE FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ? LIMIT 1"
+	var engine sql.NullString
+	if err := db.QueryRowContext(ctx, query, table).Scan(&engine); err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("SQL table %q disappeared before synchronization", table)
+		}
+		return fmt.Errorf("inspect %s storage engine: %w", table, err)
+	}
+	if !engine.Valid || !strings.EqualFold(strings.TrimSpace(engine.String), "InnoDB") {
+		name := strings.TrimSpace(engine.String)
+		if name == "" {
+			name = "unknown"
+		}
+		return fmt.Errorf("existing table %q uses non-transactional or unsupported engine %q; InnoDB is required", table, name)
+	}
+	return nil
 }
 
 func normalizeReconciliation(value ReconciliationMode) (ReconciliationMode, error) {

--- a/pkg/recordsink/sink_test.go
+++ b/pkg/recordsink/sink_test.go
@@ -388,6 +388,7 @@ type schemaDriverState struct {
 	prepared          []preparedExecution
 	columns           [][]driver.Value
 	tableExists       bool
+	engine            string
 	commits           int
 	rollbacks         int
 	productExecs      int
@@ -424,6 +425,17 @@ func (conn *schemaConn) Close() error              { return nil }
 func (conn *schemaConn) Begin() (driver.Tx, error) { return &schemaTx{state: conn.state}, nil }
 
 func (conn *schemaConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if strings.HasPrefix(query, "SELECT ENGINE FROM information_schema.tables") {
+		values := [][]driver.Value{}
+		if conn.state.tableExists {
+			engine := conn.state.engine
+			if engine == "" {
+				engine = "InnoDB"
+			}
+			values = append(values, []driver.Value{engine})
+		}
+		return &schemaRows{columns: []string{"ENGINE"}, values: values}, nil
+	}
 	if strings.Contains(query, "information_schema.tables") {
 		values := [][]driver.Value{}
 		if conn.state.tableExists {
@@ -451,6 +463,12 @@ func (conn *schemaConn) QueryContext(_ context.Context, query string, _ []driver
 
 func (conn *schemaConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
 	conn.state.execs = append(conn.state.execs, query)
+	if strings.HasPrefix(query, "CREATE TABLE IF NOT EXISTS ") {
+		conn.state.tableExists = true
+		if conn.state.engine == "" {
+			conn.state.engine = "InnoDB"
+		}
+	}
 	return driver.RowsAffected(1), nil
 }
 

--- a/pkg/recordsink/sink_test.go
+++ b/pkg/recordsink/sink_test.go
@@ -45,7 +45,7 @@ func TestWriteSQLiteReconcilesFullSnapshotAndClearsExistingTable(t *testing.T) {
 	}
 	if err := WriteSQLite(path, "products", "product_code", []map[string]interface{}{
 		{"product_code": "B", "final_price": int64(250)},
-	}); err != nil {
+	}, SnapshotOptions{Reconciliation: DeleteMissing}); err != nil {
 		t.Fatalf("replacement snapshot failed: %v", err)
 	}
 
@@ -63,7 +63,7 @@ func TestWriteSQLiteReconcilesFullSnapshotAndClearsExistingTable(t *testing.T) {
 		t.Fatalf("snapshot reconciliation left stale data: count=%d price=%d", count, price)
 	}
 
-	if err := WriteSQLite(path, "products", "product_code", nil); err != nil {
+	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{Reconciliation: DeleteMissing}); err != nil {
 		t.Fatalf("empty snapshot failed: %v", err)
 	}
 	if err := db.QueryRow(`SELECT COUNT(*) FROM products`).Scan(&count); err != nil {
@@ -86,7 +86,7 @@ func TestWriteSQLiteSnapshotRetainsProtectedKeys(t *testing.T) {
 	}
 	if err := WriteSQLite(path, "products", "product_code", []map[string]interface{}{
 		{"product_code": "B", "final_price": int64(250)},
-	}, SnapshotOptions{ProtectedKeys: []string{"A"}}); err != nil {
+	}, SnapshotOptions{Reconciliation: DeleteMissing, ProtectedKeys: []string{"A"}}); err != nil {
 		t.Fatalf("protected replacement snapshot failed: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestWriteSQLiteSnapshotRetainsProtectedKeys(t *testing.T) {
 	defer db.Close()
 	assertSQLiteCodes(t, db, []string{"A", "B"})
 
-	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{ProtectedKeys: []string{"A"}}); err != nil {
+	if err := WriteSQLite(path, "products", "product_code", nil, SnapshotOptions{Reconciliation: DeleteMissing, ProtectedKeys: []string{"A"}}); err != nil {
 		t.Fatalf("all-quarantined snapshot failed: %v", err)
 	}
 	assertSQLiteCodes(t, db, []string{"A"})
@@ -244,6 +244,20 @@ func TestMySQLCanonicalColumnTypes(t *testing.T) {
 	}
 }
 
+func TestMySQLCreatesTransactionalTable(t *testing.T) {
+	state := &schemaDriverState{}
+	db := sql.OpenDB(schemaConnector{state: state})
+	defer db.Close()
+	if err := createTable(context.Background(), db, "mysql", "products", []string{"product_code", "final_price"}, "product_code", []map[string]interface{}{{
+		"product_code": "001", "final_price": int64(100),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(state.execs) != 1 || !strings.HasSuffix(state.execs[0], " ENGINE=InnoDB") {
+		t.Fatalf("MySQL create is not explicitly transactional: %#v", state.execs)
+	}
+}
+
 func TestMySQLSchemaEvolutionAddsTypedCanonicalColumns(t *testing.T) {
 	state := &schemaDriverState{}
 	db := sql.OpenDB(schemaConnector{state: state})
@@ -297,14 +311,11 @@ func TestMySQLSnapshotPreservesTypedNullValuesAndDeletesAbsentRows(t *testing.T)
 			productWrites = append(productWrites, execution)
 		}
 	}
-	if len(productWrites) != 2 {
-		t.Fatalf("product writes = %d, want 2 (all=%#v)", len(productWrites), state.prepared)
+	if len(productWrites) != 1 {
+		t.Fatalf("product batch writes = %d, want 1 (all=%#v)", len(productWrites), state.prepared)
 	}
-	if got := productWrites[0].args; len(got) != 3 || got[0] != "001" || got[1] != nil || got[2] != float64(24.5) {
-		t.Fatalf("first typed MySQL row = %#v", got)
-	}
-	if got := productWrites[1].args; len(got) != 3 || got[0] != "002" || got[1] != int64(2009410) || got[2] != nil {
-		t.Fatalf("second typed MySQL row = %#v", got)
+	if got := productWrites[0].args; len(got) != 6 || got[0] != "001" || got[1] != nil || got[2] != float64(24.5) || got[3] != "002" || got[4] != int64(2009410) || got[5] != nil {
+		t.Fatalf("typed MySQL batch = %#v", got)
 	}
 	joined := strings.Join(state.execs, "\n")
 	if !strings.Contains(joined, "DELETE FROM `products` WHERE NOT EXISTS") {
@@ -373,12 +384,14 @@ func containsExact(values []string, expected string) bool {
 }
 
 type schemaDriverState struct {
-	execs       []string
-	prepared    []preparedExecution
-	columns     [][]driver.Value
-	tableExists bool
-	commits     int
-	rollbacks   int
+	execs             []string
+	prepared          []preparedExecution
+	columns           [][]driver.Value
+	tableExists       bool
+	commits           int
+	rollbacks         int
+	productExecs      int
+	failProductExecAt int
 }
 
 type preparedExecution struct {
@@ -419,6 +432,11 @@ func (conn *schemaConn) QueryContext(_ context.Context, query string, _ []driver
 		return &schemaRows{columns: []string{"exists"}, values: values}, nil
 	}
 	if !strings.HasPrefix(query, "SHOW COLUMNS FROM") {
+		if strings.HasPrefix(query, "SELECT ") && strings.Contains(query, " FROM `products` WHERE ") {
+			columnsPart := strings.TrimPrefix(strings.SplitN(query, " FROM ", 2)[0], "SELECT ")
+			columns := strings.Split(strings.ReplaceAll(columnsPart, "`", ""), ", ")
+			return &schemaRows{columns: columns}, nil
+		}
 		return nil, errors.New("unexpected query: " + query)
 	}
 	columns := conn.state.columns
@@ -466,6 +484,12 @@ func (stmt *schemaStmt) Close() error  { return nil }
 func (stmt *schemaStmt) NumInput() int { return -1 }
 func (stmt *schemaStmt) Exec(args []driver.Value) (driver.Result, error) {
 	stmt.state.prepared = append(stmt.state.prepared, preparedExecution{query: stmt.query, args: append([]driver.Value(nil), args...)})
+	if strings.HasPrefix(stmt.query, "INSERT INTO `products`") {
+		stmt.state.productExecs++
+		if stmt.state.failProductExecAt > 0 && stmt.state.productExecs == stmt.state.failProductExecAt {
+			return nil, errInjectedProductWrite
+		}
+	}
 	return driver.RowsAffected(1), nil
 }
 func (stmt *schemaStmt) Query([]driver.Value) (driver.Rows, error) {

--- a/pkg/recordsink/sql_sync_test.go
+++ b/pkg/recordsink/sql_sync_test.go
@@ -1,0 +1,268 @@
+package recordsink
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var errInjectedProductWrite = errors.New("injected product batch failure")
+
+func TestSQLiteSyncInitialUpdateDryRunAndProtectedDelete(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "products.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "001", "final_price": int64(100)},
+		{"product_code": "002", "final_price": int64(200)},
+		{"product_code": "003", "final_price": int64(300)},
+	}
+	result, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Batch: 2,
+	}, initial)
+	if err != nil {
+		t.Fatalf("initial SQLite sync: %v", err)
+	}
+	assertSQLResultCounts(t, result, 3, 0, 0, 0, 0)
+	if result.Reconciliation != UpsertOnly {
+		t.Fatalf("unsafe default reconciliation = %q", result.Reconciliation)
+	}
+
+	update := []map[string]interface{}{
+		{"product_code": "002", "final_price": int64(250)},
+		{"product_code": "003", "final_price": int64(300)},
+		{"product_code": "004", "final_price": int64(400)},
+	}
+	result, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Batch: 2,
+	}, update)
+	if err != nil {
+		t.Fatalf("SQLite update sync: %v", err)
+	}
+	assertSQLResultCounts(t, result, 1, 1, 1, 0, 0)
+	assertSQLiteProductState(t, path, 4, "002", 250)
+
+	preview := []map[string]interface{}{
+		{"product_code": "002", "final_price": int64(250)},
+		{"product_code": "004", "final_price": int64(450)},
+	}
+	result, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table:          "products",
+		KeyField:       "product_code",
+		Batch:          1,
+		Reconciliation: DeleteMissing,
+		DryRun:         true,
+		ProtectedKeys:  []string{"001"},
+	}, preview)
+	if err != nil {
+		t.Fatalf("SQLite dry run: %v", err)
+	}
+	assertSQLResultCounts(t, result, 0, 1, 1, 1, 0)
+	if !result.DryRun {
+		t.Fatal("dry-run result was not marked as a preview")
+	}
+	assertSQLiteProductState(t, path, 4, "004", 400)
+
+	result, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table:          "products",
+		KeyField:       "product_code",
+		Batch:          1,
+		Reconciliation: DeleteMissing,
+		ProtectedKeys:  []string{"001"},
+	}, preview)
+	if err != nil {
+		t.Fatalf("SQLite delete_missing sync: %v", err)
+	}
+	assertSQLResultCounts(t, result, 0, 1, 1, 1, 0)
+	assertSQLiteProductState(t, path, 3, "004", 450)
+}
+
+func TestSQLiteDryRunDoesNotCreateDestination(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "preview.sqlite")
+	result, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", DryRun: true,
+	}, []map[string]interface{}{{"product_code": "001", "final_price": int64(100)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, result, 1, 0, 0, 0, 0)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("dry run created destination %q: %v", path, err)
+	}
+}
+
+func TestSQLiteDryRunDoesNotEvolveSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "preview-existing.sqlite")
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code",
+	}, []map[string]interface{}{{"product_code": "001", "name": "Existing"}}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", DryRun: true,
+	}, []map[string]interface{}{{"product_code": "001", "name": "Existing", "location": "A-1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, result, 0, 1, 0, 0, 0)
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('products') WHERE name = 'location'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("dry run added the location column")
+	}
+}
+
+func TestMySQLPreparedWritesHonorBatchSize(t *testing.T) {
+	state := &schemaDriverState{
+		tableExists: true,
+		columns: [][]driver.Value{
+			{"product_code", "varchar(191)", "NO", "PRI", nil, ""},
+			{"final_price", "bigint", "YES", "", nil, ""},
+		},
+	}
+	db := sql.OpenDB(schemaConnector{state: state})
+	defer db.Close()
+	rows := make([]map[string]interface{}, 5)
+	for index := range rows {
+		rows[index] = map[string]interface{}{
+			"product_code": "00" + string(rune('1'+index)),
+			"final_price":  int64(100 + index),
+		}
+	}
+	result, err := SyncSQLDB(context.Background(), db, SQLOptions{
+		Driver: "mysql", Table: "products", KeyField: "product_code", Batch: 2,
+	}, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, result, 5, 0, 0, 0, 0)
+	productWrites := preparedProductWrites(state.prepared)
+	if len(productWrites) != 3 {
+		t.Fatalf("prepared product batches = %d, want 3: %#v", len(productWrites), productWrites)
+	}
+	for index, wantArgs := range []int{4, 4, 2} {
+		if got := len(productWrites[index].args); got != wantArgs {
+			t.Fatalf("batch %d args = %d, want %d", index, got, wantArgs)
+		}
+	}
+}
+
+func TestSQLBatchFailureRollsBackAndReportsFailedRows(t *testing.T) {
+	state := &schemaDriverState{
+		tableExists:       true,
+		failProductExecAt: 2,
+		columns: [][]driver.Value{
+			{"product_code", "varchar(191)", "NO", "PRI", nil, ""},
+			{"final_price", "bigint", "YES", "", nil, ""},
+		},
+	}
+	db := sql.OpenDB(schemaConnector{state: state})
+	defer db.Close()
+	rows := []map[string]interface{}{
+		{"product_code": "001", "final_price": int64(100)},
+		{"product_code": "002", "final_price": int64(200)},
+		{"product_code": "003", "final_price": int64(300)},
+	}
+	result, err := SyncSQLDB(context.Background(), db, SQLOptions{
+		Driver: "mysql", Table: "products", KeyField: "product_code", Batch: 2,
+	}, rows)
+	if !errors.Is(err, errInjectedProductWrite) {
+		t.Fatalf("batch error = %v", err)
+	}
+	if result.Failed != len(rows) || state.commits != 0 || state.rollbacks != 1 {
+		t.Fatalf("failure result=%+v commits=%d rollbacks=%d", result, state.commits, state.rollbacks)
+	}
+}
+
+func TestMariaDBSyncInitialWriteAndUpdate(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("PATRIS_EXPORT_TEST_MYSQL_DSN"))
+	if dsn == "" {
+		t.Skip("set PATRIS_EXPORT_TEST_MYSQL_DSN to run the MariaDB/MySQL integration proof")
+	}
+	table := fmt.Sprintf("patris_recordsink_it_%d", time.Now().UTC().UnixNano())
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal("open integration database:", err)
+	}
+	defer db.Close()
+	defer func() {
+		_, _ = db.Exec("DROP TABLE IF EXISTS " + quoteIdent("mysql", table))
+	}()
+
+	options := SQLOptions{
+		Driver: "mysql", DSN: dsn, Table: table, KeyField: "product_code", Batch: 2,
+	}
+	result, err := SyncSQLWithResult(context.Background(), options, []map[string]interface{}{
+		{"product_code": "001", "foreign_price": 10.25, "final_price": int64(100)},
+		{"product_code": "002", "foreign_price": 20.5, "final_price": int64(200)},
+	})
+	if err != nil {
+		t.Fatalf("initial MariaDB sync: %v", err)
+	}
+	assertSQLResultCounts(t, result, 2, 0, 0, 0, 0)
+
+	result, err = SyncSQLWithResult(context.Background(), options, []map[string]interface{}{
+		{"product_code": "002", "foreign_price": 21.5, "final_price": int64(250)},
+		{"product_code": "003", "foreign_price": 30.75, "final_price": int64(300)},
+	})
+	if err != nil {
+		t.Fatalf("MariaDB update sync: %v", err)
+	}
+	assertSQLResultCounts(t, result, 1, 1, 0, 0, 0)
+	var count int
+	var price int64
+	query := "SELECT COUNT(*), MAX(CASE WHEN product_code = '002' THEN final_price END) FROM " + quoteIdent("mysql", table)
+	if err := db.QueryRow(query).Scan(&count, &price); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 || price != 250 {
+		t.Fatalf("MariaDB proof state: count=%d updated_price=%d", count, price)
+	}
+}
+
+func assertSQLResultCounts(t *testing.T, result SQLResult, inserted, updated, unchanged, deleted, failed int) {
+	t.Helper()
+	if result.Inserted != inserted || result.Updated != updated || result.Unchanged != unchanged || result.Deleted != deleted || result.Failed != failed {
+		t.Fatalf("SQL result = %+v, want inserted=%d updated=%d unchanged=%d deleted=%d failed=%d", result, inserted, updated, unchanged, deleted, failed)
+	}
+}
+
+func assertSQLiteProductState(t *testing.T, path string, count int, code string, price int64) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var gotCount int
+	var gotPrice int64
+	if err := db.QueryRow(`SELECT COUNT(*), MAX(CASE WHEN product_code = ? THEN final_price END) FROM products`, code).Scan(&gotCount, &gotPrice); err != nil {
+		t.Fatal(err)
+	}
+	if gotCount != count || gotPrice != price {
+		t.Fatalf("SQLite state: count=%d price[%s]=%d, want count=%d price=%d", gotCount, code, gotPrice, count, price)
+	}
+}
+
+func preparedProductWrites(executions []preparedExecution) []preparedExecution {
+	result := []preparedExecution{}
+	for _, execution := range executions {
+		if strings.HasPrefix(execution.query, "INSERT INTO `products`") {
+			result = append(result, execution)
+		}
+	}
+	return result
+}

--- a/pkg/recordsink/sql_sync_test.go
+++ b/pkg/recordsink/sql_sync_test.go
@@ -182,8 +182,33 @@ func TestSQLBatchFailureRollsBackAndReportsFailedRows(t *testing.T) {
 	if !errors.Is(err, errInjectedProductWrite) {
 		t.Fatalf("batch error = %v", err)
 	}
-	if result.Failed != len(rows) || state.commits != 0 || state.rollbacks != 1 {
+	if result.Inserted != 0 || result.Updated != 0 || result.Unchanged != 0 || result.Deleted != 0 || result.Failed != len(rows) || state.commits != 0 || state.rollbacks != 1 {
 		t.Fatalf("failure result=%+v commits=%d rollbacks=%d", result, state.commits, state.rollbacks)
+	}
+}
+
+func TestSQLSyncRejectsExistingNonTransactionalMySQLTable(t *testing.T) {
+	state := &schemaDriverState{
+		tableExists: true,
+		engine:      "MyISAM",
+		columns: [][]driver.Value{
+			{"product_code", "varchar(191)", "NO", "PRI", nil, ""},
+			{"final_price", "bigint", "YES", "", nil, ""},
+		},
+	}
+	db := sql.OpenDB(schemaConnector{state: state})
+	defer db.Close()
+	result, err := SyncSQLDB(context.Background(), db, SQLOptions{
+		Driver: "mysql", Table: "products", KeyField: "product_code", Batch: 2,
+	}, []map[string]interface{}{{"product_code": "001", "final_price": int64(100)}})
+	if err == nil || !strings.Contains(err.Error(), "InnoDB is required") {
+		t.Fatalf("non-transactional table error = %v", err)
+	}
+	if result.Failed != 1 || result.Inserted != 0 || result.Updated != 0 || result.Unchanged != 0 || result.Deleted != 0 {
+		t.Fatalf("non-transactional failure result = %+v", result)
+	}
+	if len(state.execs) != 0 || len(state.prepared) != 0 || state.commits != 0 || state.rollbacks != 0 {
+		t.Fatalf("non-transactional table was mutated: execs=%#v prepared=%#v commits=%d rollbacks=%d", state.execs, state.prepared, state.commits, state.rollbacks)
 	}
 }
 


### PR DESCRIPTION
﻿Refs #6

## Scope

This focused second-pass slice completes the core SQL sink execution semantics without duplicating the existing transformation, typed-schema, additive-evolution, exact-decimal, or quarantine implementations.

- makes `upsert_only` the explicit, safe default and adds opt-in `delete_missing`;
- honors `batch_size` with bounded prepared multi-row writes (driver parameter limits can only reduce the requested maximum);
- uses the same bounded batching for protected snapshot-key staging;
- reports inserted, updated, unchanged, deleted, failed, elapsed_ms, dry_run, and reconciliation through a DSN-free shared `recordsink.SQLResult`;
- adds destination-safe dry runs, including no SQLite file/directory creation and no schema evolution;
- keeps canonical quarantine Codes during opt-in deletion;
- exposes config/env/CLI controls and prints the result for one-shot and watch conversions;
- adds a reproducible SQLite initial-write/update/delete-preview proof plus an optional env-gated MariaDB/MySQL proof.

## One shared path

`WriteSQLite`, `SyncSQL`, `UpsertSQL`, `SyncSnapshotSQL`, CLI one-shot conversion, and the existing watch callback all converge on `SyncSQLDB`. The watch loop already invokes the same `convertFile` -> `writeConvertOutput` route for initial and debounced updates. No live-only SQL implementation or transformation path was added.

The sink diff is necessarily larger because exact inserted/updated/unchanged previews require bounded reads and type-aware comparisons (including exact decimal tokens), while prepared chunk writes and protected reconciliation need their own bounded statement builders. Existing `recordpipe`, mapping, column typing/evolution, and decimal conversion functions remain authoritative and are reused.

## Atomicity and safety

- SQLite/MySQL data upserts and `delete_missing` run in one transaction; any chunk failure rolls back the data operation and reports every requested row as failed.
- Failure results zero all planned success counts; existing MySQL/MariaDB targets are inspected before mutation and must use InnoDB.
- Additive schema creation/evolution remains before the data transaction, matching the existing schema path; MySQL-created tables now explicitly use InnoDB.
- `delete_missing` stages snapshot and protected keys before deleting; the zero-value/default mode never deletes absent rows.
- Dry run performs reads only. A missing SQLite destination is evaluated in memory, so the requested target is not created.
- Results contain no DSN. MySQL output identifies only the table.

## Verification

- `go test ./pkg/recordsink` ? pass
- focused SQLite/batch/rollback proof ? pass
- Windows CGO `go test ./...` ? pass
- Windows CGO `go vet ./...` ? pass
- Windows CGO `go test -race ./pkg/recordsink ./pkg/appconfig ./cmd/patris-export` ? pass
- `npm ci`, `npm run build`, `npm test` ? pass (20/20 after rebase)
- `git diff --check` ? pass
- optional `TestMariaDBSyncInitialWriteAndUpdate` ? correctly skipped because `PATRIS_EXPORT_TEST_MYSQL_DSN` is not set on this workstation

A full-repository race run passed every changed package but still detects the pre-existing unsynchronized timer/map access in `pkg/watcher` (`watcher.go:153-155`, `TestFileWatcher_DebounceOneSecond`). This PR does not expand into that unrelated watcher repair.

## Intentionally remaining on issue #6

This PR does not close #6. Follow-up work remains for authenticated Web UI target status, redacted config state, connection test, manual sync, persistent last-result diagnostics, `soft_delete_missing`, custom-CA TLS registration/management, broader MariaDB/MySQL CI matrices and retry classification. DSNs should continue to be injected through protected environment configuration; browser exposure is not added here.

Rebased onto current `origin/main` `11327b425bf28ea57bca45ec380f502f868f373f`; independent review blockers were remediated and decisive local checks were rerun on head `1a264a05d927b113deffad2a32c895094652af5a`. The rebase was conflict-free and patch-equivalent (`git range-diff` exact matches; stable patch ID `dd4f98580a268a595602cd5e42411d287eb36318`). All four fresh GitHub checks passed on that head.

No merge, executable rebuild, deployment, or production database mutation is part of this PR.











