### PR TITLE
Add secure Electron, Tauri, and WebView2 host adapters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,11 @@ jobs:
     - name: Test remote delivery examples
       run: node --test scripts/examples/patris-delivery-adapter.test.cjs
 
+    - name: Test JavaScript host adapters
+      run: |
+        npm --prefix integrations/javascript run check
+        npm --prefix integrations/javascript test
+
     - name: Run tests
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ web/dist/
 # Keep package files
 !web/package.json
 !web/package-lock.json
+!integrations/javascript/package.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-linux build-windows build-all build-lib build-lib-linux build-lib-windows clean test test-delivery-examples run install install-linux uninstall-linux help deps build-web assets variant-manifest alm-current-guard alm-linux-guard
+.PHONY: build build-linux build-windows build-all build-lib build-lib-linux build-lib-windows clean test test-delivery-examples test-js run install install-linux uninstall-linux help deps build-web assets variant-manifest alm-current-guard alm-linux-guard
 
 # Binary names
 BINARY_NAME=patris-export
@@ -152,12 +152,17 @@ install-linux: ## Install Linux binary and systemd service (requires root)
 uninstall-linux: ## Remove Linux binary and systemd service (requires root)
 	@sudo ./scripts/install-linux.sh uninstall
 
-test: test-delivery-examples ## Run tests
+test: test-delivery-examples test-js ## Run tests
 	@echo "🧪 Running tests..."
 	go test $(GO_BUILD_TAG_ARGS) -v ./...
 
 test-delivery-examples: ## Test dependency-free remote delivery adapters
 	node --test scripts/examples/patris-delivery-adapter.test.cjs
+
+test-js: ## Run JavaScript host adapter tests
+	@echo "Running JavaScript host adapter tests..."
+	@npm --prefix integrations/javascript run check
+	@npm --prefix integrations/javascript test
 
 clean: ## Clean build artifacts
 	@echo "🧹 Cleaning..."

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -6,6 +6,13 @@ Patris Export can run in three modes:
 - Embedded Go mode: import `github.com/atomicdeploy/patris-export/pkg/embedded` and call the engine directly from a host application.
 - Loadable library mode: build `patris-export.dll` on Windows or `libpatris-export.so` on Linux and call the C ABI from C#, Electron native modules, Python `ctypes`, or another host.
 
+Supported Electron, Tauri, and WebView2 renderer/host contracts, the typed
+method allowlist, security boundary, runtime fallback order, tests, and
+standalone/unified installer layout are documented in
+[`integrations/javascript/README.md`](../integrations/javascript/README.md).
+Those adapters call this ABI or the existing executable/REST transports; they
+do not implement a parallel transformation engine.
+
 The embedded and IPC APIs use the same backend as the standalone server, so records, config, process/file-lock status, notifications, and live update events stay consistent.
 
 ## Build The Loadable Library

--- a/integrations/javascript/CHANGELOG.md
+++ b/integrations/javascript/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the Patris Export JavaScript host adapters are
+documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Added a directly usable Electron privileged-host adapter plus Tauri and
+  WebView2 renderer adapters and native host-routing references, all using one
+  typed result/error contract, exact origin and method allowlists,
+  privileged-only native loading, existing Digitalogic Electron bridge reuse,
+  DLL-to-executable-to-REST startup fallback, lifecycle/concurrency tests, and
+  standalone/unified packaging guidance. Native Tauri and WebView2 host binaries
+  are integration responsibilities and are not claimed by this package.

--- a/integrations/javascript/CHANGELOG.md
+++ b/integrations/javascript/CHANGELOG.md
@@ -14,3 +14,9 @@ documented in this file.
   DLL-to-executable-to-REST startup fallback, lifecycle/concurrency tests, and
   standalone/unified packaging guidance. Native Tauri and WebView2 host binaries
   are integration responsibilities and are not claimed by this package.
+- Require a host-owned session/capability authorizer for every Electron, Tauri,
+  and WebView2 request so same-origin public or login pages fail closed.
+- Add an awaited Electron shutdown barrier and a self-contained sandboxed
+  preload example with sanitized typed failures.
+- Document and test the canonical Code-keyed `records.list` result shape and
+  expose the typed public API only from the package root.

--- a/integrations/javascript/README.md
+++ b/integrations/javascript/README.md
@@ -1,0 +1,247 @@
+# Patris Export JavaScript host adapters
+
+These CommonJS adapters define one Patris Export renderer contract for Electron,
+Tauri, and WebView2 without moving database, transformation, pricing, or export
+logic into JavaScript. Electron has a directly usable privileged-host adapter;
+Tauri and WebView2 have renderer adapters plus framework-neutral host-routing
+references that native applications must bind in their privileged layer.
+`cmd/patris-export-lib` remains the only native ABI and the normal Patris
+executable and REST API remain the fallbacks.
+
+See the adapter-specific [`CHANGELOG.md`](CHANGELOG.md) for release notes.
+
+The security boundary is deliberate:
+
+```text
+untrusted renderer
+  -> typed allowlisted IPC/message call
+  -> privileged Electron/Tauri/WebView2 host (validates its own source URL)
+  -> Patris DLL worker
+  -> Patris executable on loopback
+  -> configured Patris REST endpoint
+```
+
+No adapter creates or transfers an authentication token. Application login is
+the host application's responsibility. The Patris bridge is an integration
+transport, not a second login system.
+
+For Digitalogic, keep the existing WordPress session and capability checks on
+the canonical `/panel/` route. Do not exchange that browser session for a bearer
+token or forward a renderer-supplied credential through this bridge.
+
+## Stable renderer contract
+
+Every renderer receives only `status()` and `call(method, params)`. The methods
+match ABI version 1 exactly:
+
+- `app.get`
+- `records.list`
+- `info.get`
+- `status.get`
+- `config.get`
+- `config.set`
+- `toast.show`
+- `refresh`
+
+Success:
+
+```json
+{
+  "ok": true,
+  "result": [{ "code": "1001", "name": "Example module" }],
+  "meta": { "requestId": 1, "method": "records.list", "mode": "dll" }
+}
+```
+
+Failure:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "RUNTIME_UNAVAILABLE",
+    "message": "No configured Patris runtime could be started.",
+    "retryable": true
+  },
+  "meta": { "requestId": 1, "method": "records.list" }
+}
+```
+
+The renderer never chooses a DLL path, executable path, REST base URL, origin,
+or method outside this allowlist. Startup may fall back to the next configured
+runtime. A failed data-changing call is never automatically replayed through a
+different transport.
+
+## Shared privileged host
+
+`createConfiguredHost` applies DLL -> executable -> REST startup order:
+
+```js
+const path = require('node:path');
+const { createConfiguredHost } = require('./src/index.cjs');
+
+const host = createConfiguredHost({
+  allowedOrigins: ['app://digitalogic', 'https://digitalogic.ir'],
+  dll: {
+    // The existing Digitalogic Node-API bridge. The DLL is loaded only in the
+    // child worker created by the privileged host.
+    addonPath: path.join(process.resourcesPath, 'app.asar.unpacked', 'native', 'digitalogic_patris.node'),
+    dllPath: path.join(process.resourcesPath, 'patris', 'patris-export.dll'),
+    engineOptions: {
+      database_path: 'C:\\Patris\\data4\\kala.db',
+      watch: true,
+      watch_set: true
+    }
+  },
+  executable: {
+    executablePath: path.join(process.resourcesPath, 'patris', 'patris-export.exe'),
+    databasePath: 'C:\\Patris\\data4\\kala.db',
+    watch: true
+  },
+  rest: {
+    baseUrl: 'https://patris.example.test'
+  }
+});
+```
+
+The DLL worker accepts the existing Digitalogic Node-API addon interface and
+verifies ABI version 1 plus the canonical capabilities before creating an
+engine. The worker serializes calls, owns the engine handle, frees native
+strings through the addon, and closes before it exits.
+
+Digitalogic Electron already has a `PatrisBridge` with utility-process and
+fallback management. Keep that implementation and wrap the instance rather
+than implementing a second bridge:
+
+```js
+const { PrivilegedPatrisHost, wrapExistingElectronBridge } = require('./src');
+
+const host = new PrivilegedPatrisHost({
+  allowedOrigins: ['app://digitalogic', 'https://digitalogic.ir'],
+  transports: [wrapExistingElectronBridge(new PatrisBridge(settings.patris))]
+});
+```
+
+See [`examples/electron-main.cjs`](examples/electron-main.cjs).
+
+## Electron
+
+Register handlers in the main process and expose the renderer client from a
+sandboxed preload:
+
+```js
+const { ipcMain } = require('electron');
+const { registerElectronPatrisHost } = require('./src/electron.cjs');
+
+const unregister = registerElectronPatrisHost({ ipcMain, host });
+app.once('before-quit', async () => {
+  unregister();
+  await host.close();
+});
+```
+
+Use [`examples/electron-preload.cjs`](examples/electron-preload.cjs) with
+`contextIsolation: true`, `sandbox: true`, and `nodeIntegration: false`.
+Electron origin checks use `event.senderFrame.url`; a URL sent inside the
+renderer payload is ignored. Prefer a registered `app://digitalogic` scheme for
+packaged local content instead of allowing the broad `file://` origin.
+
+## Tauri
+
+Bundle [`src/tauri.cjs`](src/tauri.cjs) into the web frontend and supply Tauri's
+`invoke` function:
+
+```js
+const { invoke } = require('@tauri-apps/api/core');
+const { createTauriRendererClient } = require('./src/tauri.cjs');
+const patris = createTauriRendererClient({ invoke });
+const response = await patris.call('records.list');
+```
+
+Implement two privileged commands, `patris_invoke` and `patris_status`. They
+must derive the caller URL/window label from Tauri's command context, compare it
+with an exact allowlist, and then call the same host contract. Never accept an
+origin, path, native handle, or endpoint from the command payload. In a native
+Tauri build, load `patris-export.dll`/`libpatris-export.so` from the signed
+application resource directory or launch the Patris sidecar; JavaScript must
+not call `libloading`, FFI plugins, or shell commands directly.
+
+The JavaScript renderer adapter and framework-neutral command-routing reference
+are covered by the Node test suite. This repository does not ship a compiled
+Tauri/Rust command plugin, and this workstation currently has `rustup` but no
+installed Rust toolchain, so no native Tauri build is claimed. A production
+Tauri application must implement and test the two commands in its privileged
+Rust core (or a signed sidecar) before calling that integration native-ready.
+This does not affect Electron, the C ABI, or the Patris executable fallback.
+
+## WebView2
+
+Bundle [`src/webview2.cjs`](src/webview2.cjs) into trusted app content:
+
+```js
+const { createWebView2RendererClient } = require('./src/webview2.cjs');
+const patris = createWebView2RendererClient({ webview: window.chrome.webview });
+const response = await patris.call('records.list');
+```
+
+The native .NET/C++ host listens for `patris:request`, reads the source from the
+WebView2 event/navigation state, checks an exact origin such as
+`https://patris.local`, and answers with `patris:result`. The host should use a
+virtual-host mapping to packaged read-only content. Do not expose a broad COM
+host object, DLL path, filesystem primitive, or process launcher to the page.
+`createWebView2MessageHandler` is the JavaScript reference harness used by the
+tests. This repository does not ship a compiled .NET/C++ WebView2 host; the
+native application must mirror this routing and origin policy in its own message
+callback and validate it in that host's test suite.
+
+## Packaging
+
+### Standalone Patris installer
+
+The existing installer remains independent. Install the executable, C ABI
+library/header, pxlib and compiler-runtime DLLs together. A standalone install
+does not require Electron, Tauri, WebView2, Node, or these adapters.
+
+### Unified Digitalogic + Patris installer
+
+Recommended layout:
+
+```text
+Digitalogic/
+  Digitalogic.exe
+  resources/
+    app.asar
+    app.asar.unpacked/native/digitalogic_patris.node
+    patris/
+      patris-export.exe
+      patris-export.dll
+      libpxlib.dll
+      libgcc_s_seh-1.dll
+      libstdc++-6.dll
+      libwinpthread-1.dll
+```
+
+- Keep the Node-API addon and native DLLs outside ASAR.
+- Resolve every native path from the signed installation root in the privileged
+  process; never from renderer settings.
+- Keep the executable beside its pxlib runtime so fallback remains portable.
+- Preserve user configuration and databases on a normal uninstall; remove them
+  only after an explicit purge choice.
+- Build the Node-API addon for the exact Electron ABI and architecture.
+- For Tauri, declare the executable as an external binary and native libraries
+  as resources. For WebView2, install the matching architecture under a
+  non-user-writable application directory.
+- Standard and optional ALM builds use the same C symbols. Package a consistent
+  Patris executable/DLL variant and do not mix licensed and unlicensed files.
+
+## Validation
+
+```powershell
+npm --prefix integrations/javascript run check
+npm --prefix integrations/javascript test
+```
+
+The tests cover method and origin rejection, typed errors, existing Electron
+bridge reuse, DLL -> executable fallback, REST identity, absence of invented
+auth headers, concurrent calls, close behavior, missing runtimes, representative
+`records.list` results, and Electron/Tauri/WebView2 request routing.

--- a/integrations/javascript/README.md
+++ b/integrations/javascript/README.md
@@ -9,25 +9,32 @@ references that native applications must bind in their privileged layer.
 executable and REST API remain the fallbacks.
 
 See the adapter-specific [`CHANGELOG.md`](CHANGELOG.md) for release notes.
+All supported JavaScript and TypeScript APIs are exported from the package
+root. The `src/` file layout is internal and is not a public subpath contract.
 
 The security boundary is deliberate:
 
 ```text
 untrusted renderer
   -> typed allowlisted IPC/message call
-  -> privileged Electron/Tauri/WebView2 host (validates its own source URL)
+  -> privileged host (validates source URL plus host-owned session/capability)
   -> Patris DLL worker
   -> Patris executable on loopback
   -> configured Patris REST endpoint
 ```
 
-No adapter creates or transfers an authentication token. Application login is
-the host application's responsibility. The Patris bridge is an integration
-transport, not a second login system.
+No adapter creates or transfers an authentication token. The privileged host
+must resolve application login and capabilities from its own trusted session
+state on every call. The Patris bridge is an integration transport, not a
+second login system.
 
 For Digitalogic, keep the existing WordPress session and capability checks on
 the canonical `/panel/` route. Do not exchange that browser session for a bearer
-token or forward a renderer-supplied credential through this bridge.
+token or forward a renderer-supplied credential through this bridge. Electron
+registration requires a privileged `authorize` callback for every status and
+method call. Origin comparison alone is not authorization: all same-origin
+WordPress routes share one origin even when the current session or route lacks
+panel capabilities.
 
 ## Stable renderer contract
 
@@ -48,7 +55,9 @@ Success:
 ```json
 {
   "ok": true,
-  "result": [{ "code": "1001", "name": "Example module" }],
+  "result": {
+    "1001": { "name": "Example module", "final_price": "150000" }
+  },
   "meta": { "requestId": 1, "method": "records.list", "mode": "dll" }
 }
 ```
@@ -78,7 +87,7 @@ different transport.
 
 ```js
 const path = require('node:path');
-const { createConfiguredHost } = require('./src/index.cjs');
+const { createConfiguredHost } = require('@atomicdeploy/patris-export-hosts');
 
 const host = createConfiguredHost({
   allowedOrigins: ['app://digitalogic', 'https://digitalogic.ir'],
@@ -114,7 +123,10 @@ fallback management. Keep that implementation and wrap the instance rather
 than implementing a second bridge:
 
 ```js
