### PR TITLE
Document and test REST, RPC, gRPC, and AJAX delivery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
         CGO_ENABLED: '0'
       run: GOOS=linux GOARCH=386 go test ./pkg/paradox -run '^TestPxLongSignExtendsNativeNegativeValue$' -count=1
 
+    - name: Test remote delivery examples
+      run: node --test scripts/examples/patris-delivery-adapter.test.cjs
+
     - name: Run tests
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Opt-in `cgo` and `cgo-static` pxlib backends now complement the default
   runtime-dynamic loader across Make, shell, and local Windows builds; manifests
   identify the selected backend and static packages omit the pxlib runtime DLL.
+- Copy-paste remote delivery recipes distinguish native REST/WordPress REST from JSON-RPC, legacy WordPress AJAX, and gRPC gateway adapters, including secret injection, idempotency, retry, failure, and replay guidance.
+- A dependency-free Node.js loopback adapter, local retryable mock receiver, sparse-payload tests, example configs, and a minimal gRPC HTTP-transcoding contract exercise non-native delivery without duplicating the Patris transformation pipeline.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-linux build-windows build-all build-lib build-lib-linux build-lib-windows clean test run install install-linux uninstall-linux help deps build-web assets variant-manifest alm-current-guard alm-linux-guard
+.PHONY: build build-linux build-windows build-all build-lib build-lib-linux build-lib-windows clean test test-delivery-examples run install install-linux uninstall-linux help deps build-web assets variant-manifest alm-current-guard alm-linux-guard
 
 # Binary names
 BINARY_NAME=patris-export
@@ -152,9 +152,12 @@ install-linux: ## Install Linux binary and systemd service (requires root)
 uninstall-linux: ## Remove Linux binary and systemd service (requires root)
 	@sudo ./scripts/install-linux.sh uninstall
 
-test: ## Run tests
+test: test-delivery-examples ## Run tests
 	@echo "🧪 Running tests..."
 	go test $(GO_BUILD_TAG_ARGS) -v ./...
+
+test-delivery-examples: ## Test dependency-free remote delivery adapters
+	node --test scripts/examples/patris-delivery-adapter.test.cjs
 
 clean: ## Clean build artifacts
 	@echo "🧹 Cleaning..."

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ See [the canonical product-sync contract](docs/CANONICAL-PRODUCT-SYNC.md) and
 `kala.db` pricing, Digitalogic, freshness, and payload details. See
 [docs/examples/export-transform-send.md](docs/examples/export-transform-send.md)
 for generic dataset mapping, SQL/MySQL DSN examples, and command delivery mode.
+For copy-paste REST, JSON-RPC, gRPC-gateway, and WordPress AJAX recipes, use
+[Remote Update Delivery](docs/REMOTE-API-EXAMPLES.md).
 
 ### Output to STDOUT
 

--- a/docs/REMOTE-API-EXAMPLES.md
+++ b/docs/REMOTE-API-EXAMPLES.md
@@ -1,0 +1,349 @@
+# Remote Update Delivery
+
+Patris Export has one native outbound pipeline: transformed records become a
+current `patris.product-sync` JSON envelope, and the HTTP sink sends that
+envelope to a receiver. REST and WordPress REST use this native path directly.
+JSON-RPC, legacy WordPress AJAX, and gRPC use a thin adapter; they do not read
+Patris or transform product data again.
+
+## Support matrix
+
+| Destination | Support | Patris configuration | Wire body |
+| --- | --- | --- | --- |
+| REST/webhook | Native | `send_updates.url` | Direct canonical envelope |
+| WordPress REST | Native and recommended | `send_updates.url` | Direct canonical envelope |
+| JSON-RPC 2.0 | Loopback adapter | Patris sends to adapter | JSON-RPC wrapper whose `params` is the unchanged envelope |
+| WordPress `admin-ajax.php` | Loopback adapter, legacy only | Patris sends to adapter | Form fields containing the unchanged envelope |
+| gRPC | HTTP/JSON transcoding gateway | Patris sends to adapter, adapter sends to gateway | Direct envelope mapped to `google.protobuf.Struct` |
+| RPC-style local command | Native command sink | `send_updates.command` | Direct envelope on stdin |
+
+Patris does **not** natively speak JSON-RPC framing, WordPress form AJAX, or
+HTTP/2 gRPC. The included Node.js adapter makes those boundaries explicit and
+keeps the canonical pipeline replaceable. It requires Node.js 18 or newer and
+uses only built-in modules.
+
+## Contract and sparse-field rules
+
+Use a canonical profile and `require_contract: true` for every product-sync
+integration. Delivery never activates pricing and never synthesizes shipping
+data. Pricing/shipping fields are eligible only when an integration provider is
+active and supplied the value. A standalone run without an active provider
+must not gain `shipping_method_id`, `shipping_price_per_kg`,
+`shipping_price_per_kg_currency`, markup, FX, or calculated-price keys merely
+because delivery is enabled. When present, the two shipping-price fields are a
+required pair and currency is exactly `CNY` or `IRR`. The upstream canonical
+pipeline converts CNY freight through the CNY-to-IRT rate and converts IRR to
+IRT by dividing by 10; adapters preserve the resulting envelope unchanged.
+
+Sparse payloads have two distinct states:
+
+- A key that was never supplied, or whose source value is empty, is absent.
+- A key explicitly supplied as JSON `null` is present with a `null` value.
+
+The adapters parse and wrap the existing envelope without normalizing product
+objects. Automated adapter tests assert that explicit null survives and unseen
+shipping/weight keys remain absent. Upgrade older binaries that still emit the
+legacy always-present pricing fields to a build containing the sparse export
+work tracked by [issue #171](https://github.com/atomicdeploy/patris-export/issues/171)
+before using these recipes in production.
+
+## Secrets and request identity
+
+Do not put secrets in a repository, URL, config value, or command line. Config
+contains only an environment-variable **name**. Patris reads the named variable
+at request time and sends it as `X-Patris-Product-Sync-Secret`.
+
+For every canonical HTTP request Patris sets:
+
+- `X-Patris-Contract`
+- `X-Patris-Contract-Version`
+- `X-Patris-Event-ID`
+- `X-Patris-Event`
+- `X-Patris-Source`
+
+`event_id` is deterministic for a given source revision and event. Receivers
+must use it as their idempotency key. Patris encodes the envelope once and
+reuses the same bytes and identity headers for all attempts. The adapter also
+sets `Idempotency-Key` on downstream HTTP requests.
+
+Remote secret-bearing destinations require HTTPS. Plain HTTP is accepted only
+for a loopback adapter or mock receiver. Redirects are not followed when the
+product-sync secret is active.
+
+The native sink provides the dedicated header secret above; it does not claim
+generic HMAC request signing. If a receiver requires HMAC, sign the exact
+canonical bytes in a small gateway and keep the signing key in that gateway's
+secret store. Do not add a second transform or product schema to do so.
+
+## Native REST and WordPress REST
+
+Copy [send-updates-rest.json](examples/send-updates-rest.json), replace the
+endpoint, and set the referenced secret in the process environment:
+
+```powershell
+$env:PATRIS_PRODUCT_SYNC_SECRET = 'replace-with-a-real-secret'
+patris-export -c .\docs\examples\send-updates-rest.json convert C:\Patris\data4\kala.db -f json -w
+```
+
+The equivalent CLI form is:
+
+```powershell
+$env:PATRIS_PRODUCT_SYNC_SECRET = 'replace-with-a-real-secret'
+patris-export convert C:\Patris\data4\kala.db -f json -w `
+  --send-url https://receiver.example/wp-json/receiver/patris/product-sync `
+  --send-format json `
+  --send-mode changes `
+  --send-initial `
+  --send-product-sync-secret-env PATRIS_PRODUCT_SYNC_SECRET `
+  --send-retry-attempts 3 `
+  --send-retry-backoff 2s
+```
+
+The WordPress REST route is the preferred WordPress integration. It receives
+the same direct body as any REST receiver; no WordPress-specific transport code
+runs in Patris.
+
+An accepted strict receiver response is:
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": "accepted",
+    "event_id": "sha256:replace-with-request-event-id",
+    "retryable": false,
+    "pending_products": 0,
+    "deferred_products": 0
+  }
+}
+```
+
+A temporary receiver failure should use HTTP `503` and may return:
+
+```json
+{
+  "success": false,
+  "code": "product_sync_busy",
+  "details": {"retryable": true}
+}
+```
+
+Patris retries network failures, HTTP 408/425/429, selected 5xx responses, and
+valid receiver states that explicitly report pending retryable work. It does
+not retry permanent 4xx rejection. Configure retries only for an idempotent
+receiver.
+
+## Web UI/config API equivalent
+
+The current visual Settings dialog does not expose outbound-delivery secrets.
+This is intentional: it must never collect or persist a secret value. It does
+persist the same full application config through `/api/config`, so an operator
+can update the non-secret `send_updates` block from the browser console while
+the secret is injected into the Patris process environment:
+
+```javascript
+const config = await fetch('/api/config').then((response) => response.json());
+config.send_updates = {
+  enabled: true,
+  url: 'https://receiver.example/wp-json/receiver/patris/product-sync',
+  method: 'POST',
+  format: 'json',
+  mode: 'changes',
+  initial: true,
+  allow_raw: false,
+  require_contract: true,
+  timeout: '10s',
+  retry_attempts: 3,
+  retry_backoff: '2s',
+  product_sync_secret_env: 'PATRIS_PRODUCT_SYNC_SECRET'
+};
+const response = await fetch('/api/config', {
+  method: 'PUT',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify(config)
+});
+if (!response.ok) throw new Error(await response.text());
+console.log(await response.json());
+```
+
+Always fetch, modify, and PUT the complete config as above. Sending only a
+partial object can reset unrelated settings. The response and subsequent
+`GET /api/config` expose only the environment-variable name, never its value.
+
+## Loopback adapter
+
+For non-native transports, start the adapter and point Patris at its fixed
+loopback endpoint using [send-updates-adapter.json](examples/send-updates-adapter.json).
+The adapter validates the canonical body and identity headers, forwards once,
+and returns a strict success or retryable failure to Patris. Patris remains the
+only retry owner.
+
+Set a loopback ingress secret in both processes:
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'replace-with-a-local-secret'
+```
+
+Then start one adapter recipe below in terminal 1 and run this in terminal 2:
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'replace-with-the-same-local-secret'
+patris-export -c .\docs\examples\send-updates-adapter.json convert C:\Patris\data4\kala.db -f json -w
+```
+
+Do not expose port 18081 beyond loopback. If the adapter must run on another
+host, terminate TLS and mutual authentication in front of it and change the
+Patris URL to HTTPS.
+
+### JSON-RPC 2.0
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'replace-with-a-local-secret'
+$env:REMOTE_API_SECRET = 'replace-with-the-remote-bearer-secret'
+node .\scripts\examples\patris-delivery-adapter.cjs `
+  --transport json-rpc `
+  --target https://api.example/rpc `
+  --method patris.productSync `
+  --ingress-secret-env PATRIS_ADAPTER_INGRESS_SECRET `
+  --target-secret-env REMOTE_API_SECRET
+```
+
+The adapter sends:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "sha256:replace-with-event-id",
+  "method": "patris.productSync",
+  "params": {
+    "schema": "patris.product-sync",
+    "schema_version": "1.1",
+    "event_id": "sha256:replace-with-event-id",
+    "products": []
+  }
+}
+```
+
+The RPC server must return the same `id`:
+
+```json
+{"jsonrpc":"2.0","id":"sha256:replace-with-event-id","result":{"accepted":true}}
+```
+
+For a temporary method error, set `error.data.retryable` to `true`. The adapter
+maps it to HTTP 503 so Patris applies its configured backoff and retry limit.
+
+### WordPress AJAX
+
+Prefer the native WordPress REST recipe. Use AJAX only for a legacy plugin that
+cannot expose a REST route:
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'replace-with-a-local-secret'
+$env:WORDPRESS_AJAX_SECRET = 'replace-with-the-remote-secret'
+node .\scripts\examples\patris-delivery-adapter.cjs `
+  --transport wordpress-ajax `
+  --target https://wordpress.example/wp-admin/admin-ajax.php `
+  --action patris_product_sync `
+  --ingress-secret-env PATRIS_ADAPTER_INGRESS_SECRET `
+  --target-secret-env WORDPRESS_AJAX_SECRET
+```
+
+The adapter submits these form fields:
+
+- `action=patris_product_sync`
+- `event_id=<canonical event_id>`
+- `payload=<unchanged canonical JSON envelope>`
+
+It sends the remote secret in `X-Patris-Product-Sync-Secret`, not a form
+field. The WordPress action must authenticate that header, deduplicate by
+`event_id`, and return the complete strict success document shown above. A
+browser nonce is not an appropriate machine-to-machine credential.
+
+### gRPC through an HTTP/JSON gateway
+
+Patris does not contain a second protobuf product model or a native gRPC
+client. Deploy an HTTP/JSON transcoding gateway in front of the gRPC service,
+using [patris-product-sync.proto](examples/patris-product-sync.proto) as the
+minimal boundary. Its `body: "envelope"` mapping accepts the direct canonical
+envelope and places it in `ApplyRequest.envelope`.
+
+Point the adapter at the gateway route:
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'replace-with-a-local-secret'
+$env:GRPC_GATEWAY_SECRET = 'replace-with-the-gateway-bearer-secret'
+node .\scripts\examples\patris-delivery-adapter.cjs `
+  --transport grpc-gateway `
+  --target https://grpc-gateway.example/v1/patris:apply `
+  --ingress-secret-env PATRIS_ADAPTER_INGRESS_SECRET `
+  --target-secret-env GRPC_GATEWAY_SECRET
+```
+
+The gateway must forward `Idempotency-Key` and the `X-Patris-*` identity headers
+as gRPC metadata. The adapter treats an HTTP 2xx gateway response as accepted
+and maps 408/425/429/5xx gateway failures to Patris retryable responses. Native
+gRPC without a gateway is not claimed or implemented by this example.
+
+## Local receiver and smoke test
+
+The adapter's `mock` transport is a credential-free local receiver. `--fail-first
+1` deliberately exposes one retryable failure before accepting the same event:
+
+```powershell
+$env:PATRIS_ADAPTER_INGRESS_SECRET = 'local-smoke-only'
+node .\scripts\examples\patris-delivery-adapter.cjs `
+  --transport mock `
+  --fail-first 1 `
+  --ingress-secret-env PATRIS_ADAPTER_INGRESS_SECRET
+```
+
+Run Patris with the adapter config and the same environment value. A verified
+adapter transcript looks like:
+
+```text
+[adapter] listening=http://127.0.0.1:18081/ingest transport=mock
+[adapter] retryable event_id=sha256:... reason=mock receiver requested a retry
+[adapter] accepted event_id=sha256:... products=292
+```
+
+For a visible terminal failure, start the mock with `--fail-first 10` while the
+Patris config permits only three attempts. Patris exits/logs a sanitized error
+containing the endpoint without query parameters, HTTP status, attempt count,
+and `retryable=true`. It never includes response bodies, product Codes, headers,
+or credentials.
+
+Run the repeatable smoke tests directly:
+
+```powershell
+node --test .\scripts\examples\patris-delivery-adapter.test.cjs
+go test ./pkg/updateout
+```
+
+The Node tests cover REST-adapter identity validation, JSON-RPC framing,
+WordPress form framing, gRPC-gateway body shape, explicit-null preservation,
+omission of unseen keys, and retryable-failure recovery. The Go tests cover the
+native HTTP sink's byte-stable retry/backoff and strict receiver responses.
+
+## Operations and dead-letter diagnostics
+
+The native sink deliberately does not persist a second product queue. The
+source database plus deterministic event ID is the replay source of truth. On
+exhaustion, capture the sanitized Patris error and adapter log in the service
+manager, alert on `event_id` and attempt count, repair the destination, then
+replay from Patris. A downstream system may maintain its own dead-letter queue
+keyed by `event_id`; it must encrypt product data at rest and must never store
+the authentication headers.
+
+Recommended production checks:
+
+1. Reject a request whose identity headers do not match its body.
+2. Make a duplicate `event_id` return an idempotent terminal success.
+3. Bound request size and response size at the reverse proxy.
+4. Return explicit retryable state only for temporary work.
+5. Keep adapter logs to event ID, counts, status, and a non-sensitive reason.
+6. Alert after Patris exhausts attempts; do not silently discard the event.
+
+See [Canonical Product Sync](CANONICAL-PRODUCT-SYNC.md) for the envelope and
+strict receiver state machine, and [Transform, Export, and Send](examples/export-transform-send.md)
+for the shared record pipeline.

