### PR TITLE
Allow safe GitHub runner purge-test roots

### DIFF
--- a/scripts/windows/Build-Installer.ps1
+++ b/scripts/windows/Build-Installer.ps1
@@ -73,7 +73,7 @@ if ($PurgeDataRoot) {
         throw "PurgeDataRoot is a smoke-test option and requires CurrentUserOnly."
     }
     $PurgeDataRoot = [System.IO.Path]::GetFullPath($PurgeDataRoot)
-    $allowedRoots = @((Join-Path $repoRoot "build"), $env:TEMP) |
+    $allowedRoots = @((Join-Path $repoRoot "build"), $env:RUNNER_TEMP, $env:TEMP) |
         Where-Object { $_ } |
         ForEach-Object { [System.IO.Path]::GetFullPath($_).TrimEnd('\') + '\' }
     $allowed = $false


### PR DESCRIPTION
## Summary

- include GitHub Actions' dedicated `RUNNER_TEMP` in the installer smoke-test purge allowlist
- retain the existing full-path normalization and descendant-only containment check
- leave production uninstall behavior unchanged; this parameter is accepted only for current-user smoke installers

## Root cause

The first merged-main ALM candidate run built the runtime and full installer, then correctly refused to compile its isolated purge test because GitHub's `D:\a\_temp` is separate from the process `%TEMP%` directory.

Failed run: https://github.com/atomicdeploy/patris-export/actions/runs/29582833162

## Verification

Using a mocked `RUNNER_TEMP` outside both `%TEMP%` and the repository:

- current-user smoke installer build: pass
- silent install: pass
- `/PURGEDATA` removed the configured runner-temp root: pass
- unrelated parent marker preserved: pass
- owned install directory clean: pass
- `git diff --check`: pass

Closes #162