-const { PrivilegedPatrisHost, wrapExistingElectronBridge } = require('./src');
+const {
+  PrivilegedPatrisHost,
+  wrapExistingElectronBridge
+} = require('@atomicdeploy/patris-export-hosts');
 
 const host = new PrivilegedPatrisHost({
   allowedOrigins: ['app://digitalogic', 'https://digitalogic.ir'],
@@ -130,41 +142,95 @@ Register handlers in the main process and expose the renderer client from a
 sandboxed preload:
 
 ```js
-const { ipcMain } = require('electron');
-const { registerElectronPatrisHost } = require('./src/electron.cjs');
+const { app, ipcMain } = require('electron');
+const {
+  registerElectronPatrisHost,
+  registerElectronShutdownBarrier
+} = require('@atomicdeploy/patris-export-hosts');
 
-const unregister = registerElectronPatrisHost({ ipcMain, host });
-app.once('before-quit', async () => {
-  unregister();
-  await host.close();
+const unregister = registerElectronPatrisHost({
+  ipcMain,
+  host,
+  authorize: async (event, { sourceUrl, method }) => {
+    const url = new URL(sourceUrl);
+    if (!url.pathname.startsWith('/panel/')) return false;
+    // This callback runs in the main process. Resolve the existing WordPress
+    // session/capability state from event.sender/session; never inspect a
+    // renderer-supplied token or authorization flag.
+    return wordpressSession.can(event.sender, method === 'config.set'
+      ? 'manage_woocommerce'
+      : 'read_digitalogic_panel');
+  }
+});
+registerElectronShutdownBarrier({
+  app,
+  cleanup: async () => {
+    unregister();
+    await host.close();
+  },
+  onError: (error) => console.error('Patris shutdown failed', error)
 });
 ```
 
-Use [`examples/electron-preload.cjs`](examples/electron-preload.cjs) with
-`contextIsolation: true`, `sandbox: true`, and `nodeIntegration: false`.
+Use the self-contained [`examples/electron-preload.cjs`](examples/electron-preload.cjs)
+with `contextIsolation: true`, `sandbox: true`, and `nodeIntegration: false`.
+It requires only Electron's sandbox-provided module; do not add local-file or
+package imports to that preload unless the host application's build first
+bundles them into the same file.
+
 Electron origin checks use `event.senderFrame.url`; a URL sent inside the
 renderer payload is ignored. Prefer a registered `app://digitalogic` scheme for
-packaged local content instead of allowing the broad `file://` origin.
+packaged local content instead of allowing the broad `file://` origin. The
+authorizer receives the privileged Electron event plus derived source/action/
+method metadata and must return exactly `true`; missing, throwing, or false
+authorizers fail closed. The shutdown barrier prevents the first `before-quit`,
+awaits cleanup once, removes itself, and only then re-enters `app.quit()` so
+Electron cannot exit ahead of the DLL worker or sidecar.
 
 ## Tauri
 
-Bundle [`src/tauri.cjs`](src/tauri.cjs) into the web frontend and supply Tauri's
-`invoke` function:
+Bundle the package-root renderer client into the web frontend and supply
+Tauri's `invoke` function:
 
 ```js
 const { invoke } = require('@tauri-apps/api/core');
-const { createTauriRendererClient } = require('./src/tauri.cjs');
+const {
+  createTauriRendererClient
+} = require('@atomicdeploy/patris-export-hosts');
 const patris = createTauriRendererClient({ invoke });
 const response = await patris.call('records.list');
 ```
 
 Implement two privileged commands, `patris_invoke` and `patris_status`. They
-must derive the caller URL/window label from Tauri's command context, compare it
-with an exact allowlist, and then call the same host contract. Never accept an
-origin, path, native handle, or endpoint from the command payload. In a native
-Tauri build, load `patris-export.dll`/`libpatris-export.so` from the signed
-application resource directory or launch the Patris sidecar; JavaScript must
-not call `libloading`, FFI plugins, or shell commands directly.
+must derive the caller URL/window label from Tauri's command context, enforce
+an exact origin allowlist, and authorize the host-owned session/capability on
+every call. The JavaScript reference handler makes that fail-closed contract
+explicit:
+
+```js
+const {
+  createTauriCommandHandlers
+} = require('@atomicdeploy/patris-export-hosts');
+
+const commands = createTauriCommandHandlers({
+  host,
+  getSourceUrl: (event) => event.privilegedWindowUrl,
+  authorize: async (event, { sourceUrl, method }) => {
+    const url = new URL(sourceUrl);
+    return url.pathname.startsWith('/panel/')
+      && wordpressSession.can(event.windowLabel, method === 'config.set'
+        ? 'manage_woocommerce'
+        : 'read_digitalogic_panel');
+  }
+});
+```
+
+Missing, throwing, or false authorizers deny the request. Never accept an
+origin, path, native handle, endpoint, auth flag, or credential from the
+command payload. In a native Tauri build, load
+`patris-export.dll`/`libpatris-export.so` from the signed application resource
+directory or launch the Patris sidecar; JavaScript must not call `libloading`,
+FFI plugins, or shell commands directly.
 
 The JavaScript renderer adapter and framework-neutral command-routing reference
 are covered by the Node test suite. This repository does not ship a compiled
@@ -176,23 +242,50 @@ This does not affect Electron, the C ABI, or the Patris executable fallback.
 
 ## WebView2
 
-Bundle [`src/webview2.cjs`](src/webview2.cjs) into trusted app content:
+Bundle the package-root renderer client into trusted app content:
 
 ```js
-const { createWebView2RendererClient } = require('./src/webview2.cjs');
+const {
+  createWebView2RendererClient
+} = require('@atomicdeploy/patris-export-hosts');
 const patris = createWebView2RendererClient({ webview: window.chrome.webview });
 const response = await patris.call('records.list');
 ```
 
+The JavaScript host-routing reference requires the same independent
+authorization decision:
+
+```js
+const {
+  createWebView2MessageHandler
+} = require('@atomicdeploy/patris-export-hosts');
+
+const handleMessage = createWebView2MessageHandler({
+  host,
+  getSourceUrl: (event) => event.privilegedSourceUrl,
+  authorize: (event, { sourceUrl, method }) => {
+    const url = new URL(sourceUrl);
+    return url.pathname.startsWith('/panel/')
+      && wordpressSession.can(event.webviewId, method === 'config.set'
+        ? 'manage_woocommerce'
+        : 'read_digitalogic_panel');
+  },
+  postMessage: (payload, event) => event.reply(payload)
+});
+```
+
 The native .NET/C++ host listens for `patris:request`, reads the source from the
 WebView2 event/navigation state, checks an exact origin such as
-`https://patris.local`, and answers with `patris:result`. The host should use a
-virtual-host mapping to packaged read-only content. Do not expose a broad COM
-host object, DLL path, filesystem primitive, or process launcher to the page.
-`createWebView2MessageHandler` is the JavaScript reference harness used by the
-tests. This repository does not ship a compiled .NET/C++ WebView2 host; the
-native application must mirror this routing and origin policy in its own message
-callback and validate it in that host's test suite.
+`https://patris.local`, resolves the host-owned login/capability state, and
+answers with `patris:result`. `createWebView2MessageHandler` is the JavaScript
+reference harness; its required `authorize(event, context)` callback runs for
+every valid request and denies on missing, false, or thrown authorization. A
+renderer-supplied flag or credential never satisfies that callback. The host
+should use a virtual-host mapping to packaged read-only content. Do not expose a
+broad COM host object, DLL path, filesystem primitive, or process launcher to
+the page. This repository does not ship a compiled .NET/C++ WebView2 host; the
+native application must mirror both origin and session/capability checks in its
+own message callback and validate them in that host's test suite.
 
 ## Packaging
 

--- a/integrations/javascript/examples/electron-main.cjs
+++ b/integrations/javascript/examples/electron-main.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+const {
+  PrivilegedPatrisHost,
+  registerElectronPatrisHost,
+  wrapExistingElectronBridge
+} = require('../src/index.cjs');
+
+// PatrisBridge is the existing Digitalogic Electron adapter. It already owns
+// DLL -> executable -> REST discovery, its utility process, and lifecycle.
+function installPatrisElectronHost({ ipcMain, PatrisBridge, settings, allowedOrigins }) {
+  const bridge = new PatrisBridge(settings);
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins,
+    transports: [wrapExistingElectronBridge(bridge)]
+  });
+  const unregister = registerElectronPatrisHost({ ipcMain, host });
+  return async () => {
+    unregister();
+    await host.close();
+  };
+}
+
+module.exports = { installPatrisElectronHost };

--- a/integrations/javascript/examples/electron-main.cjs
+++ b/integrations/javascript/examples/electron-main.cjs
@@ -2,23 +2,28 @@
 
 const {
   PrivilegedPatrisHost,
+  registerElectronShutdownBarrier,
   registerElectronPatrisHost,
   wrapExistingElectronBridge
-} = require('../src/index.cjs');
+} = require('..');
 
 // PatrisBridge is the existing Digitalogic Electron adapter. It already owns
 // DLL -> executable -> REST discovery, its utility process, and lifecycle.