--- a/docs/REMOTE-API-EXAMPLES.md
+++ b/docs/REMOTE-API-EXAMPLES.md
@@ -289,7 +289,9 @@ include `status`, matching `event_id`, `retryable`, `pending_products`, and
 `deferred_products`. The adapter validates and propagates that state, including
 valid retry-pending work, and maps 408/425/429/5xx gateway failures to Patris
 retryable responses. Native gRPC without a gateway is not claimed or
-implemented by this example.
+implemented by this example. Default ProtoJSON camelCase response names
+(`eventId`, `pendingProducts`, and `deferredProducts`) are accepted and
+normalized to the canonical snake_case receiver response.
 
 ## Local receiver and smoke test
 

--- a/docs/REMOTE-API-EXAMPLES.md
+++ b/docs/REMOTE-API-EXAMPLES.md
@@ -64,7 +64,9 @@ For every canonical HTTP request Patris sets:
 `event_id` is deterministic for a given source revision and event. Receivers
 must use it as their idempotency key. Patris encodes the envelope once and
 reuses the same bytes and identity headers for all attempts. The adapter also
-sets `Idempotency-Key` on downstream HTTP requests.
+sets `Idempotency-Key` on downstream HTTP requests. The transport header uses
+`X-Patris-Event: initial` for a body `event_type` of `snapshot`; update events
+use `update` in both places.
 
 Remote secret-bearing destinations require HTTPS. Plain HTTP is accepted only
 for a loopback adapter or mock receiver. Redirects are not followed when the

--- a/docs/REMOTE-API-EXAMPLES.md
+++ b/docs/REMOTE-API-EXAMPLES.md
@@ -14,7 +14,7 @@ Patris or transform product data again.
 | WordPress REST | Native and recommended | `send_updates.url` | Direct canonical envelope |
 | JSON-RPC 2.0 | Loopback adapter | Patris sends to adapter | JSON-RPC wrapper whose `params` is the unchanged envelope |
 | WordPress `admin-ajax.php` | Loopback adapter, legacy only | Patris sends to adapter | Form fields containing the unchanged envelope |
-| gRPC | HTTP/JSON transcoding gateway | Patris sends to adapter, adapter sends to gateway | Direct envelope mapped to `google.protobuf.Struct` |
+| gRPC | HTTP/JSON transcoding gateway | Patris sends to adapter, adapter sends to gateway | Exact canonical JSON carried in an `envelope_json` string |
 | RPC-style local command | Native command sink | `send_updates.command` | Direct envelope on stdin |
 
 Patris does **not** natively speak JSON-RPC framing, WordPress form AJAX, or
@@ -40,9 +40,10 @@ Sparse payloads have two distinct states:
 - A key that was never supplied, or whose source value is empty, is absent.
 - A key explicitly supplied as JSON `null` is present with a `null` value.
 
