### PR TITLE
fix(pricing): allow production batch latency

### DIFF
--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -126,7 +126,7 @@ stored in the Patris config:
         "batch_size": 500,
         "fresh_for": "5m",
         "max_stale": "1h",
-        "timeout": "5s",
+        "timeout": "15s",
         "max_entries": 2048,
         "max_concurrency": 8,
         "max_response_bytes": 2097152
@@ -138,8 +138,16 @@ stored in the Patris config:
 
 ```powershell
 $env:DIGITALOGIC_PRICING_READ_TOKEN = "..."
+$env:PATRIS_EXPORT_PRICING_TIMEOUT = "15s"
+$env:PATRIS_EXPORT_PRICING_BATCH_SIZE = "500"
 patris-export serve C:\Patris\data4\kala.db
 ```
+
+`PATRIS_EXPORT_PRICING_TIMEOUT` and `PATRIS_EXPORT_PRICING_BATCH_SIZE` override
+the same normalized Digitalogic provider used by file configuration. Batch
+size is capped at the remote contract maximum of 500. The 15-second timeout
+default leaves headroom for a production 500-Code response without changing
+the bounded request count or enabling single-Code fallback.
 
 Only HTTPS is accepted remotely; plain HTTP is limited to loopback. Provider
 paths must stay relative and on the configured origin, redirects are refused,

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -723,6 +723,14 @@ func ApplyEnv(cfg *Config) {
 	if value := os.Getenv("PATRIS_EXPORT_PRICING_MAX_STALE"); strings.TrimSpace(value) != "" {
 		cfg.Canonical.Pricing.Digitalogic.MaxStale = strings.TrimSpace(value)
 	}
+	if value := os.Getenv("PATRIS_EXPORT_PRICING_TIMEOUT"); strings.TrimSpace(value) != "" {
+		cfg.Canonical.Pricing.Digitalogic.Timeout = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_PRICING_BATCH_SIZE"); strings.TrimSpace(value) != "" {
+		if batch, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+			cfg.Canonical.Pricing.Digitalogic.BatchSize = batch
+		}
+	}
 	for _, key := range []string{"PATRIS_EXPORT_TEMP_DIR", "PATRIS_EXPORT_TMPDIR"} {
 		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
 			cfg.Runtime.TempDir = strings.TrimSpace(value)

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -205,6 +205,8 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_BEARER_ENV", "DIGITALOGIC_PRICING_READ_TOKEN")
 	t.Setenv("PATRIS_EXPORT_PRICING_FRESH_FOR", "2m")
 	t.Setenv("PATRIS_EXPORT_PRICING_MAX_STALE", "30m")
+	t.Setenv("PATRIS_EXPORT_PRICING_TIMEOUT", "20s")
+	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_SIZE", "250")
 	t.Setenv("DIGITALOGIC_KEY", "must-not-be-copied")
 	t.Setenv("DIGITALOGIC_SECRET", "must-not-be-copied")
 	t.Setenv("DIGITALOGIC_PRICING_READ_TOKEN", "must-not-be-copied-bearer")
@@ -215,7 +217,7 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	if cfg.Canonical.Pricing.Mode != "digitalogic" || digitalogic.BaseURL != "https://digitalogic.example/wp-json/digitalogic/v1" {
 		t.Fatalf("Digitalogic pricing provider was not selected: %+v", cfg.Canonical.Pricing)
 	}
-	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.BearerTokenEnv != "DIGITALOGIC_PRICING_READ_TOKEN" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" {
+	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.BearerTokenEnv != "DIGITALOGIC_PRICING_READ_TOKEN" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" || digitalogic.Timeout != "20s" || digitalogic.BatchSize != 250 {
 		t.Fatalf("Digitalogic provider environment references were not normalized: %+v", digitalogic)
 	}
 	encoded, err := json.Marshal(cfg)