-function installPatrisElectronHost({ ipcMain, PatrisBridge, settings, allowedOrigins }) {
+function installPatrisElectronHost({ ipcMain, PatrisBridge, settings, allowedOrigins, authorize }) {
   const bridge = new PatrisBridge(settings);
   const host = new PrivilegedPatrisHost({
     allowedOrigins,
     transports: [wrapExistingElectronBridge(bridge)]
   });
-  const unregister = registerElectronPatrisHost({ ipcMain, host });
+  const unregister = registerElectronPatrisHost({ ipcMain, host, authorize });
   return async () => {
     unregister();
     await host.close();
   };
 }
 
-module.exports = { installPatrisElectronHost };
+function installPatrisElectronShutdown({ app, cleanup, onError }) {
+  return registerElectronShutdownBarrier({ app, cleanup, onError });
+}
+
+module.exports = { installPatrisElectronHost, installPatrisElectronShutdown };

--- a/integrations/javascript/examples/electron-preload.cjs
+++ b/integrations/javascript/examples/electron-preload.cjs
@@ -1,10 +1,45 @@
 'use strict';
 
 const { contextBridge, ipcRenderer } = require('electron');
-const { createElectronRendererClient } = require('../src/electron.cjs');
 
-const client = createElectronRendererClient({
-  invoke: (channel, request) => ipcRenderer.invoke(channel, request)
+// This example is intentionally self-contained. Electron sandboxed preloads
+// may load Electron's built-in module but cannot require arbitrary application
+// files. Keep the native host, session state, and capability checks in main.
+let nextRequestId = 0;
+
+function typedFailure(code, message, requestId) {
+  return Object.freeze({
+    ok: false,
+    error: Object.freeze({ code, message, retryable: false }),
+    meta: Object.freeze({ requestId })
+  });
+}
+
+async function safeInvoke(channel, request) {
+  try {
+    const response = await ipcRenderer.invoke(channel, request);
+    if (!response || typeof response !== 'object' || typeof response.ok !== 'boolean') {
+      return typedFailure('INVALID_RESPONSE', 'The privileged Patris host returned an invalid response envelope.', request.requestId);
+    }
+    if (response.ok && !Object.prototype.hasOwnProperty.call(response, 'result')) {
+      return typedFailure('INVALID_RESPONSE', 'The privileged Patris host returned an invalid response envelope.', request.requestId);
+    }
+    if (!response.ok && (!response.error || typeof response.error.code !== 'string' || typeof response.error.message !== 'string')) {
+      return typedFailure('INVALID_RESPONSE', 'The privileged Patris host returned an invalid response envelope.', request.requestId);
+    }
+    return response;
+  } catch {
+    return typedFailure('ELECTRON_IPC_FAILED', 'The privileged Patris host could not complete the IPC request.', request.requestId);
+  }
+}
+
+const client = Object.freeze({
+  call(method, params = null) {
+    return safeInvoke('patris:invoke', { requestId: ++nextRequestId, method, params });
+  },
+  status() {
+    return safeInvoke('patris:status', { requestId: ++nextRequestId });
+  }
 });
 
 // The renderer receives two typed functions. It never receives require(), a

--- a/integrations/javascript/examples/electron-preload.cjs
+++ b/integrations/javascript/examples/electron-preload.cjs
@@ -1,0 +1,15 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+const { createElectronRendererClient } = require('../src/electron.cjs');
+
+const client = createElectronRendererClient({
+  invoke: (channel, request) => ipcRenderer.invoke(channel, request)
+});
+
+// The renderer receives two typed functions. It never receives require(), a
+// filesystem path, a native handle, the Node-API addon, or the Patris DLL.
+contextBridge.exposeInMainWorld('patrisExport', {
+  status: () => client.status(),
+  call: (method, params) => client.call(method, params)
+});

--- a/integrations/javascript/examples/tauri-renderer.cjs
+++ b/integrations/javascript/examples/tauri-renderer.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+const { createTauriRendererClient } = require('../src/tauri.cjs');
+
+function createPatrisClient(invoke) {
+  return createTauriRendererClient({ invoke });
+}
+
+module.exports = { createPatrisClient };

--- a/integrations/javascript/examples/tauri-renderer.cjs
+++ b/integrations/javascript/examples/tauri-renderer.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createTauriRendererClient } = require('../src/tauri.cjs');
+const { createTauriRendererClient } = require('..');
 
 function createPatrisClient(invoke) {
   return createTauriRendererClient({ invoke });

--- a/integrations/javascript/examples/webview2-renderer.cjs
+++ b/integrations/javascript/examples/webview2-renderer.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+const { createWebView2RendererClient } = require('../src/webview2.cjs');
+
+function createPatrisClient(webview = window.chrome.webview) {
+  return createWebView2RendererClient({ webview });
+}
+
+module.exports = { createPatrisClient };

--- a/integrations/javascript/examples/webview2-renderer.cjs
+++ b/integrations/javascript/examples/webview2-renderer.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createWebView2RendererClient } = require('../src/webview2.cjs');
+const { createWebView2RendererClient } = require('..');
 
 function createPatrisClient(webview = window.chrome.webview) {
   return createWebView2RendererClient({ webview });

--- a/integrations/javascript/package.json
+++ b/integrations/javascript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@atomicdeploy/patris-export-hosts",
+  "version": "1.2.0",
+  "private": true,
+  "description": "Privileged JavaScript host contracts for Patris Export",
+  "type": "commonjs",
+  "main": "src/index.cjs",
+  "types": "src/index.d.ts",
+  "scripts": {
+    "test": "node --test test/*.test.cjs",
+    "check": "node --check src/index.cjs && node --check src/contract.cjs && node --check src/privileged-host.cjs && node --check src/transports.cjs && node --check src/native-worker.cjs && node --check src/electron.cjs && node --check src/tauri.cjs && node --check src/webview2.cjs && node --check examples/electron-main.cjs && node --check examples/electron-preload.cjs && node --check examples/tauri-renderer.cjs && node --check examples/webview2-renderer.cjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT"
+}

--- a/integrations/javascript/package.json
+++ b/integrations/javascript/package.json
@@ -6,9 +6,16 @@
   "type": "commonjs",
   "main": "src/index.cjs",
   "types": "src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "require": "./src/index.cjs",
+      "default": "./src/index.cjs"
+    }
+  },
   "scripts": {
     "test": "node --test test/*.test.cjs",
-    "check": "node --check src/index.cjs && node --check src/contract.cjs && node --check src/privileged-host.cjs && node --check src/transports.cjs && node --check src/native-worker.cjs && node --check src/electron.cjs && node --check src/tauri.cjs && node --check src/webview2.cjs && node --check examples/electron-main.cjs && node --check examples/electron-preload.cjs && node --check examples/tauri-renderer.cjs && node --check examples/webview2-renderer.cjs"
+    "check": "node --check src/index.cjs && node --check src/contract.cjs && node --check src/authorization.cjs && node --check src/privileged-host.cjs && node --check src/transports.cjs && node --check src/native-worker.cjs && node --check src/electron.cjs && node --check src/tauri.cjs && node --check src/webview2.cjs && node --check examples/electron-main.cjs && node --check examples/electron-preload.cjs && node --check examples/tauri-renderer.cjs && node --check examples/webview2-renderer.cjs"
   },
   "engines": {
     "node": ">=20"

--- a/integrations/javascript/src/authorization.cjs
+++ b/integrations/javascript/src/authorization.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+const { PatrisHostError } = require('./contract.cjs');
+
+function requirePrivilegedAuthorizer(authorize, code, message) {
+  if (typeof authorize !== 'function') {
+    throw new PatrisHostError(code, message);
+  }
+  return authorize;
+}
+
+async function isPrivilegedCallAuthorized(authorize, event, context) {
+  try {
+    return await authorize(event, Object.freeze({ ...context })) === true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  isPrivilegedCallAuthorized,
+  requirePrivilegedAuthorizer
+};

--- a/integrations/javascript/src/contract.cjs
+++ b/integrations/javascript/src/contract.cjs
@@ -138,6 +138,5 @@ module.exports = {
   compileOriginAllowlist,
   errorEnvelope,
   normalizeOrigin,
-  publicError,
   successEnvelope
 };

--- a/integrations/javascript/src/contract.cjs
+++ b/integrations/javascript/src/contract.cjs
@@ -1,0 +1,143 @@
+'use strict';
+
+const ALLOWED_METHODS = Object.freeze([
+  'app.get',
+  'records.list',
+  'info.get',
+  'status.get',
+  'config.get',
+  'config.set',
+  'toast.show',
+  'refresh'
+]);
+
+const ALLOWED_METHOD_SET = new Set(ALLOWED_METHODS);
+
+const HTTP_METHODS = Object.freeze({
+  'app.get': Object.freeze(['GET', '/api/app']),
+  'records.list': Object.freeze(['GET', '/api/records']),
+  'info.get': Object.freeze(['GET', '/api/info']),
+  'status.get': Object.freeze(['GET', '/api/status']),
+  'config.get': Object.freeze(['GET', '/api/config']),
+  'config.set': Object.freeze(['PUT', '/api/config']),
+  'toast.show': Object.freeze(['POST', '/api/toast']),
+  refresh: Object.freeze(['POST', '/api/refresh'])
+});
+
+class PatrisHostError extends Error {
+  constructor(code, message, options = {}) {
+    super(String(message || code));
+    this.name = 'PatrisHostError';
+    this.code = String(code || 'HOST_ERROR');
+    this.retryable = options.retryable === true;
+    if (options.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+function normalizeOrigin(value) {
+  const raw = String(value || '').trim();
+  if (!raw || raw === 'null') return '';
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (error) {
+    throw new PatrisHostError('ORIGIN_INVALID', 'The caller URL is not a valid absolute URL.', { cause: error });
+  }
+  if (parsed.username || parsed.password) {
+    throw new PatrisHostError('ORIGIN_INVALID', 'Origins containing credentials are not accepted.');
+  }
+  if (parsed.origin !== 'null') return parsed.origin;
+  if (parsed.protocol === 'file:') return 'file://';
+  if (!parsed.host) {
+    throw new PatrisHostError('ORIGIN_INVALID', 'Opaque caller origins are not accepted.');
+  }
+  return `${parsed.protocol}//${parsed.host}`;
+}
+
+function compileOriginAllowlist(origins) {
+  if (!Array.isArray(origins) || origins.length === 0) {
+    throw new PatrisHostError('ORIGIN_POLICY_INVALID', 'At least one trusted renderer origin is required.');
+  }
+  const normalized = new Set();
+  for (const origin of origins) {
+    if (String(origin).includes('*')) {
+      throw new PatrisHostError('ORIGIN_POLICY_INVALID', 'Wildcard renderer origins are not supported.');
+    }
+    const value = normalizeOrigin(origin);
+    if (!value) {
+      throw new PatrisHostError('ORIGIN_POLICY_INVALID', 'Empty or opaque renderer origins are not supported.');
+    }
+    normalized.add(value);
+  }
+  return normalized;
+}
+
+function assertAllowedOrigin(sourceUrl, allowlist) {
+  const origin = normalizeOrigin(sourceUrl);
+  if (!origin || !allowlist.has(origin)) {
+    throw new PatrisHostError('ORIGIN_NOT_ALLOWED', 'This renderer origin is not allowed to call Patris Export.');
+  }
+  return origin;
+}
+
+function assertAllowedMethod(method) {
+  const value = String(method || '').trim();
+  if (!ALLOWED_METHOD_SET.has(value)) {
+    throw new PatrisHostError('METHOD_NOT_ALLOWED', `Patris method is not allowed: ${value || '(empty)'}`);
+  }
+  return value;
+}
+
+function publicError(error) {
+  const value = error instanceof PatrisHostError
+    ? error
+    : new PatrisHostError('HOST_ERROR', error && error.message ? error.message : String(error || 'Unknown Patris host error.'));
+  return Object.freeze({
+    code: value.code,
+    message: value.message,
+    retryable: value.retryable === true
+  });
+}
+
+function successEnvelope(result, meta = {}) {
+  return Object.freeze({
+    ok: true,
+    result: result === undefined ? null : result,
+    meta: Object.freeze({ ...meta })
+  });
+}
+
+function errorEnvelope(error, meta = {}) {
+  return Object.freeze({
+    ok: false,
+    error: publicError(error),
+    meta: Object.freeze({ ...meta })
+  });
+}
+
+function assertEnvelope(value) {
+  if (!value || typeof value !== 'object' || typeof value.ok !== 'boolean') {
+    throw new PatrisHostError('INVALID_RESPONSE', 'The privileged Patris host returned an invalid response envelope.');
+  }
+  if (value.ok && !Object.prototype.hasOwnProperty.call(value, 'result')) {
+    throw new PatrisHostError('INVALID_RESPONSE', 'A successful Patris response is missing its result.');
+  }
+  if (!value.ok && (!value.error || typeof value.error.code !== 'string' || typeof value.error.message !== 'string')) {
+    throw new PatrisHostError('INVALID_RESPONSE', 'A failed Patris response is missing its typed error.');
+  }
+  return value;
+}
+
+module.exports = {
+  ALLOWED_METHODS,
+  HTTP_METHODS,
+  PatrisHostError,
+  assertAllowedMethod,
+  assertAllowedOrigin,
+  assertEnvelope,
+  compileOriginAllowlist,
+  errorEnvelope,
+  normalizeOrigin,
+  publicError,
+  successEnvelope
+};

--- a/integrations/javascript/src/electron.cjs
+++ b/integrations/javascript/src/electron.cjs
@@ -1,6 +1,14 @@
 'use strict';
 
-const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+const {
+  PatrisHostError,
+  assertEnvelope,
+  errorEnvelope
+} = require('./contract.cjs');
+const {
+  isPrivilegedCallAuthorized,
+  requirePrivilegedAuthorizer
+} = require('./authorization.cjs');
 
 function sourceUrlFromElectronEvent(event) {
   // sender.getURL() identifies the top-level WebContents, not necessarily the
@@ -13,6 +21,7 @@ function sourceUrlFromElectronEvent(event) {
 function registerElectronPatrisHost(options = {}) {
   const ipcMain = options.ipcMain;
   const host = options.host;
+  const authorize = options.authorize;
   const invokeChannel = options.invokeChannel || 'patris:invoke';
   const statusChannel = options.statusChannel || 'patris:status';
   if (!ipcMain || typeof ipcMain.handle !== 'function' || typeof ipcMain.removeHandler !== 'function') {
@@ -21,13 +30,75 @@ function registerElectronPatrisHost(options = {}) {
   if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
     throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
   }
+  requirePrivilegedAuthorizer(authorize, 'ELECTRON_AUTHORIZER_REQUIRED', 'A privileged Electron session/capability authorizer is required.');
+  async function authorized(event, request, action) {
+    const sourceUrl = sourceUrlFromElectronEvent(event);
+    const requestId = request && request.requestId;
+    const method = action === 'invoke' && request ? String(request.method || '') : null;
+    const allowed = await isPrivilegedCallAuthorized(authorize, event, { sourceUrl, action, method });
+    if (allowed !== true) {
+      return errorEnvelope(new PatrisHostError(
+        'ELECTRON_NOT_AUTHORIZED',
+        'The current host session is not authorized to use Patris Export.'
+      ), { requestId });
+    }
+    return action === 'status'
+      ? host.handleStatus(sourceUrl, requestId)
+      : host.handle(sourceUrl, request);
+  }
   ipcMain.removeHandler(invokeChannel);
   ipcMain.removeHandler(statusChannel);
-  ipcMain.handle(invokeChannel, (event, request) => host.handle(sourceUrlFromElectronEvent(event), request));
-  ipcMain.handle(statusChannel, (event, request = {}) => host.handleStatus(sourceUrlFromElectronEvent(event), request.requestId));
+  ipcMain.handle(invokeChannel, (event, request = {}) => authorized(event, request, 'invoke'));
+  ipcMain.handle(statusChannel, (event, request = {}) => authorized(event, request, 'status'));
   return () => {
     ipcMain.removeHandler(invokeChannel);
     ipcMain.removeHandler(statusChannel);
+  };
+}
+
+function registerElectronShutdownBarrier(options = {}) {
+  const app = options.app;
+  const cleanup = options.cleanup;
+  const onError = options.onError;
+  if (!app || typeof app.on !== 'function' || typeof app.removeListener !== 'function' || typeof app.quit !== 'function') {
+    throw new PatrisHostError('ELECTRON_APP_INVALID', 'Electron app lifecycle methods are required.');
+  }
+  if (typeof cleanup !== 'function') {
+    throw new PatrisHostError('ELECTRON_CLEANUP_REQUIRED', 'An awaited Electron Patris cleanup callback is required.');
+  }
+  if (onError !== undefined && typeof onError !== 'function') {
+    throw new PatrisHostError('ELECTRON_CLEANUP_INVALID', 'Electron cleanup error handling must be a function.');
+  }
+
+  let started = false;
+  let released = false;
+  const beforeQuit = (event) => {
+    if (released) return;
+    if (event && typeof event.preventDefault === 'function') event.preventDefault();
+    if (started) return;
+    started = true;
+    void Promise.resolve()
+      .then(() => cleanup())
+      .catch((error) => {
+        if (!onError) return;
+        try { onError(error); } catch { /* Error reporting must not block quit. */ }
+      })
+      .finally(() => {
+        released = true;
+        app.removeListener('before-quit', beforeQuit);
+        try { app.quit(); }
+        catch (error) {
+          if (onError) {
+            try { onError(error); } catch { /* Error reporting must remain best-effort. */ }
+          }
+        }
+      });
+  };
+  app.on('before-quit', beforeQuit);
+  return () => {
+    if (released) return;
+    released = true;
+    app.removeListener('before-quit', beforeQuit);
   };
 }
 
@@ -58,6 +129,7 @@ function createElectronRendererClient(options = {}) {
 
 module.exports = {
   createElectronRendererClient,
+  registerElectronShutdownBarrier,
   registerElectronPatrisHost,
   sourceUrlFromElectronEvent
 };

--- a/integrations/javascript/src/electron.cjs
+++ b/integrations/javascript/src/electron.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+
+function sourceUrlFromElectronEvent(event) {
+  // sender.getURL() identifies the top-level WebContents, not necessarily the
+  // frame that invoked IPC. Fail closed when Electron cannot identify the
+  // initiating frame so an untrusted subframe cannot inherit its parent's
+  // trusted origin.
+  return String(event && event.senderFrame && event.senderFrame.url || '');
+}
+
+function registerElectronPatrisHost(options = {}) {
+  const ipcMain = options.ipcMain;
+  const host = options.host;
+  const invokeChannel = options.invokeChannel || 'patris:invoke';
+  const statusChannel = options.statusChannel || 'patris:status';
+  if (!ipcMain || typeof ipcMain.handle !== 'function' || typeof ipcMain.removeHandler !== 'function') {
+    throw new PatrisHostError('ELECTRON_IPC_INVALID', 'Electron ipcMain is required.');
+  }
+  if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
+    throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
+  }
+  ipcMain.removeHandler(invokeChannel);
+  ipcMain.removeHandler(statusChannel);
+  ipcMain.handle(invokeChannel, (event, request) => host.handle(sourceUrlFromElectronEvent(event), request));
+  ipcMain.handle(statusChannel, (event, request = {}) => host.handleStatus(sourceUrlFromElectronEvent(event), request.requestId));
+  return () => {
+    ipcMain.removeHandler(invokeChannel);
+    ipcMain.removeHandler(statusChannel);
+  };
+}
+
+function createElectronRendererClient(options = {}) {
+  const invoke = options.invoke;
+  const invokeChannel = options.invokeChannel || 'patris:invoke';
+  const statusChannel = options.statusChannel || 'patris:status';
+  if (typeof invoke !== 'function') throw new PatrisHostError('ELECTRON_IPC_INVALID', 'Electron ipcRenderer.invoke is required.');
+  let nextRequestId = 0;
+  async function safeInvoke(channel, request) {
+    try {
+      return assertEnvelope(await invoke(channel, request));
+    } catch (error) {
+      return errorEnvelope(error, { requestId: request.requestId });
+    }
+  }
+  return Object.freeze({
+    call(method, params = null) {
+      const request = { requestId: ++nextRequestId, method, params };
+      return safeInvoke(invokeChannel, request);
+    },
+    status() {
+      const request = { requestId: ++nextRequestId };
+      return safeInvoke(statusChannel, request);
+    }
+  });
+}
+
+module.exports = {
+  createElectronRendererClient,
+  registerElectronPatrisHost,
+  sourceUrlFromElectronEvent
+};

--- a/integrations/javascript/src/index.cjs
+++ b/integrations/javascript/src/index.cjs
@@ -1,0 +1,32 @@
+'use strict';
+
+const contract = require('./contract.cjs');
+const { PrivilegedPatrisHost, wrapExistingElectronBridge } = require('./privileged-host.cjs');
+const { ExecutableTransport, NativeWorkerTransport, RestTransport } = require('./transports.cjs');
+const electron = require('./electron.cjs');
+const tauri = require('./tauri.cjs');
+const webview2 = require('./webview2.cjs');
+
+function createConfiguredHost(options = {}) {
+  const transports = [];
+  if (options.dll) transports.push(new NativeWorkerTransport(options.dll));
+  if (options.executable) transports.push(new ExecutableTransport(options.executable));
+  if (options.rest && options.rest.baseUrl) transports.push(new RestTransport(options.rest));
+  return new PrivilegedPatrisHost({
+    allowedOrigins: options.allowedOrigins,
+    transports
+  });
+}
+
+module.exports = {
+  ...contract,
+  ...electron,
+  ...tauri,
+  ...webview2,
+  ExecutableTransport,
+  NativeWorkerTransport,
+  PrivilegedPatrisHost,
+  RestTransport,
+  createConfiguredHost,
+  wrapExistingElectronBridge
+};

--- a/integrations/javascript/src/index.d.ts
+++ b/integrations/javascript/src/index.d.ts
@@ -36,6 +36,17 @@ export interface PatrisRendererClient {
   status(): Promise<PatrisResult<PatrisHostStatus>>;
 }
 
+export interface PatrisAuthorizationContext {
+  sourceUrl: string;
+  action: 'invoke' | 'status';
+  method: string | null;
+}
+
+export type PatrisPrivilegedAuthorizer = (
+  event: unknown,
+  context: Readonly<PatrisAuthorizationContext>
+) => boolean | Promise<boolean>;
+
 export interface PatrisHostStatus {
   lifecycle: 'idle' | 'initializing' | 'ready' | 'failed' | 'closing' | 'closed';
   ready: boolean;
@@ -106,8 +117,19 @@ export function registerElectronPatrisHost(options: {
     removeHandler(channel: string): void;
   };
   host: PrivilegedPatrisHost;
+  authorize: PatrisPrivilegedAuthorizer;
   invokeChannel?: string;
   statusChannel?: string;
+}): () => void;
+
+export function registerElectronShutdownBarrier(options: {
+  app: {
+    on(name: 'before-quit', listener: (event: { preventDefault(): void }) => void): void;
+    removeListener(name: 'before-quit', listener: (event: { preventDefault(): void }) => void): void;
+    quit(): void;
+  };
+  cleanup(): void | Promise<void>;
+  onError?(error: unknown): void;
 }): () => void;
 
 export function createTauriRendererClient(options: {
@@ -119,6 +141,7 @@ export function createTauriRendererClient(options: {
 export function createTauriCommandHandlers(options: {
   host: PrivilegedPatrisHost;
   getSourceUrl(event: unknown): string | Promise<string>;
+  authorize: PatrisPrivilegedAuthorizer;
 }): {
   patrisInvoke(event: unknown, request: PatrisRequest): Promise<PatrisResult>;
   patrisStatus(event: unknown, request?: { requestId?: string | number | null }): Promise<PatrisResult<PatrisHostStatus>>;
@@ -138,6 +161,7 @@ export function createWebView2RendererClient(options: {
 export function createWebView2MessageHandler(options: {
   host: PrivilegedPatrisHost;
   getSourceUrl(event: unknown): string | Promise<string>;
+  authorize: PatrisPrivilegedAuthorizer;
   postMessage(payload: unknown, event: unknown): void | Promise<void>;
 }): (event: unknown) => Promise<boolean>;
 

--- a/integrations/javascript/src/index.d.ts
+++ b/integrations/javascript/src/index.d.ts
@@ -1,0 +1,181 @@
+export type PatrisMethod =
+  | 'app.get'
+  | 'records.list'
+  | 'info.get'
+  | 'status.get'
+  | 'config.get'
+  | 'config.set'
+  | 'toast.show'
+  | 'refresh';
+
+export interface PatrisRequest {
+  requestId?: string | number | null;
+  method: PatrisMethod;
+  params?: unknown;
+}
+
+export interface PatrisError {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface PatrisMeta {
+  requestId?: string | number | null;
+  method?: PatrisMethod;
+  mode?: string;
+  origin?: string;
+}
+
+export type PatrisResult<T = unknown> =
+  | { ok: true; result: T; meta: PatrisMeta }
+  | { ok: false; error: PatrisError; meta: PatrisMeta };
+
+export interface PatrisRendererClient {
+  call<T = unknown>(method: PatrisMethod, params?: unknown): Promise<PatrisResult<T>>;
+  status(): Promise<PatrisResult<PatrisHostStatus>>;
+}
+
+export interface PatrisHostStatus {
+  lifecycle: 'idle' | 'initializing' | 'ready' | 'failed' | 'closing' | 'closed';
+  ready: boolean;
+  mode: string;
+  attempts: Array<{ mode: string; code: string; message: string }>;
+}
+
+export interface PatrisTransport {
+  name: string;
+  initialize(): Promise<{ ready: boolean; [key: string]: unknown }>;
+  call(method: PatrisMethod, params?: unknown): Promise<unknown>;
+  close(): Promise<void> | void;
+}
+
+export const ALLOWED_METHODS: readonly PatrisMethod[];
+export const HTTP_METHODS: Readonly<Record<PatrisMethod, readonly [string, string]>>;
+
+export class PatrisHostError extends Error {
+  constructor(code: string, message: string, options?: { retryable?: boolean; cause?: unknown });
+  code: string;
+  retryable: boolean;
+  cause?: unknown;
+}
+
+export function normalizeOrigin(value: unknown): string;
+export function compileOriginAllowlist(origins: string[]): Set<string>;
+export function assertAllowedOrigin(sourceUrl: string, allowlist: ReadonlySet<string>): string;
+export function assertAllowedMethod(method: unknown): PatrisMethod;
+export function assertEnvelope<T = unknown>(value: unknown): PatrisResult<T>;
+export function successEnvelope<T = unknown>(result: T, meta?: PatrisMeta): PatrisResult<T>;
+export function errorEnvelope(error: unknown, meta?: PatrisMeta): PatrisResult<never>;
+
+export class PrivilegedPatrisHost {
+  constructor(options: { allowedOrigins: string[]; transports: PatrisTransport[] });
+  initialize(): Promise<PatrisHostStatus>;
+  status(): PatrisHostStatus;
+  handle(sourceUrl: string, request: { requestId?: string | number; method: PatrisMethod; params?: unknown }): Promise<PatrisResult>;
+  handleStatus(sourceUrl: string, requestId?: string | number | null): Promise<PatrisResult<PatrisHostStatus>>;
+  close(): Promise<PatrisHostStatus>;
+}
+
+export function createConfiguredHost(options: {
+  allowedOrigins: string[];
+  dll?: { addonPath: string; dllPath: string; engineOptions?: Record<string, unknown>; timeoutMs?: number };
+  executable?: { executablePath: string; databasePath: string; watch?: boolean; timeoutMs?: number };
+  rest?: { baseUrl: string; timeoutMs?: number };
+}): PrivilegedPatrisHost;
+
+export function wrapExistingElectronBridge(bridge: {
+  initialize(): Promise<{ ready: boolean; [key: string]: unknown }>;
+  call(method: PatrisMethod, params?: unknown): Promise<unknown>;
+  close?(): Promise<void> | void;
+}): PatrisTransport;
+
+export function createElectronRendererClient(options: {
+  invoke(channel: string, request: unknown): Promise<unknown>;
+  invokeChannel?: string;
+  statusChannel?: string;
+}): PatrisRendererClient;
+
+export function sourceUrlFromElectronEvent(event: {
+  senderFrame?: { url?: string } | null;
+} | null | undefined): string;
+
+export function registerElectronPatrisHost(options: {
+  ipcMain: {
+    handle(channel: string, handler: (event: unknown, request?: unknown) => Promise<PatrisResult>): void;
+    removeHandler(channel: string): void;
+  };
+  host: PrivilegedPatrisHost;
+  invokeChannel?: string;
+  statusChannel?: string;
+}): () => void;
+
+export function createTauriRendererClient(options: {
+  invoke(command: string, args: unknown): Promise<unknown>;
+  invokeCommand?: string;
+  statusCommand?: string;
+}): PatrisRendererClient;
+
+export function createTauriCommandHandlers(options: {
+  host: PrivilegedPatrisHost;
+  getSourceUrl(event: unknown): string | Promise<string>;
+}): {
+  patrisInvoke(event: unknown, request: PatrisRequest): Promise<PatrisResult>;
+  patrisStatus(event: unknown, request?: { requestId?: string | number | null }): Promise<PatrisResult<PatrisHostStatus>>;
+};
+
+export interface WebView2RendererBridge {
+  postMessage(value: unknown): void;
+  addEventListener(name: 'message', listener: (event: { data: unknown }) => void): void;
+  removeEventListener?(name: 'message', listener: (event: { data: unknown }) => void): void;
+}
+
+export function createWebView2RendererClient(options: {
+  webview: WebView2RendererBridge;
+  timeoutMs?: number;
+}): PatrisRendererClient & { dispose(): void };
+
+export function createWebView2MessageHandler(options: {
+  host: PrivilegedPatrisHost;
+  getSourceUrl(event: unknown): string | Promise<string>;
+  postMessage(payload: unknown, event: unknown): void | Promise<void>;
+}): (event: unknown) => Promise<boolean>;
+
+export class RestTransport implements PatrisTransport {
+  constructor(options: { baseUrl: string; name?: string; timeoutMs?: number; fetchImpl?: Function });
+  name: string;
+  initialize(): Promise<{ ready: boolean; [key: string]: unknown }>;
+  call(method: PatrisMethod, params?: unknown): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export class ExecutableTransport implements PatrisTransport {
+  constructor(options: {
+    executablePath: string;
+    databasePath: string;
+    watch?: boolean;
+    timeoutMs?: number;
+    startupAttempts?: number;
+    startupDelayMs?: number;
+    stopTimeoutMs?: number;
+  });
+  name: string;
+  initialize(): Promise<{ ready: boolean; [key: string]: unknown }>;
+  call(method: PatrisMethod, params?: unknown): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export class NativeWorkerTransport implements PatrisTransport {
+  constructor(options: {
+    addonPath: string;
+    dllPath: string;
+    engineOptions?: Record<string, unknown>;
+    workerPath?: string;
+    timeoutMs?: number;
+    stopTimeoutMs?: number;
+  });
+  name: string;
+  initialize(): Promise<{ ready: boolean; [key: string]: unknown }>;
+  call(method: PatrisMethod, params?: unknown): Promise<unknown>;
+  close(): Promise<void>;
+}

--- a/integrations/javascript/src/native-worker.cjs
+++ b/integrations/javascript/src/native-worker.cjs
@@ -1,0 +1,110 @@
+'use strict';
+
+const path = require('node:path');
+
+const { ALLOWED_METHODS, assertAllowedMethod } = require('./contract.cjs');
+
+let addon = null;
+let handle = null;
+let version = null;
+let capabilities = null;
+let chain = Promise.resolve();
+
+function typedError(error, code = 'NATIVE_ERROR') {
+  return {
+    code: String(error && error.code || code),
+    message: String(error && error.message || error || 'Patris native worker failed.'),
+    retryable: false
+  };
+}
+
+function parseJSON(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const wrapped = new Error(`${label} returned invalid JSON: ${error.message}`);
+    wrapped.code = 'INVALID_RESPONSE';
+    throw wrapped;
+  }
+}
+
+function initialize(payload = {}) {
+  const addonPath = path.resolve(String(payload.addonPath || ''));
+  addon = require(addonPath);
+  const dllPath = path.resolve(String(payload.dllPath || ''));
+  version = parseJSON(addon.patrisVersion(dllPath), 'PatrisExportVersionJSON');
+  const abiVersion = Number(addon.patrisABI(dllPath));
+  if (abiVersion !== 1) {
+    const error = new Error(`Unsupported Patris Export ABI version ${abiVersion}; this bridge supports ABI 1.`);
+    error.code = 'ABI_UNSUPPORTED';
+    throw error;
+  }
+  capabilities = parseJSON(addon.patrisCapabilities(dllPath), 'PatrisExportCapabilitiesJSON');
+  const methods = Array.isArray(capabilities.rpc_methods) ? capabilities.rpc_methods : [];
+  for (const method of ALLOWED_METHODS) {
+    if (!methods.includes(method)) {
+      const error = new Error(`Patris DLL capabilities are missing required method ${method}.`);
+      error.code = 'ABI_CAPABILITY_MISMATCH';
+      throw error;
+    }
+  }
+  const options = payload.options || {};
+  const configured = !!options.database_path || (Array.isArray(options.config_files) && options.config_files.length > 0);
+  if (configured) handle = addon.patrisCreate(dllPath, JSON.stringify(options));
+  return { ready: !!handle, configured, version, abiVersion, capabilities };
+}
+
+function call(payload = {}, id) {
+  if (!handle) {
+    const error = new Error('Patris DLL is loaded but no engine is configured.');
+    error.code = 'RUNTIME_NOT_CONFIGURED';
+    throw error;
+  }
+  const method = assertAllowedMethod(payload.method);
+  const response = parseJSON(addon.patrisCall(handle, JSON.stringify({
+    id,
+    method,
+    params: payload.params ?? null
+  })), 'PatrisExportCall');
+  if (!response || response.ok !== true) {
+    const error = new Error(response && response.error || `Patris ${method} failed.`);
+    error.code = 'NATIVE_CALL_FAILED';
+    throw error;
+  }
+  return response.result ?? null;
+}
+
+function close() {
+  if (handle) addon.patrisClose(handle);
+  handle = null;
+  return { closed: true };
+}
+
+function dispatch(message) {
+  switch (message.action) {
+    case 'init': return initialize(message.payload);
+    case 'call': return call(message.payload, message.id);
+    case 'close': return close();
+    default: {
+      const error = new Error(`Unknown Patris native worker action: ${message.action}`);
+      error.code = 'WORKER_ACTION_INVALID';
+      throw error;
+    }
+  }
+}
+
+process.on('message', (message = {}) => {
+  chain = chain
+    .then(() => dispatch(message))
+    .then((result) => process.send && process.send({ id: message.id, ok: true, result }))
+    .catch((error) => process.send && process.send({ id: message.id, ok: false, error: typedError(error) }));
+});
+
+process.on('disconnect', () => {
+  try { close(); } catch (_) {}
+  process.exit(0);
+});
+
+process.on('exit', () => {
+  try { close(); } catch (_) {}
+});

--- a/integrations/javascript/src/privileged-host.cjs
+++ b/integrations/javascript/src/privileged-host.cjs
@@ -1,0 +1,195 @@
+'use strict';
+
+const {
+  PatrisHostError,
+  assertAllowedMethod,
+  assertAllowedOrigin,
+  compileOriginAllowlist,
+  errorEnvelope,
+  successEnvelope
+} = require('./contract.cjs');
+
+function transportName(transport) {
+  return String(transport && (transport.mode || transport.name) || 'unknown');
+}
+
+function asTransportError(error, fallbackCode = 'RUNTIME_START_FAILED') {
+  if (error instanceof PatrisHostError) return error;
+  return new PatrisHostError(fallbackCode, error && error.message ? error.message : String(error), {
+    cause: error,
+    retryable: true
+  });
+}
+
+class PrivilegedPatrisHost {
+  constructor(options = {}) {
+    this.allowedOrigins = compileOriginAllowlist(options.allowedOrigins);
+    this.transports = Array.isArray(options.transports) ? options.transports.filter(Boolean) : [];
+    this.activeTransport = null;
+    this.lifecycle = 'idle';
+    this.attempts = [];
+    this.initializePromise = null;
+    this.closePromise = null;
+    this.inflight = new Set();
+    this.nextRequestId = 0;
+  }
+
+  status() {
+    return Object.freeze({
+      lifecycle: this.lifecycle,
+      ready: this.lifecycle === 'ready' && !!this.activeTransport,
+      mode: this.activeTransport ? transportName(this.activeTransport) : 'unavailable',
+      attempts: this.attempts.map((attempt) => ({ ...attempt }))
+    });
+  }
+
+  async initialize() {
+    if (this.lifecycle === 'closed') {
+      throw new PatrisHostError('HOST_CLOSED', 'The Patris host has already been closed.');
+    }
+    if (this.lifecycle === 'closing') {
+      throw new PatrisHostError('HOST_CLOSING', 'The Patris host is closing.');
+    }
+    if (this.activeTransport && this.lifecycle === 'ready') return this.status();
+    if (this.initializePromise) return this.initializePromise;
+
+    this.lifecycle = 'initializing';
+    this.initializePromise = this.initializeTransports();
+    try {
+      return await this.initializePromise;
+    } finally {
+      this.initializePromise = null;
+    }
+  }
+
+  async initializeTransports() {
+    this.attempts = [];
+    for (const transport of this.transports) {
+      const mode = transportName(transport);
+      try {
+        const state = await transport.initialize();
+        if (state && state.ready === false) {
+          throw new PatrisHostError('RUNTIME_NOT_CONFIGURED', `${mode} runtime is installed but not configured.`);
+        }
+        if (this.lifecycle === 'closing' || this.lifecycle === 'closed') {
+          await Promise.resolve(transport.close && transport.close()).catch(() => {});
+          throw new PatrisHostError('HOST_CLOSING', 'The Patris host started closing during initialization.');
+        }
+        this.activeTransport = transport;
+        this.lifecycle = 'ready';
+        return this.status();
+      } catch (error) {
+        const typed = asTransportError(error);
+        this.attempts.push(Object.freeze({ mode, code: typed.code, message: typed.message }));
+        await Promise.resolve(transport.close && transport.close()).catch(() => {});
+        if (this.lifecycle === 'closing' || this.lifecycle === 'closed') throw typed;
+      }
+    }
+    this.lifecycle = 'failed';
+    throw new PatrisHostError(
+      'RUNTIME_UNAVAILABLE',
+      this.attempts.length
+        ? 'No configured Patris runtime could be started.'
+        : 'No Patris DLL, executable, or REST runtime is configured.',
+      { retryable: true }
+    );
+  }
+
+  async handle(sourceUrl, request = {}) {
+    const requestId = request.requestId === undefined || request.requestId === null
+      ? ++this.nextRequestId
+      : request.requestId;
+    let origin = '';
+    let method = '';
+    let operation = null;
+    let transport = null;
+    try {
+      origin = assertAllowedOrigin(sourceUrl, this.allowedOrigins);
+      method = assertAllowedMethod(request.method);
+      if (this.lifecycle === 'closing') {
+        throw new PatrisHostError('HOST_CLOSING', 'The Patris host is closing.');
+      }
+      if (this.lifecycle === 'closed') {
+        throw new PatrisHostError('HOST_CLOSED', 'The Patris host has already been closed.');
+      }
+
+      // Register the whole initialize-and-call operation before yielding. This
+      // makes the request part of the close barrier even when the transport was
+      // already ready and initialize() resolves on the next microtask.
+      operation = (async () => {
+        await this.initialize();
+        transport = this.activeTransport;
+        if (!transport) {
+          throw new PatrisHostError('NOT_READY', 'The Patris runtime is not ready.', { retryable: true });
+        }
+        return transport.call(method, request.params ?? null);
+      })();
+      this.inflight.add(operation);
+      const result = await operation;
+      return successEnvelope(result, { requestId, method, mode: transportName(transport) });
+    } catch (error) {
+      return errorEnvelope(error, {
+        requestId,
+        ...(method ? { method } : {}),
+        ...(transport || this.activeTransport ? { mode: transportName(transport || this.activeTransport) } : {}),
+        ...(origin ? { origin } : {})
+      });
+    } finally {
+      if (operation) this.inflight.delete(operation);
+    }
+  }
+
+  async handleStatus(sourceUrl, requestId = null) {
+    try {
+      assertAllowedOrigin(sourceUrl, this.allowedOrigins);
+      return successEnvelope(this.status(), { requestId });
+    } catch (error) {
+      return errorEnvelope(error, { requestId });
+    }
+  }
+
+  async close() {
+    if (this.closePromise) return this.closePromise;
+    if (this.lifecycle === 'closed') return this.status();
+    this.lifecycle = 'closing';
+    this.closePromise = (async () => {
+      if (this.initializePromise) await this.initializePromise.catch(() => {});
+      await Promise.allSettled(Array.from(this.inflight));
+      const active = this.activeTransport;
+      this.activeTransport = null;
+      try {
+        if (active && typeof active.close === 'function') await active.close();
+      } catch (error) {
+        throw asTransportError(error, 'RUNTIME_CLOSE_FAILED');
+      } finally {
+        this.lifecycle = 'closed';
+      }
+      return this.status();
+    })();
+    return this.closePromise;
+  }
+}
+
+function wrapExistingElectronBridge(bridge) {
+  if (!bridge || typeof bridge.initialize !== 'function' || typeof bridge.call !== 'function') {
+    throw new PatrisHostError('BRIDGE_INVALID', 'The existing Electron PatrisBridge instance is invalid.');
+  }
+  return {
+    name: 'electron-bridge',
+    async initialize() {
+      const state = await bridge.initialize();
+      return { ...state, ready: state && state.ready === true };
+    },
+    call(method, params) {
+      return bridge.call(method, params);
+    },
+    close() {
+      return typeof bridge.close === 'function' ? bridge.close() : undefined;
+    }
+  };
+}
+
+module.exports = {
+  PrivilegedPatrisHost,
+  wrapExistingElectronBridge
+};

--- a/integrations/javascript/src/tauri.cjs
+++ b/integrations/javascript/src/tauri.cjs
@@ -1,6 +1,14 @@
 'use strict';
 
-const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+const {
+  PatrisHostError,
+  assertEnvelope,
+  errorEnvelope
+} = require('./contract.cjs');
+const {
+  isPrivilegedCallAuthorized,
+  requirePrivilegedAuthorizer
+} = require('./authorization.cjs');
 
 function createTauriRendererClient(options = {}) {
   const invoke = options.invoke;
@@ -30,18 +38,35 @@ function createTauriRendererClient(options = {}) {
 function createTauriCommandHandlers(options = {}) {
   const host = options.host;
   const getSourceUrl = options.getSourceUrl;
+  const authorize = options.authorize;
   if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
     throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
   }
   if (typeof getSourceUrl !== 'function') {
     throw new PatrisHostError('TAURI_ORIGIN_INVALID', 'A privileged Tauri source-URL resolver is required.');
   }
+  requirePrivilegedAuthorizer(authorize, 'TAURI_AUTHORIZER_REQUIRED', 'A privileged Tauri session/capability authorizer is required.');
+  async function authorized(event, request, action) {
+    let sourceUrl = '';
+    try { sourceUrl = String(await getSourceUrl(event) || ''); } catch { sourceUrl = ''; }
+    const requestId = request && request.requestId;
+    const method = action === 'invoke' && request ? String(request.method || '') : null;
+    if (!await isPrivilegedCallAuthorized(authorize, event, { sourceUrl, action, method })) {
+      return errorEnvelope(new PatrisHostError(
+        'TAURI_NOT_AUTHORIZED',
+        'The current host session is not authorized to use Patris Export.'
+      ), { requestId });
+    }
+    return action === 'status'
+      ? host.handleStatus(sourceUrl, requestId)
+      : host.handle(sourceUrl, request);
+  }
   return Object.freeze({
     async patrisInvoke(event, request) {
-      return host.handle(await getSourceUrl(event), request);
+      return authorized(event, request || {}, 'invoke');
     },
     async patrisStatus(event, request = {}) {
-      return host.handleStatus(await getSourceUrl(event), request.requestId);
+      return authorized(event, request, 'status');
     }
   });
 }

--- a/integrations/javascript/src/tauri.cjs
+++ b/integrations/javascript/src/tauri.cjs
@@ -1,0 +1,52 @@
+'use strict';
+
+const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+
+function createTauriRendererClient(options = {}) {
+  const invoke = options.invoke;
+  const invokeCommand = options.invokeCommand || 'patris_invoke';
+  const statusCommand = options.statusCommand || 'patris_status';
+  if (typeof invoke !== 'function') throw new PatrisHostError('TAURI_INVOKE_INVALID', 'Tauri invoke() is required.');
+  let nextRequestId = 0;
+  async function safeInvoke(command, request) {
+    try {
+      return assertEnvelope(await invoke(command, { request }));
+    } catch (error) {
+      return errorEnvelope(error, { requestId: request.requestId });
+    }
+  }
+  return Object.freeze({
+    call(method, params = null) {
+      const request = { requestId: ++nextRequestId, method, params };
+      return safeInvoke(invokeCommand, request);
+    },
+    status() {
+      const request = { requestId: ++nextRequestId };
+      return safeInvoke(statusCommand, request);
+    }
+  });
+}
+
+function createTauriCommandHandlers(options = {}) {
+  const host = options.host;
+  const getSourceUrl = options.getSourceUrl;
+  if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
+    throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
+  }
+  if (typeof getSourceUrl !== 'function') {
+    throw new PatrisHostError('TAURI_ORIGIN_INVALID', 'A privileged Tauri source-URL resolver is required.');
+  }
+  return Object.freeze({
+    async patrisInvoke(event, request) {
+      return host.handle(await getSourceUrl(event), request);
+    },
+    async patrisStatus(event, request = {}) {
+      return host.handleStatus(await getSourceUrl(event), request.requestId);
+    }
+  });
+}
+
+module.exports = {
+  createTauriCommandHandlers,
+  createTauriRendererClient
+};

--- a/integrations/javascript/src/transports.cjs
+++ b/integrations/javascript/src/transports.cjs
@@ -1,0 +1,321 @@
+'use strict';
+
+const fs = require('node:fs');
+const net = require('node:net');
+const path = require('node:path');
+const { fork, spawn } = require('node:child_process');
+
+const { HTTP_METHODS, PatrisHostError, assertAllowedMethod } = require('./contract.cjs');
+
+function requiredFile(filePath, label) {
+  const value = String(filePath || '').trim();
+  if (!value || !fs.existsSync(value)) {
+    throw new PatrisHostError('RUNTIME_MISSING', `${label} was not found.`, { retryable: true });
+  }
+  return path.resolve(value);
+}
+
+function normalizedBaseUrl(value) {
+  let parsed;
+  try {
+    parsed = new URL(String(value || ''));
+  } catch (error) {
+    throw new PatrisHostError('REST_URL_INVALID', 'The Patris REST base URL must be an absolute HTTP(S) URL.', { cause: error });
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+    throw new PatrisHostError('REST_URL_INVALID', 'The Patris REST base URL must be HTTP(S) and must not contain credentials.');
+  }
+  parsed.hash = '';
+  parsed.search = '';
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function timeoutSignal(timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer.unref === 'function') timer.unref();
+  return { signal: controller.signal, cancel: () => clearTimeout(timer) };
+}
+
+class RestTransport {
+  constructor(options = {}) {
+    this.name = options.name || 'rest';
+    this.baseUrl = normalizedBaseUrl(options.baseUrl);
+    this.fetchImpl = options.fetchImpl || globalThis.fetch;
+    this.timeoutMs = Number(options.timeoutMs || 30000);
+    this.ready = false;
+    if (typeof this.fetchImpl !== 'function') {
+      throw new PatrisHostError('FETCH_UNAVAILABLE', 'This privileged host does not provide fetch().');
+    }
+  }
+
+  async initialize() {
+    const app = await this.call('app.get', null, Math.min(this.timeoutMs, 5000));
+    if (!app || app.name !== 'Patris Export') {
+      throw new PatrisHostError('REST_IDENTITY_MISMATCH', 'The configured endpoint did not identify itself as Patris Export.');
+    }
+    this.ready = true;
+    return { ready: true, mode: this.name, app };
+  }
+
+  async call(method, params = null, timeoutMs = this.timeoutMs) {
+    const allowed = assertAllowedMethod(method);
+    const route = HTTP_METHODS[allowed];
+    const timeout = timeoutSignal(timeoutMs);
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${route[1]}`, {
+        method: route[0],
+        headers: route[0] === 'GET' ? { Accept: 'application/json' } : {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: route[0] === 'GET' ? undefined : JSON.stringify(params || {}),
+        signal: timeout.signal,
+        redirect: 'error'
+      });
+      if (!response || typeof response.ok !== 'boolean') {
+        throw new PatrisHostError('INVALID_RESPONSE', 'The Patris REST transport returned an invalid response.');
+      }
+      if (!response.ok) {
+        throw new PatrisHostError('HTTP_ERROR', `Patris REST returned HTTP ${response.status}.`, {
+          retryable: response.status >= 500
+        });
+      }
+      try {
+        return await response.json();
+      } catch (error) {
+        throw new PatrisHostError('INVALID_RESPONSE', 'The Patris REST response was not valid JSON.', { cause: error });
+      }
+    } catch (error) {
+      if (error instanceof PatrisHostError) throw error;
+      if (error && error.name === 'AbortError') {
+        throw new PatrisHostError('TIMEOUT', `Patris REST ${allowed} timed out.`, { cause: error, retryable: true });
+      }
+      throw new PatrisHostError('REST_UNAVAILABLE', error && error.message ? error.message : 'Patris REST is unavailable.', {
+        cause: error,
+        retryable: true
+      });
+    } finally {
+      timeout.cancel();
+    }
+  }
+
+  async close() {
+    this.ready = false;
+  }
+}
+
+function reserveLoopbackAddress() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close((error) => error ? reject(error) : resolve(`127.0.0.1:${address.port}`));
+    });
+  });
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, milliseconds);
+    if (typeof timer.unref === 'function') timer.unref();
+  });
+}
+
+async function stopChild(child, timeoutMs = 5000) {
+  // child.killed only means a signal was sent; the process may still be alive.
+  // Wait for an actual exit so close() does not report completion early.
+  if (!child) return;
+  const hasExited = child.exitCode !== null && child.exitCode !== undefined;
+  const hasSignalExit = child.signalCode !== null && child.signalCode !== undefined;
+  if (hasExited || hasSignalExit) return;
+  await new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(forceTimer);
+      child.removeListener('exit', finish);
+      resolve();
+    };
+    child.once('exit', finish);
+    const forceTimer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch (_) {}
+      finish();
+    }, timeoutMs);
+    try { child.kill(); } catch (_) { finish(); }
+  });
+}
+
+async function startExecutableSidecar(options) {
+  const executablePath = requiredFile(options.executablePath, 'Patris executable');
+  const databasePath = requiredFile(options.databasePath, 'Patris database');
+  const address = await reserveLoopbackAddress();
+  const child = (options.spawnImpl || spawn)(executablePath, [
+    'serve',
+    databasePath,
+    '--addr', address,
+    `--watch=${options.watch === false ? 'false' : 'true'}`,
+    '--ipc=false'
+  ], {
+    cwd: path.dirname(executablePath),
+    windowsHide: true,
+    stdio: 'ignore'
+  });
+  let startupError = null;
+  child.once('error', (error) => { startupError = error; });
+  child.once('exit', (code, signal) => {
+    startupError = new Error(`Patris executable exited with code ${code ?? 'none'}${signal ? ` (${signal})` : ''}.`);
+  });
+  return {
+    baseUrl: `http://${address}`,
+    startupError: () => startupError,
+    close: () => stopChild(child, Number(options.stopTimeoutMs || 5000))
+  };
+}
+
+class ExecutableTransport {
+  constructor(options = {}) {
+    this.name = 'executable';
+    this.options = { ...options };
+    this.startSidecar = options.startSidecar || startExecutableSidecar;
+    this.sidecar = null;
+    this.rest = null;
+  }
+
+  async initialize() {
+    this.sidecar = await this.startSidecar(this.options);
+    this.rest = new RestTransport({
+      name: 'executable',
+      baseUrl: this.sidecar.baseUrl,
+      fetchImpl: this.options.fetchImpl,
+      timeoutMs: this.options.timeoutMs || 30000
+    });
+    const attempts = Number(this.options.startupAttempts || 40);
+    const delayMs = Number(this.options.startupDelayMs || 250);
+    let lastError = null;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const startupError = this.sidecar.startupError && this.sidecar.startupError();
+      if (startupError) throw new PatrisHostError('EXECUTABLE_EXITED', startupError.message, { cause: startupError, retryable: true });
+      try {
+        const state = await this.rest.initialize();
+        return { ...state, mode: this.name };
+      } catch (error) {
+        lastError = error;
+        if (attempt + 1 < attempts) await sleep(delayMs);
+      }
+    }
+    throw new PatrisHostError(
+      'EXECUTABLE_START_TIMEOUT',
+      `Patris executable started but its loopback API did not become ready${lastError ? `: ${lastError.message}` : '.'}`,
+      { cause: lastError, retryable: true }
+    );
+  }
+
+  call(method, params) {
+    if (!this.rest) throw new PatrisHostError('NOT_READY', 'The Patris executable transport is not ready.');
+    return this.rest.call(method, params);
+  }
+
+  async close() {
+    if (this.rest) await this.rest.close();
+    this.rest = null;
+    if (this.sidecar && typeof this.sidecar.close === 'function') await this.sidecar.close();
+    this.sidecar = null;
+  }
+}
+
+class NativeWorkerTransport {
+  constructor(options = {}) {
+    this.name = 'dll';
+    this.options = { ...options };
+    this.worker = null;
+    this.pending = new Map();
+    this.nextId = 0;
+    this.requestTimeoutMs = Number(options.timeoutMs || 30000);
+    this.workerPath = path.resolve(options.workerPath || path.join(__dirname, 'native-worker.cjs'));
+  }
+
+  async initialize() {
+    const addonPath = requiredFile(this.options.addonPath, 'Patris Node-API bridge');
+    const dllPath = requiredFile(this.options.dllPath, 'Patris DLL');
+    const forkImpl = this.options.forkImpl || fork;
+    this.worker = forkImpl(this.workerPath, [], {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      windowsHide: true,
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc']
+    });
+    this.worker.on('message', (message) => this.onMessage(message));
+    this.worker.once('error', (error) => this.onWorkerFailure(error));
+    this.worker.once('exit', (code, signal) => {
+      this.onWorkerFailure(new Error(`Patris native worker exited with code ${code ?? 'none'}${signal ? ` (${signal})` : ''}.`));
+    });
+    const result = await this.request('init', {
+      addonPath,
+      dllPath,
+      options: this.options.engineOptions || {}
+    });
+    if (!result.ready) {
+      throw new PatrisHostError('RUNTIME_NOT_CONFIGURED', 'Patris DLL loaded, but no database or config file was supplied.');
+    }
+    return { ...result, mode: this.name };
+  }
+
+  onMessage(message) {
+    const pending = message && this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.ok) pending.resolve(message.result);
+    else pending.reject(new PatrisHostError(message.error && message.error.code || 'NATIVE_ERROR', message.error && message.error.message || 'Patris native call failed.'));
+  }
+
+  onWorkerFailure(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new PatrisHostError('NATIVE_WORKER_EXITED', error.message, { cause: error, retryable: true }));
+    }
+    this.pending.clear();
+    this.worker = null;
+  }
+
+  request(action, payload) {
+    if (!this.worker || !this.worker.connected) {
+      return Promise.reject(new PatrisHostError('NOT_READY', 'The Patris native worker is not running.'));
+    }
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new PatrisHostError('TIMEOUT', `Patris native ${action} timed out.`, { retryable: true }));
+      }, this.requestTimeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.worker.send({ id, action, payload });
+    });
+  }
+
+  call(method, params) {
+    return this.request('call', { method: assertAllowedMethod(method), params: params ?? null });
+  }
+
+  async close() {
+    const worker = this.worker;
+    if (!worker) return;
+    try { await this.request('close', {}); } catch (_) {}
+    this.worker = null;
+    await stopChild(worker, Number(this.options.stopTimeoutMs || 5000));
+  }
+}
+
+module.exports = {
+  ExecutableTransport,
+  NativeWorkerTransport,
+  RestTransport,
+  normalizedBaseUrl,
+  reserveLoopbackAddress,
+  startExecutableSidecar,
+  stopChild
+};

--- a/integrations/javascript/src/webview2.cjs
+++ b/integrations/javascript/src/webview2.cjs
@@ -1,6 +1,14 @@
 'use strict';
 
-const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+const {
+  PatrisHostError,
+  assertEnvelope,
+  errorEnvelope
+} = require('./contract.cjs');
+const {
+  isPrivilegedCallAuthorized,
+  requirePrivilegedAuthorizer
+} = require('./authorization.cjs');
 
 function createWebView2RendererClient(options = {}) {
   const webview = options.webview;
@@ -35,7 +43,17 @@ function createWebView2RendererClient(options = {}) {
         }));
       }, timeoutMs);
       pending.set(request.requestId, { resolve, timer });
-      webview.postMessage({ channel: 'patris:request', action, request });
+      try {
+        webview.postMessage({ channel: 'patris:request', action, request });
+      } catch (error) {
+        pending.delete(request.requestId);
+        clearTimeout(timer);
+        resolve(errorEnvelope(new PatrisHostError(
+          'WEBVIEW2_SEND_FAILED',
+          'The WebView2 native bridge could not accept the Patris request.',
+          { retryable: true, cause: error }
+        ), { requestId: request.requestId }));
+      }
     });
   }
 
@@ -63,22 +81,38 @@ function createWebView2MessageHandler(options = {}) {
   const host = options.host;
   const getSourceUrl = options.getSourceUrl;
   const postMessage = options.postMessage;
+  const authorize = options.authorize;
   if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
     throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
   }
   if (typeof getSourceUrl !== 'function' || typeof postMessage !== 'function') {
     throw new PatrisHostError('WEBVIEW2_HOST_INVALID', 'Privileged WebView2 source-URL and postMessage adapters are required.');
   }
+  requirePrivilegedAuthorizer(authorize, 'WEBVIEW2_AUTHORIZER_REQUIRED', 'A privileged WebView2 session/capability authorizer is required.');
   return async function handleWebMessage(event) {
     const payload = event && event.data;
     if (!payload || payload.channel !== 'patris:request' || !payload.request) return false;
-    const sourceUrl = await getSourceUrl(event);
-    const envelope = payload.action === 'status'
-      ? await host.handleStatus(sourceUrl, payload.request.requestId)
-      : await host.handle(sourceUrl, payload.request);
+    const requestId = payload.request.requestId;
+    const action = payload.action === 'status' ? 'status' : payload.action === 'invoke' ? 'invoke' : 'invalid';
+    const method = action === 'invoke' ? String(payload.request.method || '') : null;
+    let sourceUrl = '';
+    try { sourceUrl = String(await getSourceUrl(event) || ''); } catch { sourceUrl = ''; }
+    let envelope;
+    if (action === 'invalid') {
+      envelope = errorEnvelope(new PatrisHostError('WEBVIEW2_REQUEST_INVALID', 'The WebView2 Patris request action is invalid.'), { requestId });
+    } else if (!await isPrivilegedCallAuthorized(authorize, event, { sourceUrl, action, method })) {
+      envelope = errorEnvelope(new PatrisHostError(
+        'WEBVIEW2_NOT_AUTHORIZED',
+        'The current host session is not authorized to use Patris Export.'
+      ), { requestId });
+    } else {
+      envelope = action === 'status'
+        ? await host.handleStatus(sourceUrl, requestId)
+        : await host.handle(sourceUrl, payload.request);
+    }
     await postMessage({
       channel: 'patris:result',
-      requestId: payload.request.requestId,
+      requestId,
       envelope
     }, event);
     return true;

--- a/integrations/javascript/src/webview2.cjs
+++ b/integrations/javascript/src/webview2.cjs
@@ -1,0 +1,91 @@
+'use strict';
+
+const { PatrisHostError, assertEnvelope, errorEnvelope } = require('./contract.cjs');
+
+function createWebView2RendererClient(options = {}) {
+  const webview = options.webview;
+  const timeoutMs = Number(options.timeoutMs || 30000);
+  if (!webview || typeof webview.postMessage !== 'function' || typeof webview.addEventListener !== 'function') {
+    throw new PatrisHostError('WEBVIEW2_INVALID', 'window.chrome.webview is required.');
+  }
+  let nextRequestId = 0;
+  let disposed = false;
+  const pending = new Map();
+
+  function onMessage(event) {
+    const payload = event && event.data;
+    if (!payload || payload.channel !== 'patris:result') return;
+    const item = pending.get(payload.requestId);
+    if (!item) return;
+    pending.delete(payload.requestId);
+    clearTimeout(item.timer);
+    try { item.resolve(assertEnvelope(payload.envelope)); }
+    catch (error) { item.resolve(errorEnvelope(error, { requestId: payload.requestId })); }
+  }
+
+  webview.addEventListener('message', onMessage);
+
+  function send(action, request) {
+    if (disposed) return Promise.resolve(errorEnvelope(new PatrisHostError('CLIENT_DISPOSED', 'The WebView2 Patris client is disposed.'), { requestId: request.requestId }));
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        pending.delete(request.requestId);
+        resolve(errorEnvelope(new PatrisHostError('TIMEOUT', `WebView2 Patris ${action} timed out.`, { retryable: true }), {
+          requestId: request.requestId
+        }));
+      }, timeoutMs);
+      pending.set(request.requestId, { resolve, timer });
+      webview.postMessage({ channel: 'patris:request', action, request });
+    });
+  }
+
+  return Object.freeze({
+    call(method, params = null) {
+      return send('invoke', { requestId: ++nextRequestId, method, params });
+    },
+    status() {
+      return send('status', { requestId: ++nextRequestId });
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (typeof webview.removeEventListener === 'function') webview.removeEventListener('message', onMessage);
+      for (const [requestId, item] of pending) {
+        clearTimeout(item.timer);
+        item.resolve(errorEnvelope(new PatrisHostError('CLIENT_DISPOSED', 'The WebView2 Patris client was disposed.'), { requestId }));
+      }
+      pending.clear();
+    }
+  });
+}
+
+function createWebView2MessageHandler(options = {}) {
+  const host = options.host;
+  const getSourceUrl = options.getSourceUrl;
+  const postMessage = options.postMessage;
+  if (!host || typeof host.handle !== 'function' || typeof host.handleStatus !== 'function') {
+    throw new PatrisHostError('HOST_INVALID', 'A privileged Patris host is required.');
+  }
+  if (typeof getSourceUrl !== 'function' || typeof postMessage !== 'function') {
+    throw new PatrisHostError('WEBVIEW2_HOST_INVALID', 'Privileged WebView2 source-URL and postMessage adapters are required.');
+  }
+  return async function handleWebMessage(event) {
+    const payload = event && event.data;
+    if (!payload || payload.channel !== 'patris:request' || !payload.request) return false;
+    const sourceUrl = await getSourceUrl(event);
+    const envelope = payload.action === 'status'
+      ? await host.handleStatus(sourceUrl, payload.request.requestId)
+      : await host.handle(sourceUrl, payload.request);
+    await postMessage({
+      channel: 'patris:result',
+      requestId: payload.request.requestId,
+      envelope
+    }, event);
+    return true;
+  };
+}
+
+module.exports = {
+  createWebView2MessageHandler,
+  createWebView2RendererClient
+};

--- a/integrations/javascript/test/hosts.test.cjs
+++ b/integrations/javascript/test/hosts.test.cjs
@@ -2,9 +2,11 @@
 
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
+const vm = require('node:vm');
 
 const {
   ALLOWED_METHODS,
@@ -18,9 +20,10 @@ const {
   createTauriRendererClient,
   createWebView2MessageHandler,
   createWebView2RendererClient,
+  registerElectronShutdownBarrier,
   registerElectronPatrisHost,
   wrapExistingElectronBridge
-} = require('../src/index.cjs');
+} = require('..');
 const { stopChild } = require('../src/transports.cjs');
 
 const TRUSTED_ORIGIN = 'https://digitalogic.ir';
@@ -66,7 +69,7 @@ test('initialization falls back DLL to executable without duplicating a request'
       transport('dll', { initialize: async () => { throw new Error('DLL unavailable'); } }),
       transport('executable', {
         call: async (method) => method === 'records.list'
-          ? [{ code: '1001', name: 'Module', final_price: '150000' }]
+          ? { '1001': { name: 'Module', final_price: '150000' } }
           : { method }
       }),
       transport('rest', { initialize: async () => { remoteInitializations += 1; return { ready: true }; } })
@@ -75,7 +78,8 @@ test('initialization falls back DLL to executable without duplicating a request'
   const result = await host.handle(`${TRUSTED_ORIGIN}/panel/`, { method: 'records.list', requestId: 'records-1' });
   assert.equal(result.ok, true);
   assert.equal(result.meta.mode, 'executable');
-  assert.equal(result.result[0].final_price, '150000');
+  assert.equal(result.result['1001'].final_price, '150000');
+  assert.equal(Object.hasOwn(result.result['1001'], 'Code'), false);
   assert.equal(remoteInitializations, 0);
   assert.deepEqual(host.status().attempts.map((item) => item.mode), ['dll']);
   await host.close();
@@ -113,7 +117,7 @@ test('close waits for concurrent calls and rejects new work while closing', asyn
   assert.equal(rejected.error.code, 'HOST_CLOSING');
   assert.equal(closed, false);
   calls[1].resolve({ status: 'ok' });
-  calls[0].resolve([{ code: '1001' }]);
+  calls[0].resolve({ '1001': { name: 'Module' } });
   assert.equal((await first).ok, true);
   assert.equal((await second).ok, true);
   await closing;
@@ -126,7 +130,7 @@ test('close waits for a ready-host call admitted on the initialize microtask bou
   const host = new PrivilegedPatrisHost({
     allowedOrigins: [TRUSTED_ORIGIN],
     transports: [transport('dll', {
-      call: async () => [{ code: 'RACE-SAFE' }],
+      call: async () => ({ 'RACE-SAFE': { name: 'Module' } }),
       close: async () => { closed = true; }
     })]
   });
@@ -137,7 +141,7 @@ test('close waits for a ready-host call admitted on the initialize microtask bou
   const result = await request;
 
   assert.equal(result.ok, true);
-  assert.equal(result.result[0].code, 'RACE-SAFE');
+  assert.equal(result.result['RACE-SAFE'].name, 'Module');
   await closing;
   assert.equal(closed, true);
   assert.equal(host.status().lifecycle, 'closed');
@@ -190,7 +194,7 @@ test('the existing Electron PatrisBridge interface remains directly reusable', a
   const events = [];
   const existing = {
     async initialize() { events.push('initialize'); return { ready: true, mode: 'dll' }; },
-    async call(method) { events.push(method); return [{ code: '42' }]; },
+    async call(method) { events.push(method); return { '42': { name: 'Module' } }; },
     async close() { events.push('close'); }
   };
   const host = new PrivilegedPatrisHost({
@@ -198,7 +202,7 @@ test('the existing Electron PatrisBridge interface remains directly reusable', a
     transports: [wrapExistingElectronBridge(existing)]
   });
   const result = await host.handle(TRUSTED_ORIGIN, { method: 'records.list' });
-  assert.equal(result.result[0].code, '42');
+  assert.equal(result.result['42'].name, 'Module');
   await host.close();
   assert.deepEqual(events, ['initialize', 'records.list', 'close']);
 });
@@ -209,13 +213,14 @@ test('REST transport verifies identity and does not invent an auth token', async
     requests.push({ url, options });
     const body = url.endsWith('/api/app')
       ? { name: 'Patris Export', version: { version: '1.2.0' } }
-      : [{ code: '1001', stock: { main: 3 } }];
+      : { '1001': { stock: { main: 3 } } };
     return { ok: true, status: 200, async json() { return body; } };
   };
   const rest = new RestTransport({ baseUrl: 'https://patris.example/base/', fetchImpl });
   await rest.initialize();
   const records = await rest.call('records.list');
-  assert.equal(records[0].stock.main, 3);
+  assert.equal(records['1001'].stock.main, 3);
+  assert.equal(Object.hasOwn(records['1001'], 'Code'), false);
   assert.equal(requests[0].url, 'https://patris.example/base/api/app');
   assert.equal(Object.hasOwn(requests[0].options.headers, 'Authorization'), false);
 });
@@ -265,6 +270,44 @@ test('native worker refuses missing addon and DLL before starting a child', asyn
   await assert.rejects(() => native.initialize(), (error) => error.code === 'RUNTIME_MISSING');
 });
 
+test('sandboxed Electron preload is a standalone file with typed IPC failures', async () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'examples', 'electron-preload.cjs'), 'utf8');
+  assert.doesNotMatch(source, /require\(\s*['"](?:\.{1,2}\/|@atomicdeploy)/);
+
+  let exposed;
+  let fail = false;
+  const invocations = [];
+  const electron = {
+    contextBridge: {
+      exposeInMainWorld(name, value) {
+        assert.equal(name, 'patrisExport');
+        exposed = value;
+      }
+    },
+    ipcRenderer: {
+      async invoke(channel, request) {
+        invocations.push({ channel, request });
+        if (fail) throw new Error('private IPC failure details');
+        return { ok: true, result: { ready: true }, meta: { requestId: request.requestId } };
+      }
+    }
+  };
+  vm.runInNewContext(source, {
+    require(specifier) {
+      assert.equal(specifier, 'electron');
+      return electron;
+    }
+  }, { filename: 'electron-preload.cjs' });
+
+  assert.equal((await exposed.status()).result.ready, true);
+  assert.equal(invocations[0].channel, 'patris:status');
+  fail = true;
+  const failed = await exposed.call('records.list');
+  assert.equal(failed.ok, false);
+  assert.equal(failed.error.code, 'ELECTRON_IPC_FAILED');
+  assert.equal(failed.error.message.includes('private IPC failure details'), false);
+});
+
 class FakeIpcMain {
   constructor() { this.handlers = new Map(); }
   handle(channel, handler) { this.handlers.set(channel, handler); }
@@ -274,19 +317,86 @@ class FakeIpcMain {
 test('Electron derives origin from senderFrame and exposes only typed IPC calls', async () => {
   const host = new PrivilegedPatrisHost({
     allowedOrigins: [TRUSTED_ORIGIN],
-    transports: [transport('dll', { call: async () => [{ code: 'E-1' }] })]
+    transports: [transport('dll', { call: async () => ({ 'E-1': { name: 'Module' } }) })]
   });
   const ipcMain = new FakeIpcMain();
-  const unregister = registerElectronPatrisHost({ ipcMain, host });
-  const event = { senderFrame: { url: `${TRUSTED_ORIGIN}/panel/` } };
+  const authorize = async (event, context) => event.wordpressSession?.canManageProducts === true
+    && new URL(context.sourceUrl).pathname.startsWith('/panel/');
+  const unregister = registerElectronPatrisHost({ ipcMain, host, authorize });
+  const event = {
+    senderFrame: { url: `${TRUSTED_ORIGIN}/panel/` },
+    wordpressSession: { canManageProducts: true }
+  };
   const renderer = createElectronRendererClient({
     invoke: (channel, request) => ipcMain.handlers.get(channel)(event, request)
   });
   const result = await renderer.call('records.list', { sourceUrl: 'https://attacker.invalid/' });
   assert.equal(result.ok, true);
-  assert.equal(result.result[0].code, 'E-1');
+  assert.equal(result.result['E-1'].name, 'Module');
   unregister();
   assert.equal(ipcMain.handlers.size, 0);
+  await host.close();
+});
+
+test('Electron same-origin pages fail closed without privileged session authorization', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  const ipcMain = new FakeIpcMain();
+  registerElectronPatrisHost({
+    ipcMain,
+    host,
+    authorize: async (event, context) => event.wordpressSession?.canManageProducts === true
+      && new URL(context.sourceUrl).pathname.startsWith('/panel/')
+  });
+  const event = {
+    senderFrame: { url: `${TRUSTED_ORIGIN}/wp-login.php` },
+    wordpressSession: { canManageProducts: false }
+  };
+  const request = {
+    requestId: 'unauthorized-1',
+    method: 'config.set',
+    params: { rendererClaimsAuthorized: true }
+  };
+  const result = await ipcMain.handlers.get('patris:invoke')(event, request);
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'ELECTRON_NOT_AUTHORIZED');
+  assert.equal(result.meta.requestId, 'unauthorized-1');
+  assert.equal(host.status().lifecycle, 'idle');
+  await host.close();
+});
+
+test('Electron host registration requires a privileged authorizer', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  assert.throws(
+    () => registerElectronPatrisHost({ ipcMain: new FakeIpcMain(), host }),
+    (error) => error.code === 'ELECTRON_AUTHORIZER_REQUIRED'
+  );
+  await host.close();
+});
+
+test('privileged authorizer exceptions fail closed without exposing details', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  const ipcMain = new FakeIpcMain();
+  registerElectronPatrisHost({
+    ipcMain,
+    host,
+    authorize: async () => { throw new Error('private session failure details'); }
+  });
+  const result = await ipcMain.handlers.get('patris:status')({
+    senderFrame: { url: `${TRUSTED_ORIGIN}/panel/` }
+  }, { requestId: 'auth-error' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'ELECTRON_NOT_AUTHORIZED');
+  assert.equal(result.error.message.includes('private session failure details'), false);
+  assert.equal(host.status().lifecycle, 'idle');
   await host.close();
 });
 
@@ -296,7 +406,7 @@ test('Electron fails closed when the initiating sender frame is unavailable', as
     transports: [transport('dll')]
   });
   const ipcMain = new FakeIpcMain();
-  registerElectronPatrisHost({ ipcMain, host });
+  registerElectronPatrisHost({ ipcMain, host, authorize: async () => true });
   const event = { sender: { getURL: () => `${TRUSTED_ORIGIN}/panel/` } };
 
   const result = await ipcMain.handlers.get('patris:invoke')(event, { method: 'records.list' });
@@ -306,23 +416,111 @@ test('Electron fails closed when the initiating sender frame is unavailable', as
   await host.close();
 });
 