-The adapters parse and wrap the existing envelope without normalizing product
-objects. Automated adapter tests assert that explicit null survives and unseen
-shipping/weight keys remain absent. Upgrade older binaries that still emit the
+The adapters validate identity fields, but forward the original JSON text
+instead of serializing parsed JavaScript numbers. This preserves exact int64
+and decimal tokens, explicit nulls, and absent fields. Automated adapter tests
+cover all three wrappers. Upgrade older binaries that still emit the
 legacy always-present pricing fields to a build containing the sparse export
 work tracked by [issue #171](https://github.com/atomicdeploy/patris-export/issues/171)
 before using these recipes in production.
@@ -56,7 +57,6 @@ at request time and sends it as `X-Patris-Product-Sync-Secret`.
 For every canonical HTTP request Patris sets:
 
 - `X-Patris-Contract`
-- `X-Patris-Contract-Version`
 - `X-Patris-Event-ID`
 - `X-Patris-Event`
 - `X-Patris-Source`
@@ -217,8 +217,9 @@ The adapter sends:
   "method": "patris.productSync",
   "params": {
     "schema": "patris.product-sync",
-    "schema_version": "1.1",
+    "event_type": "update",
     "event_id": "sha256:replace-with-event-id",
+    "source": {"id": "patris-office"},
     "products": []
   }
 }
@@ -227,7 +228,7 @@ The adapter sends:
 The RPC server must return the same `id`:
 
 ```json
-{"jsonrpc":"2.0","id":"sha256:replace-with-event-id","result":{"accepted":true}}
+{"jsonrpc":"2.0","id":"sha256:replace-with-event-id","result":{"status":"accepted","event_id":"sha256:replace-with-event-id","retryable":false,"pending_products":0,"deferred_products":0}}
 ```
 
 For a temporary method error, set `error.data.retryable` to `true`. The adapter
@@ -265,8 +266,10 @@ browser nonce is not an appropriate machine-to-machine credential.
 Patris does not contain a second protobuf product model or a native gRPC
 client. Deploy an HTTP/JSON transcoding gateway in front of the gRPC service,
 using [patris-product-sync.proto](examples/patris-product-sync.proto) as the
-minimal boundary. Its `body: "envelope"` mapping accepts the direct canonical
-envelope and places it in `ApplyRequest.envelope`.
+minimal boundary. The adapter places the original canonical JSON text in
+`ApplyRequest.envelope_json`; the gRPC service must parse that string with a
+lossless JSON decoder. This avoids `google.protobuf.Struct`, whose double-based
+number representation cannot preserve every supported Patris int64 or decimal.
 
 Point the adapter at the gateway route:
 
@@ -281,9 +284,12 @@ node .\scripts\examples\patris-delivery-adapter.cjs `
 ```
 
 The gateway must forward `Idempotency-Key` and the `X-Patris-*` identity headers
-as gRPC metadata. The adapter treats an HTTP 2xx gateway response as accepted
-and maps 408/425/429/5xx gateway failures to Patris retryable responses. Native
-gRPC without a gateway is not claimed or implemented by this example.
+as gRPC metadata. Every successful JSON-RPC, AJAX, or gateway response must
+include `status`, matching `event_id`, `retryable`, `pending_products`, and
+`deferred_products`. The adapter validates and propagates that state, including
+valid retry-pending work, and maps 408/425/429/5xx gateway failures to Patris
+retryable responses. Native gRPC without a gateway is not claimed or
+implemented by this example.
 
 ## Local receiver and smoke test
 
@@ -304,7 +310,7 @@ adapter transcript looks like:
 ```text
 [adapter] listening=http://127.0.0.1:18081/ingest transport=mock
 [adapter] retryable event_id=sha256:... reason=mock receiver requested a retry
-[adapter] accepted event_id=sha256:... products=292
+[adapter] status=accepted event_id=sha256:... products=292
 ```
 
 For a visible terminal failure, start the mock with `--fail-first 10` while the

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,6 +4,10 @@ This directory contains examples and usage demonstrations for Patris Export.
 
 - [WebSocat terminal inspection](websocat.md)
 - [Transform, raw, export, and send update examples](export-transform-send.md)