@@ -224,6 +226,22 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	}
 	if strings.Contains(string(encoded), "must-not-be-copied") {
 		t.Fatalf("credential values were persisted in config: %s", encoded)
+	}
+}
+
+func TestApplyEnvBoundsDigitalogicPricingBatchSizeAndTimeout(t *testing.T) {
+	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_URL", "https://digitalogic.example/wp-json/digitalogic/v1/")
+	t.Setenv("PATRIS_EXPORT_PRICING_TIMEOUT", "not-a-duration")
+	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_SIZE", "501")
+
+	cfg := Default()
+	ApplyEnv(&cfg)
+	digitalogic := cfg.Canonical.Pricing.Digitalogic
+	if digitalogic.Timeout != "15s" {
+		t.Fatalf("invalid timeout did not normalize to the safe default: %+v", digitalogic)
+	}
+	if digitalogic.BatchSize != 500 {
+		t.Fatalf("batch size was not bounded to the remote contract maximum: %+v", digitalogic)
 	}
 }
 

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -17,7 +17,7 @@ const (
 	ModeDigitalogic    = "digitalogic"
 	defaultFreshFor    = 5 * time.Minute
 	defaultMaxStale    = time.Hour
-	defaultTimeout     = 5 * time.Second
+	defaultTimeout     = 15 * time.Second
 	defaultMaxEntries  = 2048
 	defaultMaxBytes    = int64(2 << 20)
 	defaultConcurrency = 8

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -915,6 +915,43 @@ func TestHTTPProviderRequiresConsistentNonNullCNYToIRT(t *testing.T) {
 	}
 }
 
+func TestHTTPProviderConfiguredTimeoutAllowsSlowBatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/integration/catalog":
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","schema_version":"1.0.0","revision":"r1","currency":{"local":"IRT","cny_to_local":25300,"cny_to_irt":25300},"pricing":{"formula_id":"landed_price_v1","formula_revision":"1.0.0"},"import_freight_methods":[{"id":"air","price_per_kg_cny":85}]}}`)
+		case "/pricing-assignments/batch":
+			time.Sleep(75 * time.Millisecond)
+			fmt.Fprint(w, `{"data":{"schema":"digitalogic.pricing-assignment-batch","schema_version":"1.0.0","requested_count":1,"resolved_count":1,"error_count":0,"maximum_codes":500,"default_percentage_markup":{"schema":"digitalogic.default-percentage-markup","schema_version":"1.0.0","configured":true,"type":"percentage","profit_percent":"30","source":"global_default","revision":"rev-30"},"results":[{"code":"A","status":"ok","assignment":{"code":"A","import_freight_method_id":"air","profit_percent":"30","profit_percent_source":"global_default","pricing_warnings":[]}}]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: server.URL, Timeout: "250ms", BatchSize: 1,
+	}, nil, time.Now)
+	resolution := provider.Prefetch(context.Background(), []string{"A"}).Resolve(context.Background(), "A")
+	if resolution.MethodID != "air" || decimalText(resolution.MarkupPercent) != "30" {
+		t.Fatalf("configured timeout did not retain the slow batch result: %+v", resolution)
+	}
+	if contains(resolution.Warnings, "pricing_assignment_batch_transport_failed") {
+		t.Fatalf("slow batch was misclassified as a transport failure: %+v", resolution)
+	}
+	if provider.client.Timeout != 250*time.Millisecond {
+		t.Fatalf("provider client timeout = %s", provider.client.Timeout)
+	}
+}
+
+func TestDigitalogicProviderDefaultsLeaveProductionBatchHeadroom(t *testing.T) {
+	digitalogic := Normalize(Config{Mode: ModeDigitalogic}).Digitalogic
+	if digitalogic.Timeout != "15s" || digitalogic.BatchSize != 500 {
+		t.Fatalf("unexpected production batch defaults: %+v", digitalogic)
+	}
+}
+
 func contains(values []string, expected string) bool {
 	for _, value := range values {
 		if value == expected {


### PR DESCRIPTION
## Summary

- raise the normalized Digitalogic pricing HTTP timeout from 5s to 15s so a measured ~7.1s production 500-Code response can complete
- expose the existing provider's timeout and bounded batch size through `PATRIS_EXPORT_PRICING_TIMEOUT` and `PATRIS_EXPORT_PRICING_BATCH_SIZE`
- keep batch size capped at the single current remote maximum of 500 and preserve the single provider/cache/prefetch path
- add environment normalization and slow-batch regression coverage; document deployment controls

## Live failure reproduced

The rebuilt main binary fetched a fresh catalog but emitted `pricing_assignment_batch_transport_failed` for product assignments. Code `113001001` therefore had FX only and omitted the derived price even though the direct batch endpoint returned `air_express` with 30% markup. The production 500-Code request exceeds the old five-second timeout.

## Verification

- `go test ./...` with Windows CGO/pxlib
- `go test -race ./pkg/pricingcatalog ./pkg/appconfig ./pkg/canonical`
- `go vet ./...`
- frontend tests 20/20 and production build
- `git diff --check`

No secrets are stored or logged. No outbound product sync is enabled by this PR.

Closes #153