+test('Electron before-quit barrier awaits cleanup exactly once before re-entering quit', async () => {
+  const app = new EventEmitter();
+  const cleanupGate = deferred();
+  let cleanupCalls = 0;
+  let quitCalls = 0;
+  let prevented = 0;
+  app.quit = () => { quitCalls += 1; };
+  registerElectronShutdownBarrier({
+    app,
+    cleanup: async () => { cleanupCalls += 1; await cleanupGate.promise; }
+  });
+
+  const event = { preventDefault: () => { prevented += 1; } };
+  app.emit('before-quit', event);
+  app.emit('before-quit', event);
+  assert.equal(prevented, 2);
+  assert.equal(cleanupCalls, 0);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(cleanupCalls, 1);
+  assert.equal(quitCalls, 0);
+
+  cleanupGate.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(cleanupCalls, 1);
+  assert.equal(quitCalls, 1);
+  assert.equal(app.listenerCount('before-quit'), 0);
+});
+
+test('Electron shutdown barrier still releases quit when cleanup and error reporting fail', async () => {
+  const app = new EventEmitter();
+  let quitCalls = 0;
+  let errorCalls = 0;
+  app.quit = () => { quitCalls += 1; };
+  registerElectronShutdownBarrier({
+    app,
+    cleanup: async () => { throw new Error('private cleanup details'); },
+    onError: () => { errorCalls += 1; throw new Error('reporter failed'); }
+  });
+
+  app.emit('before-quit', { preventDefault() {} });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(errorCalls, 1);
+  assert.equal(quitCalls, 1);
+  assert.equal(app.listenerCount('before-quit'), 0);
+});
+
 test('Tauri command contract derives origin in the privileged command handler', async () => {
   const host = new PrivilegedPatrisHost({
     allowedOrigins: ['tauri://localhost'],
-    transports: [transport('dll', { call: async () => [{ code: 'T-1' }] })]
+    transports: [transport('dll', { call: async () => ({ 'T-1': { name: 'Module' } }) })]
   });
   const handlers = createTauriCommandHandlers({
     host,
-    getSourceUrl: async (event) => event.privilegedWindowUrl
+    getSourceUrl: async (event) => event.privilegedWindowUrl,
+    authorize: async (event) => event.wordpressSession?.canReadPatris === true
   });
   const client = createTauriRendererClient({
     invoke: (command, { request }) => command === 'patris_status'
-      ? handlers.patrisStatus({ privilegedWindowUrl: 'tauri://localhost/' }, request)
-      : handlers.patrisInvoke({ privilegedWindowUrl: 'tauri://localhost/' }, request)
+      ? handlers.patrisStatus({ privilegedWindowUrl: 'tauri://localhost/', wordpressSession: { canReadPatris: true } }, request)
+      : handlers.patrisInvoke({ privilegedWindowUrl: 'tauri://localhost/', wordpressSession: { canReadPatris: true } }, request)
   });
   const result = await client.call('records.list');
   assert.equal(result.ok, true);
-  assert.equal(result.result[0].code, 'T-1');
+  assert.equal(result.result['T-1'].name, 'Module');
+  await host.close();
+});
+
+test('Tauri same-origin commands fail closed without privileged authorization', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: ['https://digitalogic.ir'],
+    transports: [transport('dll')]
+  });
+  const handlers = createTauriCommandHandlers({
+    host,
+    getSourceUrl: async (event) => event.privilegedWindowUrl,
+    authorize: async (event, context) => event.wordpressSession?.canManageProducts === true
+      && new URL(context.sourceUrl).pathname.startsWith('/panel/')
+  });
+  const result = await handlers.patrisInvoke({
+    privilegedWindowUrl: 'https://digitalogic.ir/wp-login.php',
+    wordpressSession: { canManageProducts: false }
+  }, { requestId: 'tauri-denied', method: 'config.set', params: { authorized: true } });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'TAURI_NOT_AUTHORIZED');
+  assert.equal(host.status().lifecycle, 'idle');
+  await host.close();
+});
+
+test('Tauri and WebView2 privileged handlers require authorizers', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  assert.throws(
+    () => createTauriCommandHandlers({ host, getSourceUrl: async () => TRUSTED_ORIGIN }),
+    (error) => error.code === 'TAURI_AUTHORIZER_REQUIRED'
+  );
+  assert.throws(
+    () => createWebView2MessageHandler({
+      host,
+      getSourceUrl: async () => TRUSTED_ORIGIN,
+      postMessage: async () => {}
+    }),
+    (error) => error.code === 'WEBVIEW2_AUTHORIZER_REQUIRED'
+  );
   await host.close();
 });
 