+- [Remote REST/RPC/gRPC/AJAX delivery](../REMOTE-API-EXAMPLES.md)
+- [Native REST configuration](send-updates-rest.json)
+- [Loopback adapter configuration](send-updates-adapter.json)
+- [gRPC gateway contract](patris-product-sync.proto)
 
 ## Basic Usage Examples
 

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -166,6 +166,10 @@ configured receiver's product-sync route:
 POST https://receiver.example/wp-json/receiver/patris/product-sync
 ```
 
+For complete native REST, JSON-RPC adapter, WordPress AJAX adapter, gRPC
+gateway, authentication, retry, and local mock-receiver recipes, see
+[Remote Update Delivery](../REMOTE-API-EXAMPLES.md).
+
 The dedicated `X-Patris-Product-Sync-Secret` value is resolved only at
 request time from the environment variable named by
 `product_sync_secret_env`. Inject that environment variable through the

--- a/docs/examples/patris-product-sync.proto
+++ b/docs/examples/patris-product-sync.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package patris.delivery.v1;
+
+option go_package = "example.invalid/patris/delivery/v1;patrisdeliveryv1";
+
+import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
+
+// ProductSync keeps the Patris canonical envelope as the only product schema.
+// The gateway maps the complete HTTP JSON body into ApplyRequest.envelope.
+service ProductSync {
+  rpc Apply(ApplyRequest) returns (ApplyResponse) {
+    option (google.api.http) = {
+      post: "/v1/patris:apply"
+      body: "envelope"
+    };
+  }
+}
+
+message ApplyRequest {
+  google.protobuf.Struct envelope = 1;
+}
+
+message ApplyResponse {
+  string status = 1;
+  string event_id = 2;
+  bool retryable = 3;
+  uint32 pending_products = 4;
+}

--- a/docs/examples/patris-product-sync.proto
+++ b/docs/examples/patris-product-sync.proto
@@ -5,26 +5,26 @@ package patris.delivery.v1;
 option go_package = "example.invalid/patris/delivery/v1;patrisdeliveryv1";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
-
 // ProductSync keeps the Patris canonical envelope as the only product schema.
-// The gateway maps the complete HTTP JSON body into ApplyRequest.envelope.
+// The gateway carries its original JSON text so int64 and exact decimal tokens
+// are not coerced through google.protobuf.Struct's double representation.
 service ProductSync {
   rpc Apply(ApplyRequest) returns (ApplyResponse) {
     option (google.api.http) = {
       post: "/v1/patris:apply"
-      body: "envelope"
+      body: "*"
     };
   }
 }
 
 message ApplyRequest {
-  google.protobuf.Struct envelope = 1;
+  string envelope_json = 1;
 }
 
 message ApplyResponse {
-  string status = 1;
-  string event_id = 2;
-  bool retryable = 3;
-  uint32 pending_products = 4;
+  optional string status = 1;
+  optional string event_id = 2;
+  optional bool retryable = 3;
+  optional uint32 pending_products = 4;
+  optional uint32 deferred_products = 5;
 }

--- a/docs/examples/send-updates-adapter.json
+++ b/docs/examples/send-updates-adapter.json
@@ -1,0 +1,25 @@
+{
+  "canonical": {
+    "enabled": true,
+    "source_id": "patris-office",
+    "profiles": {
+      "kala.db": {
+        "type": "kala_v1"
+      }
+    }
+  },
+  "send_updates": {
+    "enabled": true,
+    "url": "http://127.0.0.1:18081/ingest",
+    "method": "POST",
+    "format": "json",
+    "mode": "changes",
+    "initial": true,
+    "allow_raw": false,
+    "require_contract": true,
+    "timeout": "10s",
+    "retry_attempts": 3,
+    "retry_backoff": "2s",
+    "product_sync_secret_env": "PATRIS_ADAPTER_INGRESS_SECRET"
+  }
+}

--- a/docs/examples/send-updates-rest.json
+++ b/docs/examples/send-updates-rest.json
@@ -1,0 +1,28 @@
+{
+  "canonical": {
+    "enabled": true,
+    "source_id": "patris-office",
+    "profiles": {
+      "kala.db": {
+        "type": "kala_v1"
+      }
+    }
+  },
+  "send_updates": {
+    "enabled": true,
+    "url": "https://receiver.example/wp-json/receiver/patris/product-sync",
+    "method": "POST",
+    "format": "json",
+    "mode": "changes",
+    "initial": true,
+    "allow_raw": false,
+    "require_contract": true,
+    "timeout": "10s",
+    "retry_attempts": 3,
+    "retry_backoff": "2s",
+    "product_sync_secret_env": "PATRIS_PRODUCT_SYNC_SECRET",
+    "headers": {
+      "X-Integration-Name": "patris-office"
+    }
+  }
+}

--- a/pkg/appconfig/delivery_examples_test.go
+++ b/pkg/appconfig/delivery_examples_test.go
@@ -1,0 +1,48 @@
+package appconfig
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoteDeliveryExampleConfigsLoad(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		url       string
+		secretEnv string
+	}{
+		{
+			name:      "native REST",
+			file:      "send-updates-rest.json",
+			url:       "https://receiver.example/wp-json/receiver/patris/product-sync",
+			secretEnv: "PATRIS_PRODUCT_SYNC_SECRET",
+		},
+		{
+			name:      "loopback adapter",
+			file:      "send-updates-adapter.json",
+			url:       "http://127.0.0.1:18081/ingest",
+			secretEnv: "PATRIS_ADAPTER_INGRESS_SECRET",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join("..", "..", "docs", "examples", test.file)
+			manager, err := LoadFiles([]string{path})
+			if err != nil {
+				t.Fatalf("LoadFiles(%q): %v", path, err)
+			}
+			cfg := manager.Get()
+			if !cfg.Canonical.Enabled || !cfg.SendUpdates.Enabled || !cfg.SendUpdates.RequireContract || cfg.SendUpdates.AllowRaw {
+				t.Fatalf("unsafe or incomplete example config: %+v", cfg.SendUpdates)
+			}
+			if cfg.SendUpdates.URL != test.url || cfg.SendUpdates.ProductSyncSecretEnv != test.secretEnv {
+				t.Fatalf("example destination = %q via %q, want %q via %q", cfg.SendUpdates.URL, cfg.SendUpdates.ProductSyncSecretEnv, test.url, test.secretEnv)
+			}
+			if cfg.SendUpdates.RetryAttempts != 3 || cfg.SendUpdates.RetryBackoff != "2s" || cfg.SendUpdates.Timeout != "10s" {
+				t.Fatalf("example retry policy was not preserved: %+v", cfg.SendUpdates)
+			}
+		})
+	}
+}

--- a/scripts/examples/patris-delivery-adapter.cjs
+++ b/scripts/examples/patris-delivery-adapter.cjs
@@ -94,6 +94,9 @@ function validateTarget(target, hasSecret) {
   if (parsed.username || parsed.password) {
     throw new AdapterError('target credentials must be supplied through a secret environment variable, not the URL');
   }
+  if (parsed.search || parsed.hash) {
+    throw new AdapterError('target query parameters and fragments are not allowed; use secret environment variables');
+  }
   if (hasSecret && parsed.protocol !== 'https:' && !['127.0.0.1', 'localhost', '::1'].includes(parsed.hostname.toLowerCase())) {
     throw new AdapterError('a secret-bearing remote target requires HTTPS');
   }
@@ -110,8 +113,12 @@ function validateEnvelope(value, headers = {}) {
   if (typeof value.event_id !== 'string' || value.event_id.trim() === '') {
     throw new AdapterError('request is missing event_id');
   }
-  if (typeof value.schema_version !== 'string' || value.schema_version.trim() === '') {
-    throw new AdapterError('request is missing schema_version');
+  if (typeof value.event_type !== 'string' || value.event_type.trim() === '') {
+    throw new AdapterError('request is missing event_type');
+  }
+  if (!value.source || typeof value.source !== 'object' || Array.isArray(value.source)
+      || typeof value.source.id !== 'string' || value.source.id.trim() === '') {
+    throw new AdapterError('request is missing source.id');
   }
   if (!Array.isArray(value.products)) {
     throw new AdapterError('request products must be an array');
@@ -121,16 +128,20 @@ function validateEnvelope(value, headers = {}) {
     Object.entries(headers).map(([key, item]) => [key.toLowerCase(), String(item)]),
   );
   const headerContract = normalizedHeaders.get('x-patris-contract');
-  const headerVersion = normalizedHeaders.get('x-patris-contract-version');
   const headerEventID = normalizedHeaders.get('x-patris-event-id');
+  const headerEvent = normalizedHeaders.get('x-patris-event');
+  const headerSource = normalizedHeaders.get('x-patris-source');
   if (headerContract && headerContract !== value.schema) {
     throw new AdapterError('X-Patris-Contract does not match the body');
   }
-  if (headerVersion && headerVersion !== String(value.schema_version ?? '')) {
-    throw new AdapterError('X-Patris-Contract-Version does not match the body');
-  }
   if (headerEventID && headerEventID !== value.event_id) {
     throw new AdapterError('X-Patris-Event-ID does not match the body');
+  }
+  if (headerEvent && headerEvent !== value.event_type) {
+    throw new AdapterError('X-Patris-Event does not match the body');
+  }
+  if (headerSource && headerSource !== value.source.id) {
+    throw new AdapterError('X-Patris-Source does not match the body');
   }
   return value;
 }
@@ -140,15 +151,16 @@ function identityHeaders(envelope, secret, transport) {
     'Content-Type': 'application/json; charset=utf-8',
     'Idempotency-Key': envelope.event_id,
     'X-Patris-Contract': envelope.schema,
-    'X-Patris-Contract-Version': String(envelope.schema_version ?? ''),
     'X-Patris-Event-ID': envelope.event_id,
+    'X-Patris-Event': envelope.event_type,
+    'X-Patris-Source': envelope.source.id,
     'X-Patris-Adapter': transport,
   };
   if (secret) headers.Authorization = `Bearer ${secret}`;
   return headers;
 }
 
-function buildOutboundRequest(config, envelope) {
+function buildOutboundRequest(config, envelope, rawEnvelopeJSON = JSON.stringify(envelope)) {
   const target = validateTarget(config.target, config.targetSecret !== '');
   const headers = identityHeaders(envelope, config.targetSecret, config.transport);
 
@@ -158,18 +170,13 @@ function buildOutboundRequest(config, envelope) {
         url: target,
         method: 'POST',
         headers,
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: envelope.event_id,
-          method: config.method || 'patris.productSync',
-          params: envelope,
-        }),
+        body: `{"jsonrpc":"2.0","id":${JSON.stringify(envelope.event_id)},"method":${JSON.stringify(config.method || 'patris.productSync')},"params":${rawEnvelopeJSON}}`,
       };
     case 'wordpress-ajax': {
       const form = new URLSearchParams({
         action: config.action || 'patris_product_sync',
         event_id: envelope.event_id,
-        payload: JSON.stringify(envelope),
+        payload: rawEnvelopeJSON,
       });
       headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
       if (config.targetSecret) {
@@ -183,11 +190,45 @@ function buildOutboundRequest(config, envelope) {
         url: target,
         method: 'POST',
         headers,
-        body: JSON.stringify(envelope),
+        body: JSON.stringify({ envelope_json: rawEnvelopeJSON }),
       };
     default:
       throw new AdapterError(`unsupported outbound transport: ${config.transport}`);
   }
+}
+
+const TERMINAL_STATUSES = new Set(['accepted', 'already_current', 'replayed', 'recovered']);
+const RETRYABLE_STATUSES = new Set(['partially_applied', 'retry_pending']);
+
+function validateDeliveryState(value, eventID) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AdapterError('downstream response is missing delivery state');
+  }
+  const status = typeof value.status === 'string' ? value.status.trim() : '';
+  if (!status || typeof value.event_id !== 'string' || value.event_id !== eventID
+      || typeof value.retryable !== 'boolean'
+      || !Number.isSafeInteger(value.pending_products) || value.pending_products < 0
+      || !Number.isSafeInteger(value.deferred_products) || value.deferred_products < 0) {
+    throw new AdapterError('downstream delivery state is invalid');
+  }
+  if (TERMINAL_STATUSES.has(status)) {
+    if (value.retryable || value.pending_products !== 0) {
+      throw new AdapterError('downstream terminal delivery state is inconsistent');
+    }
+  } else if (RETRYABLE_STATUSES.has(status)) {
+    if (!value.retryable || value.pending_products <= 0) {
+      throw new AdapterError('downstream retryable delivery state is inconsistent');
+    }
+  } else {
+    throw new AdapterError('downstream delivery status is unsupported');
+  }
+  return {
+    status,
+    event_id: value.event_id,
+    retryable: value.retryable,
+    pending_products: value.pending_products,
+    deferred_products: value.deferred_products,
+  };
 }
 
 function retryableStatus(status) {
@@ -207,11 +248,11 @@ async function readResponseJSON(response) {
   }
 }
 
-async function forwardEnvelope(config, envelope, fetchImpl = globalThis.fetch) {
+async function forwardEnvelope(config, envelope, fetchImpl = globalThis.fetch, rawEnvelopeJSON = JSON.stringify(envelope)) {
   if (typeof fetchImpl !== 'function') {
     throw new AdapterError('this adapter requires Node.js 18 or newer');
   }
-  const outbound = buildOutboundRequest(config, envelope);
+  const outbound = buildOutboundRequest(config, envelope, rawEnvelopeJSON);
   let response;
   try {
     response = await fetchImpl(outbound.url, {
@@ -241,13 +282,17 @@ async function forwardEnvelope(config, envelope, fetchImpl = globalThis.fetch) {
         retryable: responseBody.error?.data?.retryable === true,
       });
     }
+    return validateDeliveryState(responseBody.result, envelope.event_id);
   }
-  if (config.transport === 'wordpress-ajax' && responseBody?.success !== true) {
-    throw new AdapterError('WordPress AJAX action rejected the update', {
-      retryable: responseBody?.data?.retryable === true,
-    });
+  if (config.transport === 'wordpress-ajax') {
+    if (responseBody?.success !== true) {
+      throw new AdapterError('WordPress AJAX action rejected the update', {
+        retryable: responseBody?.data?.retryable === true || responseBody?.details?.retryable === true,
+      });
+    }
+    return validateDeliveryState(responseBody.data, envelope.event_id);
   }
-  return responseBody;
+  return validateDeliveryState(responseBody, envelope.event_id);
 }
 
 function readBody(request, maxBytes) {
@@ -291,6 +336,10 @@ function acceptedResponse(eventID) {
   };
 }
 
+function successfulResponse(state) {
+  return { success: true, data: state };
+}
+
 function rejectedResponse(error) {
   return {
     success: false,
@@ -317,19 +366,22 @@ function createAdapterServer(config, dependencies = {}) {
         }
       }
       const body = await readBody(request, config.maxBodyBytes);
-      envelope = validateEnvelope(JSON.parse(body.toString('utf8')), request.headers);
+      const rawEnvelopeJSON = body.toString('utf8');
+      envelope = validateEnvelope(JSON.parse(rawEnvelopeJSON), request.headers);
       received += 1;
 
+      let state;
       if (config.transport === 'mock') {
         if (received <= config.failFirst) {
           throw new AdapterError('mock receiver requested a retry', { retryable: true, httpStatus: 503 });
         }
+        state = acceptedResponse(envelope.event_id).data;
       } else {
-        await forwardEnvelope(config, envelope, fetchImpl);
+        state = await forwardEnvelope(config, envelope, fetchImpl, rawEnvelopeJSON);
       }
 
-      console.log(`[adapter] accepted event_id=${envelope.event_id} products=${envelope.products.length}`);
-      sendJSON(response, 200, acceptedResponse(envelope.event_id));
+      console.log(`[adapter] status=${state.status} event_id=${envelope.event_id} products=${envelope.products.length}`);
+      sendJSON(response, 200, successfulResponse(state));
     } catch (caught) {
       const error = caught instanceof AdapterError
         ? caught
@@ -427,5 +479,6 @@ module.exports = {
   forwardEnvelope,
   parseArgs,
   retryableStatus,
+  validateDeliveryState,
   validateEnvelope,
 };

--- a/scripts/examples/patris-delivery-adapter.cjs
+++ b/scripts/examples/patris-delivery-adapter.cjs
@@ -103,6 +103,11 @@ function validateTarget(target, hasSecret) {
   return parsed.toString();
 }
 
+function transportEventType(contractEventType) {
+  if (contractEventType === 'snapshot') return 'initial';
+  return contractEventType;
+}
+
 function validateEnvelope(value, headers = {}) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new AdapterError('request body must be a JSON object');
@@ -137,7 +142,7 @@ function validateEnvelope(value, headers = {}) {
   if (headerEventID && headerEventID !== value.event_id) {
     throw new AdapterError('X-Patris-Event-ID does not match the body');
   }
-  if (headerEvent && headerEvent !== value.event_type) {
+  if (headerEvent && headerEvent !== transportEventType(value.event_type)) {
     throw new AdapterError('X-Patris-Event does not match the body');
   }
   if (headerSource && headerSource !== value.source.id) {
@@ -152,7 +157,7 @@ function identityHeaders(envelope, secret, transport) {
     'Idempotency-Key': envelope.event_id,
     'X-Patris-Contract': envelope.schema,
     'X-Patris-Event-ID': envelope.event_id,
-    'X-Patris-Event': envelope.event_type,
+    'X-Patris-Event': transportEventType(envelope.event_type),
     'X-Patris-Source': envelope.source.id,
     'X-Patris-Adapter': transport,
   };

--- a/scripts/examples/patris-delivery-adapter.cjs
+++ b/scripts/examples/patris-delivery-adapter.cjs
@@ -200,23 +200,37 @@ function buildOutboundRequest(config, envelope, rawEnvelopeJSON = JSON.stringify
 const TERMINAL_STATUSES = new Set(['accepted', 'already_current', 'replayed', 'recovered']);
 const RETRYABLE_STATUSES = new Set(['partially_applied', 'retry_pending']);
 
+function responseField(value, protoName, jsonName = protoName) {
+  const hasProtoName = Object.hasOwn(value, protoName);
+  const hasJSONName = jsonName !== protoName && Object.hasOwn(value, jsonName);
+  if (hasProtoName && hasJSONName && value[protoName] !== value[jsonName]) {
+    throw new AdapterError(`downstream response has conflicting ${protoName} fields`);
+  }
+  return hasProtoName ? value[protoName] : value[jsonName];
+}
+
 function validateDeliveryState(value, eventID) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new AdapterError('downstream response is missing delivery state');
   }
-  const status = typeof value.status === 'string' ? value.status.trim() : '';
-  if (!status || typeof value.event_id !== 'string' || value.event_id !== eventID
-      || typeof value.retryable !== 'boolean'
-      || !Number.isSafeInteger(value.pending_products) || value.pending_products < 0
-      || !Number.isSafeInteger(value.deferred_products) || value.deferred_products < 0) {
+  const statusValue = responseField(value, 'status');
+  const responseEventID = responseField(value, 'event_id', 'eventId');
+  const retryable = responseField(value, 'retryable');
+  const pendingProducts = responseField(value, 'pending_products', 'pendingProducts');
+  const deferredProducts = responseField(value, 'deferred_products', 'deferredProducts');
+  const status = typeof statusValue === 'string' ? statusValue.trim() : '';
+  if (!status || typeof responseEventID !== 'string' || responseEventID !== eventID
+      || typeof retryable !== 'boolean'
+      || !Number.isSafeInteger(pendingProducts) || pendingProducts < 0
+      || !Number.isSafeInteger(deferredProducts) || deferredProducts < 0) {
     throw new AdapterError('downstream delivery state is invalid');
   }
   if (TERMINAL_STATUSES.has(status)) {
-    if (value.retryable || value.pending_products !== 0) {
+    if (retryable || pendingProducts !== 0) {
       throw new AdapterError('downstream terminal delivery state is inconsistent');
     }
   } else if (RETRYABLE_STATUSES.has(status)) {
-    if (!value.retryable || value.pending_products <= 0) {
+    if (!retryable || pendingProducts <= 0) {
       throw new AdapterError('downstream retryable delivery state is inconsistent');
     }
   } else {
@@ -224,10 +238,10 @@ function validateDeliveryState(value, eventID) {
   }
   return {
     status,
-    event_id: value.event_id,
-    retryable: value.retryable,
-    pending_products: value.pending_products,
-    deferred_products: value.deferred_products,
+    event_id: responseEventID,
+    retryable,
+    pending_products: pendingProducts,
+    deferred_products: deferredProducts,
   };
 }
 

--- a/scripts/examples/patris-delivery-adapter.cjs
+++ b/scripts/examples/patris-delivery-adapter.cjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const http = require('node:http');
+const { timingSafeEqual } = require('node:crypto');
+const { URL, URLSearchParams } = require('node:url');
+
+const CONTRACT = 'patris.product-sync';
+const SECRET_HEADER = 'X-Patris-Product-Sync-Secret';
+const DEFAULT_LISTEN = '127.0.0.1:18081';
+const DEFAULT_MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+class AdapterError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'AdapterError';
+    this.retryable = options.retryable === true;
+    this.httpStatus = Number.isInteger(options.httpStatus) ? options.httpStatus : 0;
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw new AdapterError(`unexpected argument: ${token}`);
+    }
+    const equals = token.indexOf('=');
+    const rawName = token.slice(2, equals === -1 ? undefined : equals);
+    const inlineValue = equals === -1 ? undefined : token.slice(equals + 1);
+    const name = rawName.replaceAll('-', '_');
+    if (inlineValue !== undefined) {
+      options[name] = inlineValue;
+      continue;
+    }
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith('--')) {
+      options[name] = true;
+      continue;
+    }
+    options[name] = next;
+    index += 1;
+  }
+  return options;
+}
+
+function option(options, name, environmentName, fallback = '') {
+  const value = options[name] ?? process.env[environmentName] ?? fallback;
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+function requireEnvironmentSecret(name) {
+  if (!name) return '';
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new AdapterError('secret environment-variable name is invalid');
+  }
+  const secret = process.env[name];
+  if (!secret) {
+    throw new AdapterError(`required secret environment variable ${name} is empty or missing`);
+  }
+  return secret;
+}
+
+function equalSecret(left, right) {
+  if (typeof left !== 'string' || typeof right !== 'string') return false;
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function parseListen(value) {
+  const match = /^([^:]+):(\d{1,5})$/.exec(value);
+  if (!match) throw new AdapterError('listen address must use HOST:PORT');
+  const port = Number(match[2]);
+  if (port < 1 || port > 65535) throw new AdapterError('listen port is out of range');
+  if (!['127.0.0.1', 'localhost'].includes(match[1].toLowerCase())) {
+    throw new AdapterError('the adapter is loopback-only; listen on 127.0.0.1 or localhost');
+  }
+  return { host: match[1], port };
+}
+
+function validateTarget(target, hasSecret) {
+  let parsed;
+  try {
+    parsed = new URL(target);
+  } catch {
+    throw new AdapterError('target must be an absolute HTTP or HTTPS URL');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) {
+    throw new AdapterError('target must be an absolute HTTP or HTTPS URL');
+  }
+  if (parsed.username || parsed.password) {
+    throw new AdapterError('target credentials must be supplied through a secret environment variable, not the URL');
+  }
+  if (hasSecret && parsed.protocol !== 'https:' && !['127.0.0.1', 'localhost', '::1'].includes(parsed.hostname.toLowerCase())) {
+    throw new AdapterError('a secret-bearing remote target requires HTTPS');
+  }
+  return parsed.toString();
+}
+
+function validateEnvelope(value, headers = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AdapterError('request body must be a JSON object');
+  }
+  if (value.schema !== CONTRACT) {
+    throw new AdapterError(`request schema must be ${CONTRACT}`);
+  }
+  if (typeof value.event_id !== 'string' || value.event_id.trim() === '') {
+    throw new AdapterError('request is missing event_id');
+  }
+  if (typeof value.schema_version !== 'string' || value.schema_version.trim() === '') {
+    throw new AdapterError('request is missing schema_version');
+  }
+  if (!Array.isArray(value.products)) {
+    throw new AdapterError('request products must be an array');
+  }
+
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([key, item]) => [key.toLowerCase(), String(item)]),
+  );
+  const headerContract = normalizedHeaders.get('x-patris-contract');
+  const headerVersion = normalizedHeaders.get('x-patris-contract-version');
+  const headerEventID = normalizedHeaders.get('x-patris-event-id');
+  if (headerContract && headerContract !== value.schema) {
+    throw new AdapterError('X-Patris-Contract does not match the body');
+  }
+  if (headerVersion && headerVersion !== String(value.schema_version ?? '')) {
+    throw new AdapterError('X-Patris-Contract-Version does not match the body');
+  }
+  if (headerEventID && headerEventID !== value.event_id) {
+    throw new AdapterError('X-Patris-Event-ID does not match the body');
+  }
+  return value;
+}
+
+function identityHeaders(envelope, secret, transport) {
+  const headers = {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Idempotency-Key': envelope.event_id,
+    'X-Patris-Contract': envelope.schema,
+    'X-Patris-Contract-Version': String(envelope.schema_version ?? ''),
+    'X-Patris-Event-ID': envelope.event_id,
+    'X-Patris-Adapter': transport,
+  };
+  if (secret) headers.Authorization = `Bearer ${secret}`;
+  return headers;
+}
+
+function buildOutboundRequest(config, envelope) {
+  const target = validateTarget(config.target, config.targetSecret !== '');
+  const headers = identityHeaders(envelope, config.targetSecret, config.transport);
+
+  switch (config.transport) {
+    case 'json-rpc':
+      return {
+        url: target,
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: envelope.event_id,
+          method: config.method || 'patris.productSync',
+          params: envelope,
+        }),
+      };
+    case 'wordpress-ajax': {
+      const form = new URLSearchParams({
+        action: config.action || 'patris_product_sync',
+        event_id: envelope.event_id,
+        payload: JSON.stringify(envelope),
+      });
+      headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
+      if (config.targetSecret) {
+        delete headers.Authorization;
+        headers[SECRET_HEADER] = config.targetSecret;
+      }
+      return { url: target, method: 'POST', headers, body: form.toString() };
+    }
+    case 'grpc-gateway':
+      return {
+        url: target,
+        method: 'POST',
+        headers,
+        body: JSON.stringify(envelope),
+      };
+    default:
+      throw new AdapterError(`unsupported outbound transport: ${config.transport}`);
+  }
+}
+
+function retryableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
+}
+
+async function readResponseJSON(response) {
+  const text = await response.text();
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new AdapterError('downstream returned invalid JSON', {
+      retryable: retryableStatus(response.status),
+      httpStatus: response.status,
+    });
+  }
+}
+
+async function forwardEnvelope(config, envelope, fetchImpl = globalThis.fetch) {
+  if (typeof fetchImpl !== 'function') {
+    throw new AdapterError('this adapter requires Node.js 18 or newer');
+  }
+  const outbound = buildOutboundRequest(config, envelope);
+  let response;
+  try {
+    response = await fetchImpl(outbound.url, {
+      method: outbound.method,
+      headers: outbound.headers,
+      body: outbound.body,
+      signal: AbortSignal.timeout(config.timeoutMs),
+      redirect: 'manual',
+    });
+  } catch {
+    throw new AdapterError('downstream request failed', { retryable: true });
+  }
+
+  const responseBody = await readResponseJSON(response);
+  if (!response.ok) {
+    throw new AdapterError(`downstream returned HTTP ${response.status}`, {
+      retryable: retryableStatus(response.status),
+      httpStatus: response.status,
+    });
+  }
+  if (config.transport === 'json-rpc') {
+    if (!responseBody || responseBody.jsonrpc !== '2.0' || String(responseBody.id) !== envelope.event_id) {
+      throw new AdapterError('JSON-RPC response identity is invalid');
+    }
+    if (responseBody.error) {
+      throw new AdapterError('JSON-RPC method rejected the update', {
+        retryable: responseBody.error?.data?.retryable === true,
+      });
+    }
+  }
+  if (config.transport === 'wordpress-ajax' && responseBody?.success !== true) {
+    throw new AdapterError('WordPress AJAX action rejected the update', {
+      retryable: responseBody?.data?.retryable === true,
+    });
+  }
+  return responseBody;
+}
+
+function readBody(request, maxBytes) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    request.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        reject(new AdapterError('request body is too large'));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on('end', () => resolve(Buffer.concat(chunks)));
+    request.on('error', () => reject(new AdapterError('failed to read request body', { retryable: true })));
+  });
+}
+
+function sendJSON(response, status, value) {
+  const body = `${JSON.stringify(value)}\n`;
+  response.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+    'Cache-Control': 'no-store',
+  });
+  response.end(body);
+}
+
+function acceptedResponse(eventID) {
+  return {
+    success: true,
+    data: {
+      status: 'accepted',
+      event_id: eventID,
+      retryable: false,
+      pending_products: 0,
+      deferred_products: 0,
+    },
+  };
+}
+
+function rejectedResponse(error) {
+  return {
+    success: false,
+    code: error.retryable ? 'patris_adapter_downstream_unavailable' : 'patris_adapter_rejected',
+    details: { retryable: error.retryable === true },
+  };
+}
+
+function createAdapterServer(config, dependencies = {}) {
+  const fetchImpl = dependencies.fetchImpl ?? globalThis.fetch;
+  let received = 0;
+  return http.createServer(async (request, response) => {
+    if (request.method !== 'POST' || request.url !== '/ingest') {
+      sendJSON(response, 404, { success: false, code: 'not_found' });
+      return;
+    }
+
+    let envelope;
+    try {
+      if (config.ingressSecret) {
+        const supplied = request.headers[SECRET_HEADER.toLowerCase()];
+        if (!equalSecret(supplied, config.ingressSecret)) {
+          throw new AdapterError('ingress authentication failed');
+        }
+      }
+      const body = await readBody(request, config.maxBodyBytes);
+      envelope = validateEnvelope(JSON.parse(body.toString('utf8')), request.headers);
+      received += 1;
+
+      if (config.transport === 'mock') {
+        if (received <= config.failFirst) {
+          throw new AdapterError('mock receiver requested a retry', { retryable: true, httpStatus: 503 });
+        }
+      } else {
+        await forwardEnvelope(config, envelope, fetchImpl);
+      }
+
+      console.log(`[adapter] accepted event_id=${envelope.event_id} products=${envelope.products.length}`);
+      sendJSON(response, 200, acceptedResponse(envelope.event_id));
+    } catch (caught) {
+      const error = caught instanceof AdapterError
+        ? caught
+        : new AdapterError(caught instanceof SyntaxError ? 'request body is invalid JSON' : 'adapter failed');
+      const status = error.retryable ? 503 : 422;
+      console.error(`[adapter] ${error.retryable ? 'retryable' : 'rejected'} event_id=${envelope?.event_id ?? 'unknown'} reason=${error.message}`);
+      sendJSON(response, status, rejectedResponse(error));
+    }
+  });
+}
+
+function usage() {
+  return `Patris Export delivery adapter
+
+Usage:
+  node scripts/examples/patris-delivery-adapter.cjs \\
+    --transport mock|json-rpc|wordpress-ajax|grpc-gateway \\
+    [--listen ${DEFAULT_LISTEN}] [--target https://service.example/path]
+
+Options can also use PATRIS_ADAPTER_TRANSPORT, PATRIS_ADAPTER_LISTEN,
+PATRIS_ADAPTER_TARGET, PATRIS_ADAPTER_METHOD, PATRIS_ADAPTER_ACTION,
+PATRIS_ADAPTER_TARGET_SECRET_ENV, and PATRIS_ADAPTER_INGRESS_SECRET_ENV.
+The *_SECRET_ENV values name environment variables; they never contain secrets.
+`;
+}
+
+function configFromOptions(options) {
+  const transport = option(options, 'transport', 'PATRIS_ADAPTER_TRANSPORT', 'mock');
+  const supported = new Set(['mock', 'json-rpc', 'wordpress-ajax', 'grpc-gateway']);
+  if (!supported.has(transport)) throw new AdapterError(`unsupported transport: ${transport}`);
+
+  const timeoutSeconds = Number(option(options, 'timeout_seconds', 'PATRIS_ADAPTER_TIMEOUT_SECONDS', '10'));
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0 || timeoutSeconds > 120) {
+    throw new AdapterError('timeout-seconds must be greater than zero and at most 120');
+  }
+  const failFirst = Number(option(options, 'fail_first', 'PATRIS_ADAPTER_FAIL_FIRST', '0'));
+  if (!Number.isInteger(failFirst) || failFirst < 0) {
+    throw new AdapterError('fail-first must be a non-negative integer');
+  }
+
+  const target = option(options, 'target', 'PATRIS_ADAPTER_TARGET');
+  if (transport !== 'mock' && !target) throw new AdapterError(`${transport} requires --target`);
+  const ingressSecretEnv = option(options, 'ingress_secret_env', 'PATRIS_ADAPTER_INGRESS_SECRET_ENV');
+  const targetSecretEnv = option(options, 'target_secret_env', 'PATRIS_ADAPTER_TARGET_SECRET_ENV');
+  if (transport !== 'mock' && !ingressSecretEnv) {
+    throw new AdapterError(`${transport} requires --ingress-secret-env`);
+  }
+
+  return {
+    transport,
+    listen: parseListen(option(options, 'listen', 'PATRIS_ADAPTER_LISTEN', DEFAULT_LISTEN)),
+    target,
+    method: option(options, 'method', 'PATRIS_ADAPTER_METHOD', 'patris.productSync'),
+    action: option(options, 'action', 'PATRIS_ADAPTER_ACTION', 'patris_product_sync'),
+    timeoutMs: Math.round(timeoutSeconds * 1000),
+    failFirst,
+    maxBodyBytes: DEFAULT_MAX_BODY_BYTES,
+    ingressSecret: requireEnvironmentSecret(ingressSecretEnv),
+    targetSecret: requireEnvironmentSecret(targetSecretEnv),
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help || options.h) {
+    process.stdout.write(usage());
+    return;
+  }
+  const config = configFromOptions(options);
+  const server = createAdapterServer(config);
+  server.on('error', (error) => {
+    console.error(`[adapter] listener failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+  server.listen(config.listen.port, config.listen.host, () => {
+    console.log(`[adapter] listening=http://${config.listen.host}:${config.listen.port}/ingest transport=${config.transport}`);
+  });
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`[adapter] startup failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  AdapterError,
+  CONTRACT,
+  SECRET_HEADER,
+  acceptedResponse,
+  buildOutboundRequest,
+  configFromOptions,
+  createAdapterServer,
+  forwardEnvelope,
+  parseArgs,
+  retryableStatus,
+  validateEnvelope,
+};

--- a/scripts/examples/patris-delivery-adapter.test.cjs
+++ b/scripts/examples/patris-delivery-adapter.test.cjs
@@ -130,6 +130,24 @@ test('gRPC JSON gateway receives lossless canonical JSON without a parallel prod
   assert.deepEqual(JSON.parse(JSON.parse(request.body).envelope_json), envelope());
 });
 
+test('gRPC gateway default ProtoJSON camelCase response is normalized to canonical state', async () => {
+  const payload = envelope();
+  const state = await forwardEnvelope(config({
+    transport: 'grpc-gateway',
+    target: 'https://gateway.example.test/v1/patris:apply',
+  }), payload, async () => new Response(JSON.stringify({
+    status: 'accepted',
+    eventId: payload.event_id,
+    retryable: false,
+    pendingProducts: 0,
+    deferredProducts: 2,
+  }), { status: 200 }));
+  assert.deepEqual(state, {
+    status: 'accepted', event_id: payload.event_id, retryable: false,
+    pending_products: 0, deferred_products: 2,
+  });
+});
+
 test('all adapter modes preserve exact canonical numeric tokens', () => {
   const raw = '{"schema":"patris.product-sync","event_type":"update","event_id":"evt-exact","source":{"id":"patris-test"},"products":[{"product_code":"EXACT","final_price":100000000000000001,"foreign_price":0.1000000000000000006}]}';
   const payload = validateEnvelope(JSON.parse(raw));

--- a/scripts/examples/patris-delivery-adapter.test.cjs
+++ b/scripts/examples/patris-delivery-adapter.test.cjs
@@ -75,7 +75,7 @@ test('accepts the repository canonical golden envelope without an invented schem
   assert.equal(validateEnvelope(payload, {
     'X-Patris-Contract': payload.schema,
     'X-Patris-Event-ID': payload.event_id,
-    'X-Patris-Event': payload.event_type,
+    'X-Patris-Event': 'initial',
     'X-Patris-Source': payload.source.id,
   }), payload);
 });
@@ -103,6 +103,19 @@ test('JSON-RPC wrapper preserves explicit null and does not invent unseen keys',
   assert.equal(request.headers['X-Patris-Source'], 'patris-test');
   assert.equal(Object.hasOwn(request.headers, 'X-Patris-Contract-Version'), false);
   assert.equal(request.headers.Authorization, 'Bearer test-only');
+});
+
+test('snapshot envelopes retain the sender initial-event header convention', () => {
+  const payload = {
+    ...envelope(),
+    event_type: 'snapshot',
+  };
+  assert.equal(validateEnvelope(payload, { 'X-Patris-Event': 'initial' }), payload);
+  assert.throws(() => validateEnvelope(payload, { 'X-Patris-Event': 'snapshot' }), /does not match/);
+  const request = buildOutboundRequest(config({
+    transport: 'json-rpc', target: 'https://api.example.test/rpc',
+  }), payload);
+  assert.equal(request.headers['X-Patris-Event'], 'initial');
 });
 
 test('WordPress AJAX wrapper preserves the original sparse envelope', () => {

--- a/scripts/examples/patris-delivery-adapter.test.cjs
+++ b/scripts/examples/patris-delivery-adapter.test.cjs
@@ -2,6 +2,8 @@
 
 const assert = require('node:assert/strict');
 const { once } = require('node:events');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 
 const {
@@ -16,9 +18,9 @@ const {
 function envelope() {
   return {
     schema: 'patris.product-sync',
-    schema_version: '1.1',
     event_type: 'update',
     event_id: 'evt-sparse-001',
+    source: { id: 'patris-test' },
     products: [
       {
         product_code: '113007045',
@@ -55,14 +57,27 @@ test('validates canonical body identity against Patris headers', () => {
   assert.equal(SECRET_HEADER, 'X-Patris-Product-Sync-Secret');
   assert.equal(validateEnvelope(payload, {
     'X-Patris-Contract': payload.schema,
-    'X-Patris-Contract-Version': payload.schema_version,
     'X-Patris-Event-ID': payload.event_id,
+    'X-Patris-Event': payload.event_type,
+    'X-Patris-Source': payload.source.id,
   }), payload);
 
   assert.throws(
     () => validateEnvelope(payload, { 'X-Patris-Event-ID': 'different' }),
     /does not match/,
   );
+});
+
+test('accepts the repository canonical golden envelope without an invented schema version', () => {
+  const fixturePath = path.join(__dirname, '..', '..', 'testdata', 'patris-product-sync.synthetic.json');
+  const payload = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+  assert.equal(Object.hasOwn(payload, 'schema_version'), false);
+  assert.equal(validateEnvelope(payload, {
+    'X-Patris-Contract': payload.schema,
+    'X-Patris-Event-ID': payload.event_id,
+    'X-Patris-Event': payload.event_type,
+    'X-Patris-Source': payload.source.id,
+  }), payload);
 });
 
 test('JSON-RPC wrapper preserves explicit null and does not invent unseen keys', () => {
@@ -84,6 +99,9 @@ test('JSON-RPC wrapper preserves explicit null and does not invent unseen keys',
   assert.equal(body.params.products[1].shipping_price_per_kg, null);
   assert.equal(body.params.products[1].shipping_price_per_kg_currency, null);
   assert.equal(request.headers['Idempotency-Key'], 'evt-sparse-001');
+  assert.equal(request.headers['X-Patris-Event'], 'update');
+  assert.equal(request.headers['X-Patris-Source'], 'patris-test');
+  assert.equal(Object.hasOwn(request.headers, 'X-Patris-Contract-Version'), false);
   assert.equal(request.headers.Authorization, 'Bearer test-only');
 });
 
@@ -104,12 +122,27 @@ test('WordPress AJAX wrapper preserves the original sparse envelope', () => {
   assert.equal(Object.hasOwn(request.headers, 'Authorization'), false);
 });
 
-test('gRPC JSON gateway receives the direct envelope without a parallel schema', () => {
+test('gRPC JSON gateway receives lossless canonical JSON without a parallel product schema', () => {
   const request = buildOutboundRequest(config({
     transport: 'grpc-gateway',
     target: 'https://gateway.example.test/v1/patris:apply',
   }), envelope());
-  assert.deepEqual(JSON.parse(request.body), envelope());
+  assert.deepEqual(JSON.parse(JSON.parse(request.body).envelope_json), envelope());
+});
+
+test('all adapter modes preserve exact canonical numeric tokens', () => {
+  const raw = '{"schema":"patris.product-sync","event_type":"update","event_id":"evt-exact","source":{"id":"patris-test"},"products":[{"product_code":"EXACT","final_price":100000000000000001,"foreign_price":0.1000000000000000006}]}';
+  const payload = validateEnvelope(JSON.parse(raw));
+
+  const rpc = buildOutboundRequest(config({ transport: 'json-rpc', target: 'https://api.example.test/rpc' }), payload, raw);
+  assert.match(rpc.body, /"final_price":100000000000000001/);
+  assert.match(rpc.body, /"foreign_price":0\.1000000000000000006/);
+
+  const ajax = buildOutboundRequest(config({ transport: 'wordpress-ajax', target: 'https://api.example.test/ajax' }), payload, raw);
+  assert.equal(new URLSearchParams(ajax.body).get('payload'), raw);
+
+  const grpc = buildOutboundRequest(config({ transport: 'grpc-gateway', target: 'https://api.example.test/grpc' }), payload, raw);
+  assert.equal(JSON.parse(grpc.body).envelope_json, raw);
 });
 
 test('secret-bearing remote adapter targets require HTTPS', () => {
@@ -124,6 +157,11 @@ test('secret-bearing remote adapter targets require HTTPS', () => {
     target: 'http://127.0.0.1:18082/rpc',
     targetSecret: 'loopback-test',
   }), envelope()));
+
+  assert.throws(() => buildOutboundRequest(config({
+    transport: 'json-rpc',
+    target: 'https://api.example.test/rpc?token=not-allowed',
+  }), envelope()), /query parameters/);
 });
 
 test('CLI configuration resolves secret names without storing them in options', (t) => {
@@ -156,7 +194,14 @@ test('JSON-RPC response identity and method errors are enforced', async () => {
   let captured;
   const fetchOK = async (url, options) => {
     captured = { url, options };
-    return new Response(JSON.stringify({ jsonrpc: '2.0', id: payload.event_id, result: { accepted: true } }), {
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      id: payload.event_id,
+      result: {
+        status: 'accepted', event_id: payload.event_id, retryable: false,
+        pending_products: 0, deferred_products: 0,
+      },
+    }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -180,6 +225,18 @@ test('JSON-RPC response identity and method errors are enforced', async () => {
     }), { status: 200 })),
     (error) => error.retryable === true && /rejected/.test(error.message),
   );
+
+  await assert.rejects(
+    forwardEnvelope(config({
+      transport: 'json-rpc',
+      target: 'https://api.example.test/rpc',
+    }), payload, async () => new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      id: payload.event_id,
+      result: { accepted: false, retryable: true },
+    }), { status: 200 })),
+    /delivery state/,
+  );
 });
 
 test('mock receiver exposes a retryable failure and then accepts identical event identity', async (t) => {
@@ -197,8 +254,9 @@ test('mock receiver exposes a retryable failure and then accepts identical event
   const headers = {
     'Content-Type': 'application/json',
     'X-Patris-Contract': 'patris.product-sync',
-    'X-Patris-Contract-Version': '1.1',
     'X-Patris-Event-ID': 'evt-sparse-001',
+    'X-Patris-Event': 'update',
+    'X-Patris-Source': 'patris-test',
     [SECRET_HEADER]: 'local-ingress-test',
   };
 
@@ -213,4 +271,43 @@ test('mock receiver exposes a retryable failure and then accepts identical event
   assert.equal(accepted.data.retryable, false);
   assert.equal(accepted.data.pending_products, 0);
   assert.equal(accepted.data.deferred_products, 0);
+});
+
+test('WordPress retry-pending state is validated and propagated to Patris', async (t) => {
+  const payload = envelope();
+  const server = createAdapterServer(config({
+    transport: 'wordpress-ajax',
+    target: 'https://wordpress.example.test/wp-admin/admin-ajax.php',
+    ingressSecret: 'local-ingress-test',
+  }), {
+    fetchImpl: async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        status: 'retry_pending', event_id: payload.event_id, retryable: true,
+        pending_products: 10, deferred_products: 3,
+      },
+    }), { status: 200 }),
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => server.close());
+
+  const address = server.address();
+  const response = await fetch(`http://127.0.0.1:${address.port}/ingest`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Patris-Contract': payload.schema,
+      'X-Patris-Event-ID': payload.event_id,
+      'X-Patris-Event': payload.event_type,
+      'X-Patris-Source': payload.source.id,
+      [SECRET_HEADER]: 'local-ingress-test',
+    },
+    body: JSON.stringify(payload),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual((await response.json()).data, {
+    status: 'retry_pending', event_id: payload.event_id, retryable: true,
+    pending_products: 10, deferred_products: 3,
+  });
 });

