### PR TITLE
Make product sync receiver-neutral and presence-strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ Thumbs.db
 !testdata/*.inf
 !testdata/*.txt
 !testdata/canonical-static-config.json
-!testdata/digitalogic-product-sync.synthetic.json
+!testdata/patris-product-sync.synthetic.json
 
 # Web/Node.js
 web/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 
 - Canonical JSON, CSV, HTTP, spreadsheet, SQL, and outbound-update rows now share a sparse field boundary: never-received values are omitted while explicitly received nulls remain null.
-- Product-sync is now a single living, versionless standard with strict current-field decoding; obsolete aliases and compatibility branches are rejected.
+- Product-sync is now one living standard with strict current-field decoding; obsolete aliases and compatibility branches are rejected.
 - Shipping integration uses only `shipping_method_id` and `shipping_price_per_kg_cny`.
 - Missing source/reference values are omitted, while `null` is preserved only when explicitly supplied upstream.
+- Successful product-sync responses must include typed status, identity, retry, pending, and deferred fields; missing or explicit-null fields fail closed.
+- Persisted custom headers cannot use any product-sync-secret name; receiver credentials remain environment-backed only.
 
 ### Fixed
 
@@ -66,7 +68,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Native Paradox/BDE database reading through pxlib with safe temporary-copy handling, integrity checks, process/lock visibility, and Patris81 Persian character conversion.
 - JSON, CSV, canonical Excel, SQLite, MariaDB/MySQL, REST, RPC-style command, and webhook/update delivery outputs driven by one transformation pipeline.
-- Versioned Digitalogic product-sync contracts with landed-price calculation, currency and import-freight catalog lookup, product pricing assignments, raw-field rejection, hashes, replay safety, retries, and deferred reconciliation status.
+- Product-sync delivery with landed-price calculation, currency and import-freight catalog lookup, product pricing assignments, raw-field rejection, hashes, replay safety, retries, and deferred reconciliation status.
 - Real-time REST, WebSocket, polling, manual refresh, edge-upload, embedded-library, local IPC, self-update, and standalone operation modes.
 - Responsive web viewer and terminal dashboard with RTL/LTR support, mapping/configuration tools, filters, sorting, column resizing and visibility, row selection, context actions, conditional icons, export controls, notifications, and accessible keyboard interactions.
 - Persistent layered configuration, environment-variable secret injection, configurable system notifications, and source/update manifest endpoints.
@@ -74,7 +76,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- Canonical product data is transformed before Digitalogic receives it; raw Patris fields remain confined to source/debug paths.
+- Canonical product data is transformed before outbound delivery; raw Patris fields remain confined to source/debug paths.
 - SQL synchronization now supports bounded batches, dry runs, safe reconciliation policies, protected/quarantined keys, exact decimals, and fail-closed transaction handling.
 - Pricing assignment prefetching is atomic, scoped, cache-aware, and tolerant of configured production latency.
 - Viewer data-grid behavior and canonical Excel output now share consistent transformed values and export semantics.

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ patris-export convert kala.db \
   --reconciliation delete_missing \
   --dry-run
 
-# Watch and send canonical JSON changes to the Digitalogic receiver.
-# DIGITALOGIC_PRODUCT_SYNC_SECRET is injected into the process environment by
+# Watch and send canonical JSON changes to a configured receiver.
+# PATRIS_PRODUCT_SYNC_SECRET is injected into the process environment by
 # the deployment secret manager; only its variable name appears here.
 patris-export convert kala.db -f json -w \
-  --send-url https://digitalogic.example/wp-json/digitalogic/patris/product-sync \
+  --send-url https://receiver.example/wp-json/receiver/patris/product-sync \
   --send-mode changes \
-  --send-product-sync-secret-env DIGITALOGIC_PRODUCT_SYNC_SECRET \
+  --send-product-sync-secret-env PATRIS_PRODUCT_SYNC_SECRET \
   --send-retry-attempts 3 \
   --send-retry-backoff 2s
 ```
@@ -560,7 +560,7 @@ widths, and the independent row-coloring toggle are persisted under `ui` in the
 normal Patris Export config file rather than in a separate table-settings file.
 
 For a configured canonical dataset, `GET /api/product-sync` returns the full
-living `digitalogic.product-sync` envelope. Missing source/reference values are
+current `patris.product-sync` envelope. Missing source/reference values are
 omitted; `null` is reserved for an explicitly supplied upstream null.
 `/api/records` deliberately remains the Code-keyed product-row collection used
 by the viewer and embedded records API. `GET

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -164,7 +164,7 @@ Supports Persian/Farsi encoding conversion and file watching.
 	convertCmd.Flags().StringVar(&sendMode, "send-mode", "", "Send update mode: changes or full")
 	convertCmd.Flags().StringVar(&sendCommand, "send-command", "", "Command to run for initial/watch updates; payload is written to stdin")
 	convertCmd.Flags().BoolVar(&sendInitial, "send-initial", true, "Send a full initial payload before watch updates")
-	convertCmd.Flags().StringVar(&sendSecretEnv, "send-product-sync-secret-env", "", "Environment-variable name containing the header-only Digitalogic product-sync secret")
+	convertCmd.Flags().StringVar(&sendSecretEnv, "send-product-sync-secret-env", "", "Environment-variable name containing the header-only product-sync secret")
 	convertCmd.Flags().IntVar(&sendAttempts, "send-retry-attempts", 0, "Total HTTP delivery attempts (default 1; use retries only with idempotent receivers)")
 	convertCmd.Flags().StringVar(&sendBackoff, "send-retry-backoff", "", "Delay between retryable HTTP delivery attempts (for example 1s)")
 

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -33,7 +33,7 @@ never become a destructive zero or a generated JSON `null`. Duplicate Codes are
 quarantined from the contract.
 
 Raw `Sharh1`, `Sharh2`, `FOROSH`, `KHARYD`, `ALLANBAR`, and `ANBAR*` keys never
-cross the `digitalogic.product-sync` boundary.
+cross the `patris.product-sync` boundary.
 
 The wire boundary is sparse. A key that was never received or derived from a
 real value is omitted from JSON and from the union of CSV/XLSX/SQL columns. A
@@ -44,8 +44,8 @@ when static pricing is explicitly populated or a Digitalogic endpoint is
 configured. The only shipping names are `shipping_method_id`,
 `shipping_price_per_kg_cny`, and `shipping_methods`.
 
-This is a living, versionless integration standard. The current field set and
-routes are the only supported shape; producers and consumers change together.
+This is a living integration standard. The current field set and routes are the
+only supported shape; producers and consumers change together.
 Unknown fields fail closed rather than selecting a compatibility branch. See
 [`INTEGRATION-STANDARD.md`](INTEGRATION-STANDARD.md) for the maintenance policy.
 
@@ -118,7 +118,7 @@ values fail closed. A `global_default` value must exactly match the shared
 default snapshot.
 
 Outbound delivery uses only the dedicated `/patris/product-sync` receiver. It
-validates the current `digitalogic.product-sync` shape, merges update envelopes,
+validates the current `patris.product-sync` shape, merges update envelopes,
 honours `deleted_codes`, and deduplicates `event_id`. Do not point canonical
 delivery at `/patris/push` or another full-replacement parser.
 
@@ -196,10 +196,10 @@ adds explicit warnings.
 
 ## Transport contract
 
-Canonical JSON and JSON webhooks use the living
-`digitalogic.product-sync` shape. There is no schema version field, route
-version, formula revision, or compatibility negotiation. Category and exclusion
-projections are part of the current shape without exposing raw Patris fields.
+Canonical JSON and JSON webhooks use the current `patris.product-sync` shape.
+Retired shapes and compatibility negotiation are not accepted. Category and
+exclusion projections are part of the current shape without exposing raw Patris
+fields.
 
 `event_id` covers the validated `generated_at` value as well as the sorted
 record hashes and tombstones. Identical content generated at a later time is a
@@ -218,12 +218,12 @@ the same table, filtering, column, context-menu, accessibility, and RTL logic.
 ![Canonical landed-pricing row in the records viewer](screenshots/canonical-product-sync-viewer.png)
 
 Cross-project contract verification uses the entirely synthetic two-product
-fixture at `testdata/digitalogic-product-sync.synthetic.json`; production
+fixture at `testdata/patris-product-sync.synthetic.json`; production
 exports and catalog values must never be committed as golden fixtures.
 
 ```json
 {
-  "schema": "digitalogic.product-sync",
+  "schema": "patris.product-sync",
   "event_type": "snapshot",
   "event_id": "sha256:...",
   "local_currency": "IRT",
@@ -308,13 +308,15 @@ integers. Both SQL sinks add newly introduced columns on later exports.
 
 ![Accessible canonical XLSX download action](screenshots/canonical-xlsx-export-menu.png)
 
-For direct delivery to Digitalogic, use the existing HTTP update sink with
+For direct delivery to a receiver, use the existing HTTP update sink with
 `require_contract: true`, the dedicated `/patris/product-sync` endpoint, and a
 `product_sync_secret_env` reference. The secret value is read from that named
 environment variable at request time and sent only in
-`X-Digitalogic-Product-Sync-Secret`; it is not copied into persisted config or
-delivery logs or inherited by an optional command sink. Remote secret-bearing
-destinations require HTTPS. The sink preserves the canonical `X-Patris-*`
+`X-Patris-Product-Sync-Secret`; it is not copied into persisted config or
+delivery logs or inherited by an optional command sink. Custom header names
+ending in `product-sync-secret` are rejected so a retired header cannot retain
+or transmit a persisted credential. Remote secret-bearing destinations require
+HTTPS. The sink preserves the canonical `X-Patris-*`
 identity headers and uses contract `source.id` instead of the local database
 path for `X-Patris-Source`. It parses the WordPress REST response, surfaces
 apply state, and can retry the identical event when the receiver reports

--- a/docs/INTEGRATION-STANDARD.md
+++ b/docs/INTEGRATION-STANDARD.md
@@ -1,14 +1,13 @@
 # Living Integration Standard
 
-Patris Export, Digitalogic-WP, and Ashko-WP share one current integration
-standard. It is intentionally versionless while all producers, receivers, and
-deployments remain under coordinated control.
+Patris Export and others share one current integration standard while all
+producers, receivers, and deployments remain under coordinated control.
 
 ## Rules
 
-- `schema` identifies a document kind; it does not select a version.
-- Routes contain no version segment. Producers and consumers are deployed as a
-  coordinated change when the shape evolves.
+- `schema` identifies the current document kind.
+- Producers and consumers are deployed as a coordinated change when the shape
+  evolves.
 - Unknown fields and obsolete aliases fail closed. There are no compatibility
   branches for earlier payload shapes.
 - Missing source or reference data omits the corresponding key.
@@ -26,9 +25,9 @@ deployments remain under coordinated control.
 
 ## Change process
 
-An integration change updates producer code, both WordPress consumers, fixtures,
+An integration change updates producer code, all configured receivers, fixtures,
 tests, endpoint documentation, and deployment configuration together. The
 cutover sends a full snapshot after resetting receiver state when event identity
-or payload meaning changes. Software release versions and internal database
-migration counters may still be used for packaging and deployment mechanics;
-they are not wire-contract versions.
+or payload meaning changes. Software release identifiers and internal database
+migration counters remain packaging and deployment mechanics, outside the wire
+contract.

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -153,20 +153,20 @@ and the complete transformed `record`, so downstream upserts do not need to
 reconstruct unchanged fields.
 
 For a canonical profile and JSON delivery, the webhook body is the direct,
-living `digitalogic.product-sync` envelope instead of this generic wrapper.
+current `patris.product-sync` envelope instead of this generic wrapper.
 It carries deterministic event identity, complete changed products, and
 deleted-Code tombstones. CSV delivery retains the generic tabular change form.
 
 The existing HTTP sink serves webhook and REST destinations, including HTTP
-adapters that accept the direct JSON envelope; there is no second Digitalogic
-or JSON-RPC delivery implementation. For the Digitalogic receiver, point it
-at:
+adapters that accept the direct JSON envelope; there is no second
+receiver-specific or JSON-RPC delivery implementation. Point it at the
+configured receiver's product-sync route:
 
 ```text
-POST https://digitalogic.example/wp-json/digitalogic/patris/product-sync
+POST https://receiver.example/wp-json/receiver/patris/product-sync
 ```
 
-The dedicated `X-Digitalogic-Product-Sync-Secret` value is resolved only at
+The dedicated `X-Patris-Product-Sync-Secret` value is resolved only at
 request time from the environment variable named by
 `product_sync_secret_env`. Inject that environment variable through the
 service/process secret manager. Never put the value in the config `headers`
@@ -188,14 +188,14 @@ configured event source.
 
 Raw-mode outbound delivery fails closed by default. `send_updates.allow_raw`
 must be explicitly enabled for a trusted, non-integration destination; never
-enable it for Digitalogic or another product-sync consumer.
+enable it for a product-sync consumer or others.
 
 ```powershell
 patris-export convert C:\Patris\data4\kala.db -f json -w `
-  --send-url https://digitalogic.example/wp-json/digitalogic/patris/product-sync `
+  --send-url https://receiver.example/wp-json/receiver/patris/product-sync `
   --send-format json `
   --send-mode changes `
-  --send-product-sync-secret-env DIGITALOGIC_PRODUCT_SYNC_SECRET `
+  --send-product-sync-secret-env PATRIS_PRODUCT_SYNC_SECRET `
   --send-retry-attempts 3 `
   --send-retry-backoff 2s
 ```
@@ -212,7 +212,7 @@ Config equivalent:
 {
   "send_updates": {
     "enabled": true,
-    "url": "https://digitalogic.example/wp-json/digitalogic/patris/product-sync",
+    "url": "https://receiver.example/wp-json/receiver/patris/product-sync",
     "method": "POST",
     "format": "json",
     "mode": "changes",
@@ -221,7 +221,7 @@ Config equivalent:
     "timeout": "10s",
     "retry_attempts": 3,
     "retry_backoff": "2s",
-    "product_sync_secret_env": "DIGITALOGIC_PRODUCT_SYNC_SECRET",
+    "product_sync_secret_env": "PATRIS_PRODUCT_SYNC_SECRET",
     "headers": {
       "X-Integration-Name": "patris-office"
     }
@@ -229,31 +229,33 @@ Config equivalent:
 }
 ```
 
-Set `require_contract` for every Digitalogic-compatible integration target.
+Set `require_contract` for every product-sync integration target.
 It rejects generic transformed rows as well as raw rows, and it also rejects
 CSV, so a missing profile or disabled canonical stage cannot leak legacy Patris
 fields through a seemingly non-raw update.
 
 The default is one HTTP attempt, preserving generic webhook behavior. Opt in
-to retries only for an idempotent receiver. Digitalogic retries are safe:
+to retries only for an idempotent receiver. Product-sync retries are safe:
 Patris encodes the envelope once and reuses the exact bytes, event ID, identity
 headers, and secret for every attempt. Network failures, HTTP 408/425/429 and
 selected 5xx transients, and receiver responses with `retryable: true`,
 `partially_applied`, or `retry_pending` are retried. The receiver's
 `accepted`, `already_current`, `replayed`, or `recovered` state is surfaced in
-the CLI/server log. Those terminal states may also report a bounded,
-non-negative `deferred_products` count for Codes that require later catalog
+the CLI/server log. Those terminal states also report a bounded, non-negative
+`deferred_products` count for Codes that require later catalog
 reconciliation (for example, a product that does not exist in WooCommerce or
 an exact Code/SKU collision that must not be guessed). Deferred reconciliation
 is durable receiver work, not a delivery failure: it is logged as a count only
-and does not cause another HTTP attempt. A missing `deferred_products` field is
-treated as zero for compatibility with existing receivers.
+and does not cause another HTTP attempt. Current successful responses must
+include `status`, `event_id`, `retryable`, `pending_products`, and
+`deferred_products`; omission and explicit `null` both fail closed rather than
+being converted to empty strings, `false`, or zero.
 
 The receiver may include a sibling `deferred_reconciliation` summary containing
 native integer `missing`, `ambiguous`, and `details_truncated` counts plus at
 most 100 detail objects. Patris validates that missing plus ambiguous, and the
 detail count plus truncated count, both equal `deferred_products`; it then
-discards the detail objects. The summary is optional for replaceable receivers,
+discards the detail objects. The summary is optional in the current standard,
 and neither its product Codes nor reason details enter logs or delivery errors.
 
 Only `pending_products` represents transient apply work and causes a retry.
@@ -263,8 +265,8 @@ terminal state with `retryable: false` and `pending_products: 0`, even if a
 nonzero deferred count remains. Exhaustion reports only the sanitized endpoint
 and structured status/attempt/pending/deferred counts; query strings, response
 bodies, product identities, request headers, and credential values are never
-included. This distinction is paired with the bounded reconciliation state in
-`atomicdeploy/digitalogic-wp#64`.
+included. This distinction is paired with bounded reconciliation state in each
+receiver.
 
 Typed receiver responses fail closed unless their state is internally
 consistent: terminal states require zero pending products and

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -271,14 +271,14 @@ func TestEnvironmentCanRequireCanonicalOutboundContract(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_SEND_ALLOW_RAW", "false")
 	t.Setenv("PATRIS_EXPORT_SEND_RETRY_ATTEMPTS", "3")
 	t.Setenv("PATRIS_EXPORT_SEND_RETRY_BACKOFF", "250ms")
-	t.Setenv("PATRIS_EXPORT_SEND_PRODUCT_SYNC_SECRET_ENV", "DIGITALOGIC_PRODUCT_SYNC_SECRET")
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_SECRET", "must-not-enter-config")
+	t.Setenv("PATRIS_EXPORT_SEND_PRODUCT_SYNC_SECRET_ENV", "PATRIS_PRODUCT_SYNC_SECRET")
+	t.Setenv("PATRIS_PRODUCT_SYNC_SECRET", "must-not-enter-config")
 	cfg := Default()
 	ApplyEnv(&cfg)
 	if !cfg.SendUpdates.RequireContract || cfg.SendUpdates.AllowRaw || cfg.SendUpdates.RetryAttempts != 3 || cfg.SendUpdates.RetryBackoff != "250ms" {
 		t.Fatalf("outbound safety environment overrides were not applied: %+v", cfg.SendUpdates)
 	}
-	if cfg.SendUpdates.ProductSyncSecretEnv != "DIGITALOGIC_PRODUCT_SYNC_SECRET" {
+	if cfg.SendUpdates.ProductSyncSecretEnv != "PATRIS_PRODUCT_SYNC_SECRET" {
 		t.Fatalf("product-sync secret environment reference was not applied: %+v", cfg.SendUpdates)
 	}
 	encoded, err := json.Marshal(cfg)

--- a/pkg/canonical/canonical_test.go
+++ b/pkg/canonical/canonical_test.go
@@ -285,7 +285,7 @@ func TestIntegratedProfilePreservesExplicitReferenceNulls(t *testing.T) {
 
 func TestProductSyncDecoderRejectsUnknownFields(t *testing.T) {
 	var envelope Envelope
-	if err := json.Unmarshal([]byte(`{"schema":"digitalogic.product-sync","obsolete_field":true}`), &envelope); err == nil {
+	if err := json.Unmarshal([]byte(`{"schema":"patris.product-sync","obsolete_field":true}`), &envelope); err == nil {
 		t.Fatal("unknown envelope field was silently accepted")
 	}
 	var product Product
@@ -296,10 +296,10 @@ func TestProductSyncDecoderRejectsUnknownFields(t *testing.T) {
 	if err := json.Unmarshal([]byte(`{"category_code":"A","obsolete_field":true}`), &category); err == nil {
 		t.Fatal("unknown category field was silently accepted")
 	}
-	if err := json.Unmarshal([]byte(`{"schema":"digitalogic.product-sync","source":{"id":"A","obsolete_field":true}}`), &envelope); err == nil {
+	if err := json.Unmarshal([]byte(`{"schema":"patris.product-sync","source":{"id":"A","obsolete_field":true}}`), &envelope); err == nil {
 		t.Fatal("unknown source field was silently accepted")
 	}
-	if err := json.Unmarshal([]byte(`{"schema":"digitalogic.product-sync","deleted_codes":[{"product_code":"A","deleted":true,"obsolete_field":true}]}`), &envelope); err == nil {
+	if err := json.Unmarshal([]byte(`{"schema":"patris.product-sync","deleted_codes":[{"product_code":"A","deleted":true,"obsolete_field":true}]}`), &envelope); err == nil {
 		t.Fatal("unknown tombstone field was silently accepted")
 	}
 }

--- a/pkg/canonical/contract.go
+++ b/pkg/canonical/contract.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	ContractName  = "digitalogic.product-sync"
+	ContractName  = "patris.product-sync"
 	FormulaID     = "landed_price"
 	LocalCurrency = "IRT"
 )

--- a/pkg/canonical/golden_test.go
+++ b/pkg/canonical/golden_test.go
@@ -18,7 +18,7 @@ func TestSyntheticProductSyncGoldenFixture(t *testing.T) {
 		t.Fatal(err)
 	}
 	actual := append(encoded, '\n')
-	path := filepath.Join("..", "..", "testdata", "digitalogic-product-sync.synthetic.json")
+	path := filepath.Join("..", "..", "testdata", "patris-product-sync.synthetic.json")
 	if os.Getenv("UPDATE_GOLDEN") == "1" {
 		if err := os.WriteFile(path, actual, 0o644); err != nil {
 			t.Fatal(err)

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -29,7 +29,7 @@ func TestCanonicalXLSXRoundTripPreservesTypesLayoutAndMetadata(t *testing.T) {
 	options := XLSXOptions{
 		RightToLeft: true,
 		Metadata: XLSXMetadata{
-			Schema:         "digitalogic.product-sync",
+			Schema:         "patris.product-sync",
 			FormulaID:      "landed_price",
 			LocalCurrency:  "IRT",
 			SourceID:       "patris-office",
@@ -96,7 +96,7 @@ func TestCanonicalXLSXRoundTripPreservesTypesLayoutAndMetadata(t *testing.T) {
 	}
 	metadata := metadataValues(metadataRows)
 	for key, want := range map[string]string{
-		"schema":          "digitalogic.product-sync",
+		"schema":          "patris.product-sync",
 		"formula_id":      "landed_price",
 		"source_id":       "patris-office",
 		"source_dataset":  "kala.db",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -602,7 +602,7 @@ func (s *Server) handleGetProductSyncContract(w http.ResponseWriter, _ *http.Req
 		http.Error(w, "canonical product-sync contract is not available for this dataset", http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/vnd.digitalogic.product-sync+json")
+	w.Header().Set("Content-Type", "application/vnd.patris.product-sync+json")
 	if err := json.NewEncoder(w).Encode(result.Contract); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to encode product-sync contract: %v", err), http.StatusInternalServerError)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -557,7 +557,7 @@ func TestCanonicalKalaParityAcrossRESTCSVXLSXAndWebSocket(t *testing.T) {
 	if contractRecorder.Code != http.StatusOK {
 		t.Fatalf("contract status = %d: %s", contractRecorder.Code, contractRecorder.Body.String())
 	}
-	if contentType := contractRecorder.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/vnd.digitalogic.product-sync+json") {
+	if contentType := contractRecorder.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/vnd.patris.product-sync+json") {
 		t.Fatalf("unexpected contract content type %q", contentType)
 	}
 	var envelope canonical.Envelope

--- a/pkg/updateout/updateout.go
+++ b/pkg/updateout/updateout.go
@@ -37,10 +37,10 @@ type Config struct {
 	Command              []string          `json:"command,omitempty" yaml:"command,omitempty" toml:"command,omitempty"`
 }
 
-const productSyncSecretHeader = "X-Digitalogic-Product-Sync-Secret"
+const productSyncSecretHeader = "X-Patris-Product-Sync-Secret"
 
 // Receiver-reported product counts use a stable, architecture-independent
-// bound. The Digitalogic receiver may enforce a lower storage bound, but a
+// bound. A receiver may enforce a lower storage bound, but a
 // response above this limit is never safe to accept as delivery state.
 const maxReceiverReportedProducts uint64 = 1<<31 - 1
 
@@ -179,7 +179,7 @@ func Dispatch(ctx context.Context, cfg Config, event Event) error {
 }
 
 // DispatchWithResult sends through the shared HTTP/command update path and
-// returns Digitalogic receiver state when the destination supplies it.
+// returns product-sync receiver state when the destination supplies it.
 func DispatchWithResult(ctx context.Context, cfg Config, event Event) (DeliveryResult, error) {
 	cfg = Normalize(cfg)
 	if !cfg.Enabled {
@@ -332,8 +332,8 @@ func applyHeaders(req *http.Request, cfg Config, event Event, contract *canonica
 
 func validateSecretConfig(cfg Config, event Event) error {
 	for key := range cfg.Headers {
-		if strings.EqualFold(strings.TrimSpace(key), productSyncSecretHeader) {
-			return fmt.Errorf("%s is reserved; set product_sync_secret_env to an environment-variable name instead of storing the secret in headers", productSyncSecretHeader)
+		if isProductSyncSecretHeader(key) {
+			return fmt.Errorf("product-sync secret headers are reserved; set product_sync_secret_env to an environment-variable name instead of storing the secret in headers")
 		}
 	}
 	if cfg.ProductSyncSecretEnv == "" {
@@ -344,7 +344,7 @@ func validateSecretConfig(cfg Config, event Event) error {
 	}
 	contract := selectedContract(cfg, event)
 	if cfg.URL == "" || cfg.Format != "json" || contract == nil || contract.Schema != canonical.ContractName {
-		return fmt.Errorf("product_sync_secret_env requires an HTTP JSON digitalogic.product-sync contract destination")
+		return fmt.Errorf("product_sync_secret_env requires an HTTP JSON patris.product-sync contract destination")
 	}
 	endpoint, err := url.Parse(cfg.URL)
 	if err != nil || (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.Host == "" {
@@ -357,6 +357,11 @@ func validateSecretConfig(cfg Config, event Event) error {
 		return fmt.Errorf("product-sync destination requires HTTPS except for loopback test or development hosts")
 	}
 	return nil
+}
+
+func isProductSyncSecretHeader(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	return key == "product-sync-secret" || strings.HasSuffix(key, "-product-sync-secret")
 }
 
 func isLoopbackHost(host string) bool {
@@ -389,17 +394,19 @@ func resolveProductSyncSecret(cfg Config) (string, error) {
 	return secret, nil
 }
 
+type receiverResponseData struct {
+	Status                 json.RawMessage `json:"status"`
+	EventID                json.RawMessage `json:"event_id"`
+	Retryable              json.RawMessage `json:"retryable"`
+	PendingProducts        json.RawMessage `json:"pending_products"`
+	DeferredProducts       json.RawMessage `json:"deferred_products"`
+	DeferredReconciliation json.RawMessage `json:"deferred_reconciliation"`
+}
+
 type receiverResponse struct {
-	Success *bool  `json:"success"`
-	Code    string `json:"code"`
-	Data    struct {
-		Status                 string          `json:"status"`
-		EventID                string          `json:"event_id"`
-		Retryable              bool            `json:"retryable"`
-		PendingProducts        int             `json:"pending_products"`
-		DeferredProducts       json.RawMessage `json:"deferred_products"`
-		DeferredReconciliation json.RawMessage `json:"deferred_reconciliation"`
-	} `json:"data"`
+	Success *bool                `json:"success"`
+	Code    string               `json:"code"`
+	Data    receiverResponseData `json:"data"`
 	Details struct {
 		Retryable bool `json:"retryable"`
 	} `json:"details"`
@@ -412,33 +419,24 @@ func classifyHTTPResponse(result DeliveryResult, body []byte, contract *canonica
 	receiverRejected := false
 	var receiverStateError error
 	if decodedOK {
-		deferredProducts, err := receiverProductCount(decoded.Data.DeferredProducts)
-		if err == nil {
-			err = validateDeferredReconciliation(decoded.Data.DeferredReconciliation, deferredProducts)
-		}
-		if err != nil {
-			receiverStateError = err
-		} else {
-			result.Status = safeToken(decoded.Data.Status)
-			result.EventID = safeToken(decoded.Data.EventID)
-			result.PendingProducts = decoded.Data.PendingProducts
-			result.DeferredProducts = deferredProducts
-			result.Retryable = decoded.Data.Retryable
-			if contract != nil && result.EventID != "" && result.EventID != contract.EventID {
+		if *decoded.Success {
+			if err := applySuccessfulReceiverState(&result, decoded.Data); err != nil {
+				receiverStateError = err
+			} else if contract != nil && result.EventID != contract.EventID {
 				result.Retryable = false
 				return result, errReceiverIdentityMismatch
+			} else if err := validateReceiverState(result); err != nil {
+				result.Retryable = false
+				return result, err
 			}
-			if *decoded.Success {
-				if err := validateReceiverState(result); err != nil {
-					result.Retryable = false
-					return result, err
-				}
-			} else {
-				receiverRejected = true
-				result.Retryable = decoded.Data.Retryable || decoded.Details.Retryable
-				if result.Status == "" {
-					result.Status = safeToken(decoded.Code)
-				}
+		} else {
+			receiverRejected = true
+			status, _ := receiverString(decoded.Data.Status)
+			retryable, _ := receiverBool(decoded.Data.Retryable)
+			result.Status = safeToken(status)
+			result.Retryable = retryable || decoded.Details.Retryable
+			if result.Status == "" {
+				result.Status = safeToken(decoded.Code)
 			}
 		}
 	}
@@ -464,12 +462,81 @@ func classifyHTTPResponse(result DeliveryResult, body []byte, contract *canonica
 	return result, nil
 }
 
+func applySuccessfulReceiverState(result *DeliveryResult, data receiverResponseData) error {
+	status, err := requiredReceiverString(data.Status)
+	if err != nil {
+		return err
+	}
+	eventID, err := requiredReceiverString(data.EventID)
+	if err != nil {
+		return err
+	}
+	retryable, err := requiredReceiverBool(data.Retryable)
+	if err != nil {
+		return err
+	}
+	pendingProducts, err := requiredReceiverProductCount(data.PendingProducts)
+	if err != nil {
+		return err
+	}
+	deferredProducts, err := requiredReceiverProductCount(data.DeferredProducts)
+	if err != nil {
+		return err
+	}
+	if err := validateDeferredReconciliation(data.DeferredReconciliation, deferredProducts); err != nil {
+		return err
+	}
+
+	result.Status = status
+	result.EventID = eventID
+	result.Retryable = retryable
+	result.PendingProducts = pendingProducts
+	result.DeferredProducts = deferredProducts
+	if result.Status == "" || result.EventID == "" {
+		return errReceiverStateInvalid
+	}
+	return nil
+}
+
+func requiredReceiverString(raw json.RawMessage) (string, error) {
+	value, err := receiverString(raw)
+	if err != nil || value == "" {
+		return "", errReceiverStateInvalid
+	}
+	return value, nil
+}
+
+func receiverString(raw json.RawMessage) (string, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return "", errReceiverStateInvalid
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", errReceiverStateInvalid
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func requiredReceiverBool(raw json.RawMessage) (bool, error) {
+	return receiverBool(raw)
+}
+
+func receiverBool(raw json.RawMessage) (bool, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return false, errReceiverStateInvalid
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, errReceiverStateInvalid
+	}
+	return value, nil
+}
+
 func receiverProductCount(raw json.RawMessage) (int, error) {
 	raw = bytes.TrimSpace(raw)
-	if len(raw) == 0 {
-		return 0, nil
-	}
-	if bytes.Equal(raw, []byte("null")) {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
 		return 0, errReceiverStateInvalid
 	}
 	var count uint64

--- a/pkg/updateout/updateout_test.go
+++ b/pkg/updateout/updateout_test.go
@@ -181,7 +181,7 @@ func TestDispatchHTTPReportsNonSuccessStatus(t *testing.T) {
 	}
 }
 
-func TestDispatchCanonicalContractUsesDirectDigitalogicEnvelope(t *testing.T) {
+func TestDispatchCanonicalContractUsesDirectProductSyncEnvelope(t *testing.T) {
 	var body []byte
 	headers := http.Header{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -219,9 +219,9 @@ func TestDispatchCanonicalContractUsesDirectDigitalogicEnvelope(t *testing.T) {
 	}
 }
 
-func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.T) {
+func TestDispatchProductSyncRetriesIdenticalEventAndSurfacesRecovery(t *testing.T) {
 	const secret = "test-product-sync-secret-must-not-be-persisted"
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", secret)
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", secret)
 
 	product := canonical.Product{ProductCode: "113007045", RecordHash: "sha256:record"}
 	contract := canonical.NewEnvelope([]canonical.Product{product}, "kala.db", "patris-office", time.Unix(1, 0))
@@ -250,7 +250,7 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 		switch attempts {
 		case 1:
 			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprintf(w, `{"success":false,"code":"digitalogic_product_sync_busy","details":{"retryable":true}}`)
+			fmt.Fprintf(w, `{"success":false,"code":"receiver_product_sync_busy","details":{"retryable":true}}`)
 		case 2:
 			fmt.Fprintf(w, `{"success":true,"data":{"status":"partially_applied","event_id":%q,"retryable":true,"pending_products":1,"deferred_products":2}}`, contract.EventID)
 		default:
@@ -261,7 +261,7 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 
 	cfg := Config{
 		Enabled: true, URL: server.URL, Format: "json", Mode: "changes", RequireContract: true,
-		RetryAttempts: 3, RetryBackoff: "1ns", ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		RetryAttempts: 3, RetryBackoff: "1ns", ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 		Headers: map[string]string{
 			"X-Patris-Contract": "spoofed",
 			"X-Patris-Event-ID": "spoofed",
@@ -288,8 +288,8 @@ func TestDispatchDigitalogicRetriesIdenticalEventAndSurfacesRecovery(t *testing.
 	}
 }
 
-func TestDispatchDigitalogicTerminalDeferredProductsDoNotRetry(t *testing.T) {
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", "terminal-deferred")
+func TestDispatchProductSyncTerminalDeferredProductsDoNotRetry(t *testing.T) {
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", "terminal-deferred")
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	var attempts int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -301,7 +301,7 @@ func TestDispatchDigitalogicTerminalDeferredProductsDoNotRetry(t *testing.T) {
 
 	result, err := DispatchWithResult(t.Context(), Config{
 		Enabled: true, URL: server.URL, Format: "json", RequireContract: true,
-		RetryAttempts: 3, RetryBackoff: "1ns", ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		RetryAttempts: 3, RetryBackoff: "1ns", ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Source: "kala.db", Contract: contract})
 	if err != nil {
 		t.Fatalf("terminal deferred reconciliation was rejected: %v", err)
@@ -314,9 +314,9 @@ func TestDispatchDigitalogicTerminalDeferredProductsDoNotRetry(t *testing.T) {
 	}
 }
 
-func TestDispatchDigitalogicPartialExhaustionIsSafeToLog(t *testing.T) {
+func TestDispatchProductSyncPartialExhaustionIsSafeToLog(t *testing.T) {
 	const secret = "must-never-appear-in-errors"
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", secret)
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", secret)
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -326,7 +326,7 @@ func TestDispatchDigitalogicPartialExhaustionIsSafeToLog(t *testing.T) {
 
 	result, err := DispatchWithResult(t.Context(), Config{
 		Enabled: true, URL: server.URL, Format: "json", RequireContract: true,
-		RetryAttempts: 2, RetryBackoff: "1ns", ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		RetryAttempts: 2, RetryBackoff: "1ns", ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Source: "kala.db", Contract: contract})
 	if err == nil {
 		t.Fatal("expected retry exhaustion")
@@ -349,7 +349,7 @@ func TestDispatchDigitalogicPartialExhaustionIsSafeToLog(t *testing.T) {
 
 func TestDispatchDoesNotForwardProductSyncSecretAcrossRedirect(t *testing.T) {
 	const secret = "redirect-sensitive-secret"
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", secret)
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", secret)
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	var redirectedSecret string
 	var targetCalls int
@@ -367,7 +367,7 @@ func TestDispatchDoesNotForwardProductSyncSecretAcrossRedirect(t *testing.T) {
 
 	err := Dispatch(t.Context(), Config{
 		Enabled: true, URL: origin.URL, Format: "json", RequireContract: true,
-		ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Contract: contract})
 	if err == nil || !strings.Contains(err.Error(), "HTTP 307") {
 		t.Fatalf("redirect was not rejected: %v", err)
@@ -378,24 +378,24 @@ func TestDispatchDoesNotForwardProductSyncSecretAcrossRedirect(t *testing.T) {
 }
 
 func TestDispatchRequiresReceiverEventIdentityInStrictProductSyncResponse(t *testing.T) {
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", "strict-response")
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", "strict-response")
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"success":true,"data":{"status":"accepted","retryable":false,"pending_products":0}}`)
+		fmt.Fprint(w, `{"success":true,"data":{"status":"accepted","retryable":false,"pending_products":0,"deferred_products":0}}`)
 	}))
 	defer server.Close()
 
 	err := Dispatch(t.Context(), Config{
 		Enabled: true, URL: server.URL, Format: "json", RequireContract: true,
-		ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Contract: contract})
-	if err == nil || !strings.Contains(err.Error(), "missing product-sync delivery state") {
+	if err == nil || !strings.Contains(err.Error(), "inconsistent product-sync delivery state") {
 		t.Fatalf("missing receiver event identity was accepted: %v", err)
 	}
 }
 
-func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
+func TestClassifyProductSyncReceiverStateMachine(t *testing.T) {
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	tests := []struct {
 		name      string
@@ -416,6 +416,7 @@ func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
 		{name: "terminal pending", status: "recovered", pending: 1, wantError: true},
 		{name: "partial not retryable", status: "partially_applied", pending: 1, wantError: true},
 		{name: "partial without pending", status: "retry_pending", retryable: true, wantError: true},
+		{name: "punctuated status", status: "accep!ted", wantError: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -434,22 +435,54 @@ func TestClassifyDigitalogicReceiverStateMachine(t *testing.T) {
 	}
 }
 
-func TestClassifyDigitalogicReceiverDefaultsOmittedDeferredProductsToZero(t *testing.T) {
+func TestClassifyProductSyncReceiverDoesNotNormalizeEventIdentity(t *testing.T) {
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
-	body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0}}`, contract.EventID)
+	alteredEventID := strings.Replace(contract.EventID, ":", ": ", 1)
+	body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":0}}`, alteredEventID)
 	result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
-	if err != nil || result.DeferredProducts != 0 {
-		t.Fatalf("omitted deferred count was not compatible: result=%+v err=%v", result, err)
+	if !errors.Is(err, errReceiverIdentityMismatch) || result.EventID != alteredEventID || result.Retryable {
+		t.Fatalf("altered receiver event identity was normalized or accepted: result=%+v err=%v", result, err)
 	}
+}
 
-	body = fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":%d}}`, contract.EventID, maxReceiverReportedProducts)
-	result, err = classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
+func TestClassifyProductSyncReceiverRequiresPresentNonNullStateFields(t *testing.T) {
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	valid := fmt.Sprintf(`{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":0}}`, contract.EventID)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing status", body: strings.Replace(valid, `"status":"accepted",`, "", 1)},
+		{name: "null status", body: strings.Replace(valid, `"status":"accepted"`, `"status":null`, 1)},
+		{name: "missing event id", body: strings.Replace(valid, fmt.Sprintf(`"event_id":%q,`, contract.EventID), "", 1)},
+		{name: "null event id", body: strings.Replace(valid, fmt.Sprintf(`"event_id":%q`, contract.EventID), `"event_id":null`, 1)},
+		{name: "missing retryable", body: strings.Replace(valid, `"retryable":false,`, "", 1)},
+		{name: "null retryable", body: strings.Replace(valid, `"retryable":false`, `"retryable":null`, 1)},
+		{name: "missing pending products", body: strings.Replace(valid, `"pending_products":0,`, "", 1)},
+		{name: "null pending products", body: strings.Replace(valid, `"pending_products":0`, `"pending_products":null`, 1)},
+		{name: "missing deferred products", body: strings.Replace(valid, `,"deferred_products":0`, "", 1)},
+		{name: "null deferred products", body: strings.Replace(valid, `"deferred_products":0`, `"deferred_products":null`, 1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, []byte(test.body), contract, true)
+			if !errors.Is(err, errReceiverStateInvalid) || result.Retryable {
+				t.Fatalf("missing or null receiver state was not rejected: result=%+v err=%v body=%s", result, err, test.body)
+			}
+		})
+	}
+}
+
+func TestClassifyProductSyncReceiverAcceptsMaximumBoundedProductCounts(t *testing.T) {
+	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
+	body := fmt.Appendf(nil, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":%d}}`, contract.EventID, maxReceiverReportedProducts)
+	result, err := classifyHTTPResponse(DeliveryResult{HTTPStatus: http.StatusOK, Attempts: 1}, body, contract, true)
 	if err != nil || uint64(result.DeferredProducts) != maxReceiverReportedProducts {
 		t.Fatalf("maximum bounded deferred count was not accepted: result=%+v err=%v", result, err)
 	}
 }
 
-func TestClassifyDigitalogicReceiverRejectsInvalidDeferredProductCounts(t *testing.T) {
+func TestClassifyProductSyncReceiverRejectsInvalidDeferredProductCounts(t *testing.T) {
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	tests := []struct {
 		name  string
@@ -473,7 +506,7 @@ func TestClassifyDigitalogicReceiverRejectsInvalidDeferredProductCounts(t *testi
 	}
 }
 
-func TestClassifyDigitalogicReceiverRejectsInconsistentDeferredReconciliation(t *testing.T) {
+func TestClassifyProductSyncReceiverRejectsInconsistentDeferredReconciliation(t *testing.T) {
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	detailObjects := strings.TrimSuffix(strings.Repeat(`{},`, maxReceiverDeferredDetails+1), ",")
 	tests := []struct {
@@ -517,12 +550,20 @@ func TestDispatchGenericWebhookIgnoresProductSyncReceiverFields(t *testing.T) {
 
 func TestDispatchRejectsPersistedProductSyncSecretHeader(t *testing.T) {
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
-	err := Dispatch(t.Context(), Config{
-		Enabled: true, URL: "https://example.invalid", Format: "json",
-		Headers: map[string]string{"x-digitalogic-product-sync-secret": "plaintext"},
-	}, Event{Type: "initial", Contract: contract})
-	if err == nil || !strings.Contains(err.Error(), "product_sync_secret_env") {
-		t.Fatalf("persisted receiver secret was not rejected: %v", err)
+	for _, header := range []string{
+		"x-patris-product-sync-secret",
+		"x-ReTiReD-PrOdUcT-SyNc-SeCrEt",
+		"Product-Sync-Secret",
+	} {
+		t.Run(header, func(t *testing.T) {
+			err := Dispatch(t.Context(), Config{
+				Enabled: true, URL: "https://example.invalid", Format: "json",
+				Headers: map[string]string{header: "plaintext"},
+			}, Event{Type: "initial", Contract: contract})
+			if err == nil || !strings.Contains(err.Error(), "product_sync_secret_env") {
+				t.Fatalf("persisted receiver secret header %q was not rejected: %v", header, err)
+			}
+		})
 	}
 }
 
@@ -530,7 +571,7 @@ func TestDispatchRequiresConfiguredProductSyncSecretEnvironmentValue(t *testing.
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	err := Dispatch(t.Context(), Config{
 		Enabled: true, URL: "https://example.invalid", Format: "json",
-		ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_MISSING_SECRET",
+		ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_MISSING_SECRET",
 	}, Event{Type: "initial", Contract: contract})
 	if err == nil || !strings.Contains(err.Error(), "missing or empty") {
 		t.Fatalf("missing receiver secret did not fail closed: %v", err)
@@ -538,11 +579,11 @@ func TestDispatchRequiresConfiguredProductSyncSecretEnvironmentValue(t *testing.
 }
 
 func TestDispatchRejectsProductSyncDestinationQueryAuthentication(t *testing.T) {
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", "header-only")
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", "header-only")
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	err := Dispatch(t.Context(), Config{
 		Enabled: true, URL: "https://example.invalid/product-sync?token=legacy", Format: "json",
-		ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Contract: contract})
 	if err == nil || !strings.Contains(err.Error(), "header-only") {
 		t.Fatalf("query authentication was not rejected: %v", err)
@@ -550,11 +591,11 @@ func TestDispatchRejectsProductSyncDestinationQueryAuthentication(t *testing.T) 
 }
 
 func TestDispatchRejectsRemotePlainHTTPProductSyncDestination(t *testing.T) {
-	t.Setenv("DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET", "https-only")
+	t.Setenv("PATRIS_PRODUCT_SYNC_TEST_SECRET", "https-only")
 	contract := canonical.NewEnvelope(nil, "kala.db", "patris-office", time.Unix(1, 0))
 	err := Dispatch(t.Context(), Config{
-		Enabled: true, URL: "http://digitalogic.example/wp-json/digitalogic/patris/product-sync", Format: "json",
-		ProductSyncSecretEnv: "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET",
+		Enabled: true, URL: "http://receiver.example/wp-json/receiver/patris/product-sync", Format: "json",
+		ProductSyncSecretEnv: "PATRIS_PRODUCT_SYNC_TEST_SECRET",
 	}, Event{Type: "initial", Contract: contract})
 	if err == nil || !strings.Contains(err.Error(), "requires HTTPS") {
 		t.Fatalf("remote plaintext destination was not rejected: %v", err)
@@ -666,7 +707,7 @@ func TestDispatchCommandReceivesChangePayloadAndMetadata(t *testing.T) {
 }
 
 func TestCommandSinkDoesNotInheritHTTPProductSyncSecret(t *testing.T) {
-	const secretEnv = "DIGITALOGIC_PRODUCT_SYNC_TEST_SECRET"
+	const secretEnv = "PATRIS_PRODUCT_SYNC_TEST_SECRET"
 	t.Setenv("GO_WANT_UPDATEOUT_HELPER", "1")
 	t.Setenv(secretEnv, "must-not-reach-command")
 	t.Setenv("UPDATEOUT_FORBIDDEN_ENV_NAME", secretEnv)
@@ -678,7 +719,7 @@ func TestCommandSinkDoesNotInheritHTTPProductSyncSecret(t *testing.T) {
 			t.Errorf("HTTP sink did not receive its dedicated secret")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0}}`, contract.EventID)
+		fmt.Fprintf(w, `{"success":true,"data":{"status":"accepted","event_id":%q,"retryable":false,"pending_products":0,"deferred_products":0}}`, contract.EventID)
 	}))
 	defer server.Close()
 

--- a/testdata/patris-product-sync.synthetic.json
+++ b/testdata/patris-product-sync.synthetic.json
@@ -1,7 +1,7 @@
 {
-  "schema": "digitalogic.product-sync",
+  "schema": "patris.product-sync",
   "event_type": "snapshot",
-  "event_id": "sha256:98823d5e6d61e93826db55f70c4709324fd1c97346bc30cf870b6513098adc96",
+  "event_id": "sha256:91f8d8fdf0008f125499f56a7100eaba86fd6bb42f0fc3f2a4bcb4e6e8add87f",
   "local_currency": "IRT",
   "formula_id": "landed_price",
   "source": {

--- a/web/test/records.test.mjs
+++ b/web/test/records.test.mjs
@@ -18,7 +18,7 @@ test('normalizes Code-keyed API rows without treating metadata as records', () =
 
 test('consumes product-sync products and ignores envelope metadata', () => {
     const rows = normalizeRecordsPayload({
-        schema: 'digitalogic.product-sync',
+        schema: 'patris.product-sync',
         event_id: 'sha256:event',
         products: [
             { product_code: '102001011', name: 'LM75' },
@@ -37,7 +37,7 @@ test('normalizes keyed and contract category rows using the shared Code alias', 
     }).map(row => row.Code), ['101', '101001']);
 
     const rows = normalizeCategoriesPayload({
-        schema: 'digitalogic.product-sync',
+        schema: 'patris.product-sync',
         categories: [{ category_code: '102', name: 'Sensors', depth: 1 }]
     });
     assert.deepEqual(rows, [{ category_code: '102', name: 'Sensors', depth: 1, Code: '102' }]);


### PR DESCRIPTION
## Summary

- emit the receiver-neutral `patris.product-sync` shape and neutral secret header
- rename the synthetic golden fixture and regenerate its deterministic identity
- require present, non-null, correctly typed successful receiver state fields
- preserve exact successful status/event identity without normalization
- reject any persisted product-sync-secret-shaped custom header
- neutralize product-sync documentation, examples, environment names, and tests while retaining independent provider subsystems

## Verification

- full native `go test ./...`
- uncached `go test -count=1 ./pkg/updateout`
- web tests: 27/27
- production web build
- `gofmt` and `git diff --check`
- prohibited schema/header/coupling scans

Closes #182