@@ -338,13 +536,14 @@ test('WebView2 maps concurrent responses by request id and validates host origin
   const host = new PrivilegedPatrisHost({
     allowedOrigins: ['https://patris.local'],
     transports: [transport('dll', {
-      call: async (method) => method === 'records.list' ? [{ code: 'W-1' }] : { status: 'ok' }
+      call: async (method) => method === 'records.list' ? { 'W-1': { name: 'Module' } } : { status: 'ok' }
     })]
   });
   const webview = new FakeWebView();
   const handleMessage = createWebView2MessageHandler({
     host,
     getSourceUrl: async () => 'https://patris.local/index.html',
+    authorize: async (event) => event.trustedSource === 'native',
     postMessage: async (payload) => setImmediate(() => webview.receive(payload))
   });
   webview.outbound = (payload) => setImmediate(() => handleMessage({ data: payload, trustedSource: 'native' }));
@@ -353,10 +552,38 @@ test('WebView2 maps concurrent responses by request id and validates host origin
     client.call('records.list'),
     client.call('status.get')
   ]);
-  assert.equal(records.result[0].code, 'W-1');
+  assert.equal(records.result['W-1'].name, 'Module');
   assert.equal(status.result.status, 'ok');
   client.dispose();
   assert.equal(webview.listeners.size, 0);