--- a/scripts/examples/patris-delivery-adapter.test.cjs
+++ b/scripts/examples/patris-delivery-adapter.test.cjs
@@ -1,0 +1,216 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { once } = require('node:events');
+const test = require('node:test');
+
+const {
+  SECRET_HEADER,
+  buildOutboundRequest,
+  configFromOptions,
+  createAdapterServer,
+  forwardEnvelope,
+  validateEnvelope,
+} = require('./patris-delivery-adapter.cjs');
+
+function envelope() {
+  return {
+    schema: 'patris.product-sync',
+    schema_version: '1.1',
+    event_type: 'update',
+    event_id: 'evt-sparse-001',
+    products: [
+      {
+        product_code: '113007045',
+        name: null,
+        warehouse_stock: { central: 2 },
+      },
+      {
+        product_code: 'EXPLICIT-NULL-PAIR',
+        shipping_price_per_kg: null,
+        shipping_price_per_kg_currency: null,
+      },
+    ],
+  };
+}
+
+function config(overrides = {}) {
+  return {
+    transport: 'mock',
+    listen: { host: '127.0.0.1', port: 0 },
+    target: '',
+    method: 'patris.productSync',
+    action: 'patris_product_sync',
+    timeoutMs: 1000,
+    failFirst: 0,
+    maxBodyBytes: 1024 * 1024,
+    ingressSecret: '',
+    targetSecret: '',
+    ...overrides,
+  };
+}
+
+test('validates canonical body identity against Patris headers', () => {
+  const payload = envelope();
+  assert.equal(SECRET_HEADER, 'X-Patris-Product-Sync-Secret');
+  assert.equal(validateEnvelope(payload, {
+    'X-Patris-Contract': payload.schema,
+    'X-Patris-Contract-Version': payload.schema_version,
+    'X-Patris-Event-ID': payload.event_id,
+  }), payload);
+
+  assert.throws(
+    () => validateEnvelope(payload, { 'X-Patris-Event-ID': 'different' }),
+    /does not match/,
+  );
+});
+
+test('JSON-RPC wrapper preserves explicit null and does not invent unseen keys', () => {
+  const request = buildOutboundRequest(config({
+    transport: 'json-rpc',
+    target: 'https://api.example.test/rpc',
+    targetSecret: 'test-only',
+  }), envelope());
+  const body = JSON.parse(request.body);
+
+  assert.equal(body.jsonrpc, '2.0');
+  assert.equal(body.id, 'evt-sparse-001');
+  assert.equal(body.params.products[0].name, null);
+  assert.equal(Object.hasOwn(body.params.products[0], 'name'), true);
+  assert.equal(Object.hasOwn(body.params.products[0], 'shipping_method_id'), false);
+  assert.equal(Object.hasOwn(body.params.products[0], 'shipping_price_per_kg'), false);
+  assert.equal(Object.hasOwn(body.params.products[0], 'shipping_price_per_kg_currency'), false);
+  assert.equal(Object.hasOwn(body.params.products[0], 'weight_grams'), false);
+  assert.equal(body.params.products[1].shipping_price_per_kg, null);
+  assert.equal(body.params.products[1].shipping_price_per_kg_currency, null);
+  assert.equal(request.headers['Idempotency-Key'], 'evt-sparse-001');
+  assert.equal(request.headers.Authorization, 'Bearer test-only');
+});
+
+test('WordPress AJAX wrapper preserves the original sparse envelope', () => {
+  const request = buildOutboundRequest(config({
+    transport: 'wordpress-ajax',
+    target: 'https://wordpress.example.test/wp-admin/admin-ajax.php',
+    targetSecret: 'test-only',
+  }), envelope());
+  const form = new URLSearchParams(request.body);
+  const payload = JSON.parse(form.get('payload'));
+
+  assert.equal(form.get('action'), 'patris_product_sync');
+  assert.equal(form.get('event_id'), 'evt-sparse-001');
+  assert.equal(payload.products[0].name, null);
+  assert.equal(Object.hasOwn(payload.products[0], 'shipping_method_id'), false);
+  assert.equal(request.headers[SECRET_HEADER], 'test-only');
+  assert.equal(Object.hasOwn(request.headers, 'Authorization'), false);
+});
+
+test('gRPC JSON gateway receives the direct envelope without a parallel schema', () => {
+  const request = buildOutboundRequest(config({
+    transport: 'grpc-gateway',
+    target: 'https://gateway.example.test/v1/patris:apply',
+  }), envelope());
+  assert.deepEqual(JSON.parse(request.body), envelope());
+});
+
+test('secret-bearing remote adapter targets require HTTPS', () => {
+  assert.throws(() => buildOutboundRequest(config({
+    transport: 'json-rpc',
+    target: 'http://api.example.test/rpc',
+    targetSecret: 'must-not-cross-plaintext-http',
+  }), envelope()), /requires HTTPS/);
+
+  assert.doesNotThrow(() => buildOutboundRequest(config({
+    transport: 'json-rpc',
+    target: 'http://127.0.0.1:18082/rpc',
+    targetSecret: 'loopback-test',
+  }), envelope()));
+});
+
+test('CLI configuration resolves secret names without storing them in options', (t) => {
+  const variable = 'PATRIS_ADAPTER_TEST_INGRESS_SECRET';
+  const previous = process.env[variable];
+  process.env[variable] = 'local-test-value';
+  t.after(() => {
+    if (previous === undefined) delete process.env[variable];
+    else process.env[variable] = previous;
+  });
+
+  const parsed = configFromOptions({
+    transport: 'json-rpc',
+    target: 'https://api.example.test/rpc',
+    ingress_secret_env: variable,
+    listen: 'localhost:18081',
+  });
+  assert.equal(parsed.ingressSecret, 'local-test-value');
+  assert.equal(parsed.action, 'patris_product_sync');
+  assert.equal(Object.hasOwn(parsed, 'ingress_secret_env'), false);
+
+  assert.throws(() => configFromOptions({
+    transport: 'json-rpc',
+    target: 'https://api.example.test/rpc',
+  }), /requires --ingress-secret-env/);
+});
+
+test('JSON-RPC response identity and method errors are enforced', async () => {
+  const payload = envelope();
+  let captured;
+  const fetchOK = async (url, options) => {
+    captured = { url, options };
+    return new Response(JSON.stringify({ jsonrpc: '2.0', id: payload.event_id, result: { accepted: true } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  await forwardEnvelope(config({
+    transport: 'json-rpc',
+    target: 'https://api.example.test/rpc',
+  }), payload, fetchOK);
+  assert.equal(captured.url, 'https://api.example.test/rpc');
+  assert.equal(JSON.parse(captured.options.body).params.event_id, payload.event_id);
+
+  await assert.rejects(
+    forwardEnvelope(config({
+      transport: 'json-rpc',
+      target: 'https://api.example.test/rpc',
+    }), payload, async () => new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      id: payload.event_id,
+      error: { code: -32001, message: 'busy', data: { retryable: true } },
+    }), { status: 200 })),
+    (error) => error.retryable === true && /rejected/.test(error.message),
+  );
+});
+
+test('mock receiver exposes a retryable failure and then accepts identical event identity', async (t) => {
+  const server = createAdapterServer(config({
+    failFirst: 1,
+    ingressSecret: 'local-ingress-test',
+  }));
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => server.close());
+
+  const address = server.address();
+  const url = `http://127.0.0.1:${address.port}/ingest`;
+  const body = JSON.stringify(envelope());
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Patris-Contract': 'patris.product-sync',
+    'X-Patris-Contract-Version': '1.1',
+    'X-Patris-Event-ID': 'evt-sparse-001',
+    [SECRET_HEADER]: 'local-ingress-test',
+  };
+
+  const first = await fetch(url, { method: 'POST', headers, body });
+  assert.equal(first.status, 503);
+  assert.equal((await first.json()).details.retryable, true);
+
+  const second = await fetch(url, { method: 'POST', headers, body });
+  assert.equal(second.status, 200);
+  const accepted = await second.json();
+  assert.equal(accepted.data.event_id, 'evt-sparse-001');
+  assert.equal(accepted.data.retryable, false);
+  assert.equal(accepted.data.pending_products, 0);
+  assert.equal(accepted.data.deferred_products, 0);
+});