+  await host.close();
+});
+
+test('WebView2 same-origin messages return a typed denial without privileged authorization', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: ['https://digitalogic.ir'],
+    transports: [transport('dll')]
+  });
+  let response;
+  const handleMessage = createWebView2MessageHandler({
+    host,
+    getSourceUrl: async (event) => event.sourceUrl,
+    authorize: async (event, context) => event.wordpressSession?.canManageProducts === true
+      && new URL(context.sourceUrl).pathname.startsWith('/panel/'),
+    postMessage: async (payload) => { response = payload; }
+  });
+  const handled = await handleMessage({
+    sourceUrl: 'https://digitalogic.ir/public/',
+    wordpressSession: { canManageProducts: false },
+    data: {
+      channel: 'patris:request', action: 'invoke',
+      request: { requestId: 'webview-denied', method: 'config.set', params: { authorized: true } }
+    }
+  });
+  assert.equal(handled, true);
+  assert.equal(response.envelope.ok, false);
+  assert.equal(response.envelope.error.code, 'WEBVIEW2_NOT_AUTHORIZED');
+  assert.equal(host.status().lifecycle, 'idle');
   await host.close();
 });
 
@@ -367,5 +594,17 @@ test('WebView2 missing host response becomes a typed timeout', async () => {
   const result = await client.call('records.list');
   assert.equal(result.ok, false);
   assert.equal(result.error.code, 'TIMEOUT');
+  client.dispose();
+});
+
+test('WebView2 synchronous native send failure is typed and clears pending work', async () => {
+  const webview = new FakeWebView();
+  webview.outbound = () => { throw new Error('native bridge unavailable'); };
+  const client = createWebView2RendererClient({ webview, timeoutMs: 1000 });
+  const result = await client.call('records.list');
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'WEBVIEW2_SEND_FAILED');
+  assert.equal(result.error.retryable, true);
+  assert.equal(result.error.message.includes('native bridge unavailable'), false);
   client.dispose();
 });

--- a/integrations/javascript/test/hosts.test.cjs
+++ b/integrations/javascript/test/hosts.test.cjs
@@ -1,0 +1,371 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  ALLOWED_METHODS,
+  ExecutableTransport,
+  NativeWorkerTransport,
+  PrivilegedPatrisHost,
+  RestTransport,
+  compileOriginAllowlist,
+  createElectronRendererClient,
+  createTauriCommandHandlers,
+  createTauriRendererClient,
+  createWebView2MessageHandler,
+  createWebView2RendererClient,
+  registerElectronPatrisHost,
+  wrapExistingElectronBridge
+} = require('../src/index.cjs');
+const { stopChild } = require('../src/transports.cjs');
+
+const TRUSTED_ORIGIN = 'https://digitalogic.ir';
+
+function transport(name, handlers = {}) {
+  return {
+    name,
+    initialize: handlers.initialize || (async () => ({ ready: true })),
+    call: handlers.call || (async (method) => ({ method })),
+    close: handlers.close || (async () => {})
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+test('origin policy is exact and does not accept wildcard or opaque origins', () => {
+  const allowlist = compileOriginAllowlist([
+    'https://digitalogic.ir/panel/',
+    'tauri://localhost/',
+    'https://patris.local/'
+  ]);
+  assert.deepEqual([...allowlist], ['https://digitalogic.ir', 'tauri://localhost', 'https://patris.local']);
+  assert.throws(() => compileOriginAllowlist(['https://*.example.com']), /Wildcard/);
+  assert.throws(() => compileOriginAllowlist([]), /trusted renderer origin/);
+});
+
+test('the canonical method allowlist cannot be extended at runtime', () => {
+  assert.equal(Object.isFrozen(ALLOWED_METHODS), true);
+  assert.throws(() => ALLOWED_METHODS.push('process.exec'), TypeError);
+  assert.equal(ALLOWED_METHODS.includes('process.exec'), false);
+});
+
+test('initialization falls back DLL to executable without duplicating a request', async () => {
+  let remoteInitializations = 0;
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [
+      transport('dll', { initialize: async () => { throw new Error('DLL unavailable'); } }),
+      transport('executable', {
+        call: async (method) => method === 'records.list'
+          ? [{ code: '1001', name: 'Module', final_price: '150000' }]
+          : { method }
+      }),
+      transport('rest', { initialize: async () => { remoteInitializations += 1; return { ready: true }; } })
+    ]
+  });
+  const result = await host.handle(`${TRUSTED_ORIGIN}/panel/`, { method: 'records.list', requestId: 'records-1' });
+  assert.equal(result.ok, true);
+  assert.equal(result.meta.mode, 'executable');
+  assert.equal(result.result[0].final_price, '150000');
+  assert.equal(remoteInitializations, 0);
+  assert.deepEqual(host.status().attempts.map((item) => item.mode), ['dll']);
+  await host.close();
+});
+
+test('origin and method failures use the same typed result contract', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  const origin = await host.handle('https://attacker.invalid/', { method: 'records.list' });
+  assert.deepEqual({ ok: origin.ok, code: origin.error.code }, { ok: false, code: 'ORIGIN_NOT_ALLOWED' });
+  const method = await host.handle(`${TRUSTED_ORIGIN}/`, { method: 'process.exec' });
+  assert.deepEqual({ ok: method.ok, code: method.error.code }, { ok: false, code: 'METHOD_NOT_ALLOWED' });
+  await host.close();
+});
+
+test('close waits for concurrent calls and rejects new work while closing', async () => {
+  const calls = [deferred(), deferred()];
+  let callIndex = 0;
+  let closed = false;
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll', {
+      call: async () => calls[callIndex++].promise,
+      close: async () => { closed = true; }
+    })]
+  });
+  await host.initialize();
+  const first = host.handle(TRUSTED_ORIGIN, { method: 'records.list', requestId: 1 });
+  const second = host.handle(TRUSTED_ORIGIN, { method: 'status.get', requestId: 2 });
+  await new Promise((resolve) => setImmediate(resolve));
+  const closing = host.close();
+  const rejected = await host.handle(TRUSTED_ORIGIN, { method: 'app.get', requestId: 3 });
+  assert.equal(rejected.error.code, 'HOST_CLOSING');
+  assert.equal(closed, false);
+  calls[1].resolve({ status: 'ok' });
+  calls[0].resolve([{ code: '1001' }]);
+  assert.equal((await first).ok, true);
+  assert.equal((await second).ok, true);
+  await closing;
+  assert.equal(closed, true);
+  assert.equal(host.status().lifecycle, 'closed');
+});
+
+test('close waits for a ready-host call admitted on the initialize microtask boundary', async () => {
+  let closed = false;
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll', {
+      call: async () => [{ code: 'RACE-SAFE' }],
+      close: async () => { closed = true; }
+    })]
+  });
+  await host.initialize();
+
+  const request = host.handle(TRUSTED_ORIGIN, { method: 'records.list', requestId: 'admitted' });
+  const closing = host.close();
+  const result = await request;
+
+  assert.equal(result.ok, true);
+  assert.equal(result.result[0].code, 'RACE-SAFE');
+  await closing;
+  assert.equal(closed, true);
+  assert.equal(host.status().lifecycle, 'closed');
+});
+
+test('close during initialization does not activate or leak a late runtime', async () => {
+  const startup = deferred();
+  let closeCount = 0;
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll', {
+      initialize: async () => startup.promise,
+      close: async () => { closeCount += 1; }
+    })]
+  });
+  const initializing = host.initialize();
+  const closing = host.close();
+  startup.resolve({ ready: true });
+  await assert.rejects(() => initializing, (error) => error.code === 'HOST_CLOSING');
+  await closing;
+  assert.equal(host.status().lifecycle, 'closed');
+  assert.equal(host.status().ready, false);
+  assert.ok(closeCount >= 1);
+});
+
+test('a transport close failure is typed without leaving the host stuck closing', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll', {
+      close: async () => { throw new Error('close failed'); }
+    })]
+  });
+  await host.initialize();
+
+  await assert.rejects(() => host.close(), (error) => error.code === 'RUNTIME_CLOSE_FAILED');
+  assert.equal(host.status().lifecycle, 'closed');
+  assert.equal(host.status().ready, false);
+});
+
+test('missing runtime is reported without leaking implementation details', async () => {
+  const host = new PrivilegedPatrisHost({ allowedOrigins: [TRUSTED_ORIGIN], transports: [] });
+  const result = await host.handle(TRUSTED_ORIGIN, { method: 'records.list' });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'RUNTIME_UNAVAILABLE');
+  assert.equal(result.error.retryable, true);
+  await host.close();
+});
+
+test('the existing Electron PatrisBridge interface remains directly reusable', async () => {
+  const events = [];
+  const existing = {
+    async initialize() { events.push('initialize'); return { ready: true, mode: 'dll' }; },
+    async call(method) { events.push(method); return [{ code: '42' }]; },
+    async close() { events.push('close'); }
+  };
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [wrapExistingElectronBridge(existing)]
+  });
+  const result = await host.handle(TRUSTED_ORIGIN, { method: 'records.list' });
+  assert.equal(result.result[0].code, '42');
+  await host.close();
+  assert.deepEqual(events, ['initialize', 'records.list', 'close']);
+});
+
+test('REST transport verifies identity and does not invent an auth token', async () => {
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    const body = url.endsWith('/api/app')
+      ? { name: 'Patris Export', version: { version: '1.2.0' } }
+      : [{ code: '1001', stock: { main: 3 } }];
+    return { ok: true, status: 200, async json() { return body; } };
+  };
+  const rest = new RestTransport({ baseUrl: 'https://patris.example/base/', fetchImpl });
+  await rest.initialize();
+  const records = await rest.call('records.list');
+  assert.equal(records[0].stock.main, 3);
+  assert.equal(requests[0].url, 'https://patris.example/base/api/app');
+  assert.equal(Object.hasOwn(requests[0].options.headers, 'Authorization'), false);
+});
+
+test('executable transport delegates to the verified loopback REST contract', async () => {
+  let closed = false;
+  const fetchImpl = async (url) => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return url.endsWith('/api/app') ? { name: 'Patris Export' } : { refreshed: true };
+    }
+  });
+  const executable = new ExecutableTransport({
+    startSidecar: async () => ({ baseUrl: 'http://127.0.0.1:39111', startupError: () => null, close: async () => { closed = true; } }),
+    fetchImpl,
+    startupAttempts: 1
+  });
+  assert.equal((await executable.initialize()).ready, true);
+  assert.deepEqual(await executable.call('refresh'), { refreshed: true });
+  await executable.close();
+  assert.equal(closed, true);
+});
+
+test('child shutdown waits for process exit after a kill signal was already sent', async () => {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.killed = true;
+  let exited = false;
+  child.kill = () => {
+    setImmediate(() => {
+      exited = true;
+      child.exitCode = 0;
+      child.emit('exit', 0, null);
+    });
+    return true;
+  };
+
+  await stopChild(child, 1000);
+  assert.equal(exited, true);
+});
+
+test('native worker refuses missing addon and DLL before starting a child', async () => {
+  const missing = path.join(os.tmpdir(), `missing-patris-${process.pid}`);
+  const native = new NativeWorkerTransport({ addonPath: `${missing}.node`, dllPath: `${missing}.dll` });
+  await assert.rejects(() => native.initialize(), (error) => error.code === 'RUNTIME_MISSING');
+});
+
+class FakeIpcMain {
+  constructor() { this.handlers = new Map(); }
+  handle(channel, handler) { this.handlers.set(channel, handler); }
+  removeHandler(channel) { this.handlers.delete(channel); }
+}
+
+test('Electron derives origin from senderFrame and exposes only typed IPC calls', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll', { call: async () => [{ code: 'E-1' }] })]
+  });
+  const ipcMain = new FakeIpcMain();
+  const unregister = registerElectronPatrisHost({ ipcMain, host });
+  const event = { senderFrame: { url: `${TRUSTED_ORIGIN}/panel/` } };
+  const renderer = createElectronRendererClient({
+    invoke: (channel, request) => ipcMain.handlers.get(channel)(event, request)
+  });
+  const result = await renderer.call('records.list', { sourceUrl: 'https://attacker.invalid/' });
+  assert.equal(result.ok, true);
+  assert.equal(result.result[0].code, 'E-1');
+  unregister();
+  assert.equal(ipcMain.handlers.size, 0);
+  await host.close();
+});
+
+test('Electron fails closed when the initiating sender frame is unavailable', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: [TRUSTED_ORIGIN],
+    transports: [transport('dll')]
+  });
+  const ipcMain = new FakeIpcMain();
+  registerElectronPatrisHost({ ipcMain, host });
+  const event = { sender: { getURL: () => `${TRUSTED_ORIGIN}/panel/` } };
+
+  const result = await ipcMain.handlers.get('patris:invoke')(event, { method: 'records.list' });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'ORIGIN_NOT_ALLOWED');
+  await host.close();
+});
+
+test('Tauri command contract derives origin in the privileged command handler', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: ['tauri://localhost'],
+    transports: [transport('dll', { call: async () => [{ code: 'T-1' }] })]
+  });
+  const handlers = createTauriCommandHandlers({
+    host,
+    getSourceUrl: async (event) => event.privilegedWindowUrl
+  });
+  const client = createTauriRendererClient({
+    invoke: (command, { request }) => command === 'patris_status'
+      ? handlers.patrisStatus({ privilegedWindowUrl: 'tauri://localhost/' }, request)
+      : handlers.patrisInvoke({ privilegedWindowUrl: 'tauri://localhost/' }, request)
+  });
+  const result = await client.call('records.list');
+  assert.equal(result.ok, true);
+  assert.equal(result.result[0].code, 'T-1');
+  await host.close();
+});
+
+class FakeWebView {
+  constructor() { this.listeners = new Set(); this.outbound = null; }
+  addEventListener(name, listener) { if (name === 'message') this.listeners.add(listener); }
+  removeEventListener(name, listener) { if (name === 'message') this.listeners.delete(listener); }
+  postMessage(payload) { this.outbound(payload); }
+  receive(payload) { for (const listener of this.listeners) listener({ data: payload }); }
+}
+
+test('WebView2 maps concurrent responses by request id and validates host origin', async () => {
+  const host = new PrivilegedPatrisHost({
+    allowedOrigins: ['https://patris.local'],
+    transports: [transport('dll', {
+      call: async (method) => method === 'records.list' ? [{ code: 'W-1' }] : { status: 'ok' }
+    })]
+  });
+  const webview = new FakeWebView();
+  const handleMessage = createWebView2MessageHandler({
+    host,
+    getSourceUrl: async () => 'https://patris.local/index.html',
+    postMessage: async (payload) => setImmediate(() => webview.receive(payload))
+  });
+  webview.outbound = (payload) => setImmediate(() => handleMessage({ data: payload, trustedSource: 'native' }));
+  const client = createWebView2RendererClient({ webview, timeoutMs: 1000 });
+  const [records, status] = await Promise.all([
+    client.call('records.list'),
+    client.call('status.get')
+  ]);
+  assert.equal(records.result[0].code, 'W-1');
+  assert.equal(status.result.status, 'ok');
+  client.dispose();
+  assert.equal(webview.listeners.size, 0);
+  await host.close();
+});
+
+test('WebView2 missing host response becomes a typed timeout', async () => {
+  const webview = new FakeWebView();
+  webview.outbound = () => {};
+  const client = createWebView2RendererClient({ webview, timeoutMs: 10 });
+  const result = await client.call('records.list');
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, 'TIMEOUT');
+  client.dispose();
+});