### PR DESCRIPTION
﻿## Summary
- document the native REST and WordPress REST product-sync path with CLI, layered config, and config-API examples
- add a dependency-free loopback adapter for JSON-RPC 2.0, legacy WordPress AJAX, and HTTP/JSON-to-gRPC gateways without duplicating transformation or retry logic
- add safe secret indirection, identity validation, HTTPS enforcement, idempotency guidance, sanitized failure/replay operations, local success/failure smoke transcripts, and example configs/proto
- test explicit-null preservation, omission of unseen keys, adapter framing, identity validation, retry recovery, HTTPS guards, and example-config loading in CI

## Support boundary
Patris remains a native HTTP/JSON sender. JSON-RPC and AJAX are adapter modes; gRPC requires the documented HTTP/JSON transcoding gateway. No native gRPC transport is claimed.

Sparse integration output itself is implemented separately in #173. This PR preserves the incoming sparse envelope unchanged and documents the required upgrade boundary rather than reimplementing that pipeline.

## Verification
- `node --test scripts/examples/patris-delivery-adapter.test.cjs` (13 passed)
- `go test ./...` (passed after building the required embedded web bundle)
- `npm test` in `web` (27 passed)
- `npm audit --audit-level=high` in `web` (0 vulnerabilities)
- `make test-delivery-examples` (13 passed)
- `git diff --check`

The repository owner authorized automatic merge in the current Codex task and will perform post-merge review.

Closes #175