### PR DESCRIPTION
## Summary

- add one shared, typed JavaScript host contract for Electron, Tauri, and WebView2
- reuse the existing Digitalogic Electron `PatrisBridge` instead of duplicating the native engine
- keep DLL loading in a privileged child worker and support DLL -> executable sidecar -> REST startup fallback
- enforce exact host-derived origin and canonical method allowlists
- require a host-owned session/capability authorizer on every Electron, Tauri, and WebView2 call; same-origin public/login pages fail closed and renderer credentials are ignored
- add an awaited exactly-once Electron shutdown barrier and a self-contained sandbox-compatible preload
- expose the typed API from the package root and document the canonical Code-keyed `records.list` result
- document standalone and unified installer layouts plus native Tauri/WebView2 integration boundaries

## Contract

Renderers receive only `status()` and `call(method, params)` and return either:

- `{ ok: true, result, meta }`
- `{ ok: false, error: { code, message, retryable }, meta }`

The allowlist matches ABI version 1 exposed by `cmd/patris-export-lib`. No bearer-token handoff or second login mechanism is introduced; the host resolves the existing application session/capability in its privileged process.

## Verification

- `npm.cmd --prefix integrations/javascript run check`
- `npm.cmd --prefix integrations/javascript test` (29/29 passing)
- `npm.cmd pack --dry-run` from `integrations/javascript`
- `go test ./...` with the local pxlib runtime
- `go vet ./...` with the local pxlib runtime
- package-root self-resolution, runtime/type export parity, example module loading, and `git diff --check`
- isolated Windows executable and C-shared DLL builds
- executable sidecar smoke against real `testdata/kala.db` (292 transformed records)
- DLL worker smoke through the existing Digitalogic Node-API addon (ABI 1, ready, 292 transformed records)
- CLI smoke against the real fixture (354 source records, 28 fields)
- independent exact-tree security/lifecycle review: PASS

## Local candidate artifacts

These remain local verification candidates and are not deployed or attached as release assets:

- `build/patris-export-js-hosts-windows-amd64.exe`
- `build/patris-export-js-hosts.dll`
- generated C header and local pxlib runtime

## Known limitation

The JavaScript Tauri adapter and privileged command contract are tested. A native Tauri/Rust compile is not claimed because `rustup` is present on this workstation but its toolchain download was unavailable. Electron, WebView2, the Go/C ABI builds, DLL worker, executable fallback, and REST transport were validated locally.

The repository owner authorized automatic merge in the current Codex task and will perform post-merge review.

Closes #174