### PR TITLE
Harden pxlib FFI pointer handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
     - name: Audit Go pointer usage
       run: go vet ./...
 
+    - name: Verify Linux ILP32 native long decoding
+      env:
+        CGO_ENABLED: '0'
+      run: GOOS=linux GOARCH=386 go test ./pkg/paradox -run '^TestPxLongSignExtendsNativeNegativeValue$' -count=1
+
     - name: Run tests
       shell: bash
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,10 @@ jobs:
         cd web
         npm test
         npm run build
-        
+
+    - name: Audit Go pointer usage
+      run: go vet ./...
+
     - name: Run tests
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- The pxlib reader now keeps native data as typed pointers, bounds record and string reads, serializes close against active reads, and passes `go vet` without suppressions.
 - Standalone exports no longer contain Digitalogic pricing, formula, or shipping-method fields and warnings when no pricing integration is configured.
 - Windows file-lock monitoring now uses targeted Restart Manager queries instead of overlapping system-wide handle snapshots that could exhaust committed memory.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ shared-object path for troubleshooting. On Windows foreground `.db` read
 failures show a TaskDialog-style message by default; set
 `PATRIS_EXPORT_NO_TASKDIALOG=1` for scripts and services.
 
+The native boundary's audited layouts, pointer-lifetime rules, read bounds,
+and backend requirements are documented in [docs/PXLIB-FFI.md](docs/PXLIB-FFI.md).
+
 ## 📖 Usage
 
 ### Convert Database to JSON

--- a/docs/PXLIB-FFI.md
+++ b/docs/PXLIB-FFI.md
@@ -23,15 +23,24 @@ struct px_val {
 The release targets are Windows amd64 (LLP64) and Linux amd64 (LP64). Both use
 8-byte pointers and 4-byte `int`; `px_field` has offsets 0/8/12/16 and size 24,
 while `px_val` has offsets 0/4/8 and size 24. Windows uses a 4-byte C `long`
-and Linux uses an 8-byte C `long`; the platform-specific `pxLong` readers
-preserve that distinction. The string union member is 16 bytes on both
+on both ILP32 and LLP64. Unix uses a 4-byte C `long` on ILP32 and an 8-byte C
+`long` on LP64. The platform-specific `pxLong` readers select that width before
+sign-extending to Go's `int64`. The string union member is 16 bytes on both
 64-bit targets.
 
-The Go mirrors also remain layout-correct for ILP32 source builds: 4-byte
-pointers produce a 16-byte `px_field`, a 16-byte `px_val`, and an 8-byte
-string member. Patris Export does not publish 32-bit artifacts. Unit tests
-derive and assert all offsets and sizes from the active pointer width, so a
-new architecture fails before it can silently use a different layout.
+The Go mirrors are layout-correct for ILP32 compilation: 4-byte pointers
+produce a 16-byte `px_field`, a 16-byte `px_val`, and an 8-byte string member.
+Patris Export does not publish any 32-bit artifact. Unit tests derive and
+assert all offsets and sizes from the active pointer width, so a new
+architecture fails before it can silently use a different layout.
+
+CI runs the negative-C-long regression as a Linux/386 executable; this would
+decode `-1` as `4294967295` if an ILP32 build read the full 8-byte union.
+Linux/386 is the only ILP32 runtime exercised by this audit. Windows/386
+runtime-dynamic remains unsupported and unverified: pxlib's WIN32 API uses
+`__cdecl`, and cross-compiling cannot prove that purego `RegisterFunc` invokes
+that 32-bit calling convention correctly. The Windows/386 checks in this work
+are layout/compilation evidence only, not a runtime support claim.
 
 ## Bounds, ownership, and lifetime
 

--- a/docs/PXLIB-FFI.md
+++ b/docs/PXLIB-FFI.md
@@ -1,0 +1,82 @@
+# pxlib FFI boundary
+
+Patris Export loads the pinned pxlib revision in `dependencies/pxlib.ref` at
+runtime by default. Library and symbol handles are integer-valued platform
+handles, but pxlib data is always represented as `unsafe.Pointer` or a typed
+native pointer. Data pointers must never make a `pointer -> uintptr -> pointer`
+round trip.
+
+## Audited ABI
+
+The definitions below mirror `paradox.h` at pxlib revision
+`e32d17611e5ee353c4e3ce04e61b0b38feb95855`:
+
+```c
+struct px_field { char *px_fname; char px_ftype; int px_flen; int px_fdc; };
+struct px_val {
+    char isnull;
+    int type;
+    union { long lval; double dval; struct { char *val; int len; } str; } value;
+};
+```
+
+The release targets are Windows amd64 (LLP64) and Linux amd64 (LP64). Both use
+8-byte pointers and 4-byte `int`; `px_field` has offsets 0/8/12/16 and size 24,
+while `px_val` has offsets 0/4/8 and size 24. Windows uses a 4-byte C `long`
+and Linux uses an 8-byte C `long`; the platform-specific `pxLong` readers
+preserve that distinction. The string union member is 16 bytes on both
+64-bit targets.
+
+The Go mirrors also remain layout-correct for ILP32 source builds: 4-byte
+pointers produce a 16-byte `px_field`, a 16-byte `px_val`, and an 8-byte
+string member. Patris Export does not publish 32-bit artifacts. Unit tests
+derive and assert all offsets and sizes from the active pointer width, so a
+new architecture fails before it can silently use a different layout.
+
+## Bounds, ownership, and lifetime
+
+- `PX_get_num_fields` is validated as non-negative and no greater than the
+  unsigned 16-bit Paradox header limit before it sizes the `pxval_t **` view.
+  A non-empty record with a null array pointer is rejected.
+- The pinned pxlib parser uses a 300-byte temporary field-name buffer and
+  always appends a NUL. Patris Export scans with `unsafe.Add` and fails if a
+  terminator is not found within that exact contract; it never performs an
+  unbounded integer-address walk.
+- String/blob/byte values are copied immediately using pxlib's signed
+  32-bit length. Negative lengths and a null pointer paired with a positive
+  length are rejected before `unsafe.Slice` is constructed.
+- `PX_get_field` returns metadata owned by the open `pxdoc_t`.
+  `PX_retrieve_record` returns an array and values allocated through the
+  document's configured allocator. The pinned public API exposes no matching
+  cross-runtime release function. Patris Export therefore copies every field
+  synchronously, retains no native pointer, and does not call a potentially
+  incompatible C runtime's `free`.
+- Each `Database` holds a read lock for the complete metadata/value-copy
+  window. `Close` takes the write lock before `PX_close` and `PX_delete`, so
+  document-owned memory cannot be released concurrently with a Go read.
+  `runtime.KeepAlive` makes the access window explicit to the compiler.
+
+## Backends
+
+The default `runtime-dynamic` backend binds the typed signatures through
+purego. Optional `cgo` and `cgo-static` variants must implement the same
+`pxlib` function fields by converting `C.pxdoc_t *`, `C.pxfield_t *`, and
+`C.pxval_t **` directly to `unsafe.Pointer` or their corresponding typed Go
+pointers. They must not restore integer-held data addresses. Link mode does not
+change the C layouts, ownership, bounds, or locking rules above.
+
+## Verification
+
+The portable regression gate is:
+
+```text
+go vet ./...
+go test ./...
+go test -race ./pkg/paradox
+```
+
+Release workflows additionally build and read `testdata/kala.db` with the
+source-built pxlib runtime on Linux amd64, native Windows amd64, and the MinGW
+Windows cross-build under Wine. Optional CGO link-mode verification remains
+part of the backend-specific work and must use the same real-database smoke
+test before such an artifact is published.

--- a/pkg/paradox/native.go
+++ b/pkg/paradox/native.go
@@ -84,21 +84,35 @@ type pxlib struct {
 
 	pxBoot           func()
 	pxShutdown       func()
-	pxNew            func() uintptr
-	pxOpenFile       func(uintptr, string) int32
-	pxClose          func(uintptr)
-	pxDelete         func(uintptr)
-	pxGetNumFields   func(uintptr) int32
-	pxGetNumRecords  func(uintptr) int32
-	pxGetField       func(uintptr, int32) uintptr
-	pxRetrieveRecord func(uintptr, int32) uintptr
+	pxNew            func() unsafe.Pointer
+	pxOpenFile       func(unsafe.Pointer, string) int32
+	pxClose          func(unsafe.Pointer)
+	pxDelete         func(unsafe.Pointer)
+	pxGetNumFields   func(unsafe.Pointer) int32
+	pxGetNumRecords  func(unsafe.Pointer) int32
+	pxGetField       func(unsafe.Pointer, int32) *pxField
+	pxRetrieveRecord func(unsafe.Pointer, int32) **pxVal
 }
 
+// pxField mirrors pxlib's pxfield_t. The explicit padding keeps px_flen at
+// offset 8 on 32-bit targets and offset 12 on 64-bit targets, matching the C
+// ABI on the supported ILP32, LP64, and LLP64 platforms.
+type pxField struct {
+	name         *byte
+	typ          int8
+	_            [3]byte
+	length       int32
+	decimalCount int32
+}
+
+// pxVal mirrors pxlib's pxval_t. The union is two pointer-width words: 8 bytes
+// on 32-bit targets and 16 bytes on 64-bit targets. That is the size of the
+// largest C union member (the pointer/length string descriptor) on both ABIs.
 type pxVal struct {
 	isNull int8
 	_      [3]byte
 	typ    int32
-	value  [16]byte
+	value  [2]uintptr
 }
 
 type pxStringValue struct {
@@ -108,8 +122,9 @@ type pxStringValue struct {
 
 // Database represents a Paradox database file.
 type Database struct {
+	mu    sync.RWMutex
 	lib   *pxlib
-	pxdoc uintptr
+	pxdoc unsafe.Pointer
 	path  string
 }
 
@@ -123,7 +138,7 @@ func Open(path string) (*Database, error) {
 	lib.pxBoot()
 
 	pxdoc := lib.pxNew()
-	if pxdoc == 0 {
+	if pxdoc == nil {
 		return nil, fmt.Errorf("failed to create pxdoc structure")
 	}
 
@@ -141,32 +156,43 @@ func Open(path string) (*Database, error) {
 
 // Close closes the database.
 func (db *Database) Close() error {
-	if db.pxdoc != 0 {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if db.pxdoc != nil {
 		db.lib.pxClose(db.pxdoc)
 		db.lib.pxDelete(db.pxdoc)
-		db.pxdoc = 0
+		db.pxdoc = nil
 	}
 	return nil
 }
 
 // GetFields returns the list of fields in the database.
 func (db *Database) GetFields() ([]Field, error) {
-	if db.pxdoc == 0 {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	defer runtime.KeepAlive(db)
+
+	if db.pxdoc == nil {
 		return nil, fmt.Errorf("database is not open")
 	}
 
-	numFields := int(db.lib.pxGetNumFields(db.pxdoc))
+	numFields, err := nativeFieldCount(db.lib.pxGetNumFields(db.pxdoc))
+	if err != nil {
+		return nil, err
+	}
 	fields := make([]Field, numFields)
 
 	for i := 0; i < numFields; i++ {
-		fieldPtr := db.lib.pxGetField(db.pxdoc, int32(i))
-		if fieldPtr == 0 {
-			continue
+		field := db.lib.pxGetField(db.pxdoc, int32(i))
+		name, err := nativeFieldName(field)
+		if err != nil {
+			return nil, fmt.Errorf("decode field %d metadata: %w", i, err)
 		}
 		fields[i] = Field{
-			Name: cString(fieldName(fieldPtr)),
-			Type: fieldTypeName(fieldType(fieldPtr)),
-			Size: int(fieldLen(fieldPtr)),
+			Name: name,
+			Type: fieldTypeName(field.typ),
+			Size: int(field.length),
 		}
 	}
 
@@ -175,36 +201,55 @@ func (db *Database) GetFields() ([]Field, error) {
 
 // GetRecords returns all records from the database.
 func (db *Database) GetRecords() ([]Record, error) {
-	if db.pxdoc == 0 {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	defer runtime.KeepAlive(db)
+
+	if db.pxdoc == nil {
 		return nil, fmt.Errorf("database is not open")
 	}
 
-	numRecords := int(db.lib.pxGetNumRecords(db.pxdoc))
-	numFields := int(db.lib.pxGetNumFields(db.pxdoc))
+	numRecords, err := nonNegativeNativeCount("record", db.lib.pxGetNumRecords(db.pxdoc))
+	if err != nil {
+		return nil, err
+	}
+	numFields, err := nativeFieldCount(db.lib.pxGetNumFields(db.pxdoc))
+	if err != nil {
+		return nil, err
+	}
 	records := make([]Record, 0, numRecords)
 
 	for i := 0; i < numRecords; i++ {
 		valuesPtr := db.lib.pxRetrieveRecord(db.pxdoc, int32(i))
-		if valuesPtr == 0 {
+		if valuesPtr == nil {
 			continue
 		}
 
-		values := unsafe.Slice((*uintptr)(unsafe.Pointer(valuesPtr)), numFields)
+		values, err := nativeRecordValues(valuesPtr, numFields)
+		if err != nil {
+			return nil, fmt.Errorf("decode record %d values: %w", i, err)
+		}
 		record := make(Record)
 
 		for j := 0; j < numFields; j++ {
-			fieldPtr := db.lib.pxGetField(db.pxdoc, int32(j))
-			if fieldPtr == 0 || values[j] == 0 {
+			fieldMeta := db.lib.pxGetField(db.pxdoc, int32(j))
+			if values[j] == nil {
 				continue
 			}
 
-			field := cString(fieldName(fieldPtr))
-			nativeValue := (*pxVal)(unsafe.Pointer(values[j]))
+			field, err := nativeFieldName(fieldMeta)
+			if err != nil {
+				return nil, fmt.Errorf("decode record %d field %d metadata: %w", i, j, err)
+			}
+			nativeValue := values[j]
 			if nativeValue.isNull != 0 {
 				record[field] = nil
 				continue
 			}
-			value := getFieldValue(nativeValue, fieldType(fieldPtr))
+			value, err := getFieldValue(nativeValue, fieldMeta.typ)
+			if err != nil {
+				return nil, fmt.Errorf("decode record %d field %q: %w", i, field, err)
+			}
 			if value != nil {
 				record[field] = value
 			}
@@ -218,18 +263,34 @@ func (db *Database) GetRecords() ([]Record, error) {
 
 // GetNumRecords returns the number of records in the database.
 func (db *Database) GetNumRecords() int {
-	if db.pxdoc == 0 {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	defer runtime.KeepAlive(db)
+
+	if db.pxdoc == nil {
 		return 0
 	}
-	return int(db.lib.pxGetNumRecords(db.pxdoc))
+	count, err := nonNegativeNativeCount("record", db.lib.pxGetNumRecords(db.pxdoc))
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 // GetNumFields returns the number of fields in the database.
 func (db *Database) GetNumFields() int {
-	if db.pxdoc == 0 {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	defer runtime.KeepAlive(db)
+
+	if db.pxdoc == nil {
 		return 0
 	}
-	return int(db.lib.pxGetNumFields(db.pxdoc))
+	count, err := nativeFieldCount(db.lib.pxGetNumFields(db.pxdoc))
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 // Shutdown shuts down pxlib.
@@ -416,62 +477,109 @@ func fieldTypeName(fieldType int8) string {
 	}
 }
 
-func fieldName(fieldPtr uintptr) *byte {
-	return *(**byte)(unsafe.Pointer(fieldPtr))
-}
-
-func fieldType(fieldPtr uintptr) int8 {
-	return *(*int8)(unsafe.Pointer(fieldPtr + unsafe.Sizeof(uintptr(0))))
-}
-
-func fieldLen(fieldPtr uintptr) int32 {
-	return *(*int32)(unsafe.Pointer(fieldPtr + alignUp(unsafe.Sizeof(uintptr(0))+1, 4)))
-}
-
 func alignUp(value, alignment uintptr) uintptr {
 	return (value + alignment - 1) &^ (alignment - 1)
 }
 
-func getFieldValue(value *pxVal, fieldType int8) interface{} {
+const (
+	// pxlib's pinned parser reads field names into TMPBUFFSIZE and always adds
+	// a terminator. Scanning beyond this contract would turn malformed native
+	// output into an unbounded read.
+	maxNativeFieldNameBytes = 300
+	// Paradox stores the field count in an unsigned 16-bit header value. This
+	// cap also bounds the pxval_t** slice returned by PX_retrieve_record.
+	maxNativeFields = 1<<16 - 1
+	// Field length is stored in the file's one-byte TFldInfoRec.fSize member.
+	maxNativeFieldBytes = 1<<8 - 1
+)
+
+func nonNegativeNativeCount(kind string, count int32) (int, error) {
+	if count < 0 {
+		return 0, fmt.Errorf("pxlib returned negative %s count %d", kind, count)
+	}
+	return int(count), nil
+}
+
+func nativeFieldCount(count int32) (int, error) {
+	value, err := nonNegativeNativeCount("field", count)
+	if err != nil {
+		return 0, err
+	}
+	if value > maxNativeFields {
+		return 0, fmt.Errorf("pxlib returned field count %d above Paradox limit %d", value, maxNativeFields)
+	}
+	return value, nil
+}
+
+func nativeRecordValues(values **pxVal, count int) ([]*pxVal, error) {
+	if count < 0 || count > maxNativeFields {
+		return nil, fmt.Errorf("invalid record field count %d", count)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	if values == nil {
+		return nil, fmt.Errorf("pxlib returned a null record array for %d fields", count)
+	}
+	return unsafe.Slice(values, count), nil
+}
+
+func nativeFieldName(field *pxField) (string, error) {
+	if field == nil {
+		return "", fmt.Errorf("pxlib returned null field metadata")
+	}
+	if field.length < 0 || field.length > maxNativeFieldBytes {
+		return "", fmt.Errorf("pxlib returned invalid field length %d", field.length)
+	}
+	return cString(field.name)
+}
+
+func getFieldValue(value *pxVal, fieldType int8) (interface{}, error) {
 	if value == nil || value.isNull != 0 {
-		return nil
+		return nil, nil
 	}
 
 	switch fieldType {
-	case pxfAlpha:
+	case pxfAlpha, pxfMemoBLOb, pxfBLOb, pxfFmtMemoBLOb, pxfOLE, pxfGraphic, pxfBCD, pxfBytes:
 		return pxString(value)
-	case pxfShort, pxfLong, pxfAutoInc, pxfDate:
-		return int(pxLong(value))
-	case pxfNumber, pxfCurrency:
-		return *(*float64)(unsafe.Pointer(&value.value[0]))
+	case pxfShort, pxfLong, pxfAutoInc, pxfDate, pxfTime:
+		return int(pxLong(value)), nil
+	case pxfNumber, pxfCurrency, pxfTimestamp:
+		return *(*float64)(unsafe.Pointer(&value.value[0])), nil
 	case pxfLogical:
-		return pxLong(value) != 0
-	default:
-		if str := pxString(value); str != "" {
-			return str
-		}
+		return pxLong(value) != 0, nil
 	}
-	return nil
+	return nil, nil
 }
 
-func pxString(value *pxVal) string {
+func pxString(value *pxVal) (string, error) {
+	if value == nil {
+		return "", nil
+	}
 	str := (*pxStringValue)(unsafe.Pointer(&value.value[0]))
-	if str.ptr == nil || str.len <= 0 {
-		return ""
+	if str.len < 0 {
+		return "", fmt.Errorf("pxlib returned negative string length %d", str.len)
 	}
-	return string(unsafe.Slice(str.ptr, int(str.len)))
+	if str.ptr == nil {
+		if str.len != 0 {
+			return "", fmt.Errorf("pxlib returned null string data with length %d", str.len)
+		}
+		return "", nil
+	}
+	if str.len == 0 {
+		return "", nil
+	}
+	return string(unsafe.Slice(str.ptr, int(str.len))), nil
 }
 
-func cString(ptr *byte) string {
+func cString(ptr *byte) (string, error) {
 	if ptr == nil {
-		return ""
+		return "", nil
 	}
-	var n int
-	for p := uintptr(unsafe.Pointer(ptr)); ; p++ {
-		if *(*byte)(unsafe.Pointer(p)) == 0 {
-			break
+	for n := 0; n < maxNativeFieldNameBytes; n++ {
+		if *(*byte)(unsafe.Add(unsafe.Pointer(ptr), n)) == 0 {
+			return string(unsafe.Slice(ptr, n)), nil
 		}
-		n++
 	}
-	return string(unsafe.Slice(ptr, n))
+	return "", fmt.Errorf("pxlib field name is not NUL-terminated within %d bytes", maxNativeFieldNameBytes)
 }

--- a/pkg/paradox/native.go
+++ b/pkg/paradox/native.go
@@ -96,7 +96,8 @@ type pxlib struct {
 
 // pxField mirrors pxlib's pxfield_t. The explicit padding keeps px_flen at
 // offset 8 on 32-bit targets and offset 12 on 64-bit targets, matching the C
-// ABI on the supported ILP32, LP64, and LLP64 platforms.
+// layouts audited for ILP32, LP64, and LLP64. Runtime support remains limited
+// to the platform/backend combinations documented in docs/PXLIB-FFI.md.
 type pxField struct {
 	name         *byte
 	typ          int8

--- a/pkg/paradox/native_test.go
+++ b/pkg/paradox/native_test.go
@@ -3,9 +3,186 @@ package paradox
 import (
 	"errors"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
+	"unsafe"
 )
+
+func TestPxlibABILayout(t *testing.T) {
+	pointerSize := unsafe.Sizeof(uintptr(0))
+	fieldLengthOffset := alignUp(pointerSize+1, unsafe.Alignof(int32(0)))
+	fieldSize := alignUp(fieldLengthOffset+2*unsafe.Sizeof(int32(0)), pointerSize)
+	valueSize := uintptr(8) + 2*pointerSize
+	stringSize := alignUp(pointerSize+unsafe.Sizeof(int32(0)), pointerSize)
+
+	if got := unsafe.Offsetof(pxField{}.name); got != 0 {
+		t.Fatalf("pxField.name offset = %d, want 0", got)
+	}
+	if got := unsafe.Offsetof(pxField{}.typ); got != pointerSize {
+		t.Fatalf("pxField.typ offset = %d, want %d", got, pointerSize)
+	}
+	if got := unsafe.Offsetof(pxField{}.length); got != fieldLengthOffset {
+		t.Fatalf("pxField.length offset = %d, want %d", got, fieldLengthOffset)
+	}
+	if got := unsafe.Offsetof(pxField{}.decimalCount); got != fieldLengthOffset+4 {
+		t.Fatalf("pxField.decimalCount offset = %d, want %d", got, fieldLengthOffset+4)
+	}
+	if got := unsafe.Sizeof(pxField{}); got != fieldSize {
+		t.Fatalf("pxField size = %d, want %d", got, fieldSize)
+	}
+
+	if got := unsafe.Offsetof(pxVal{}.typ); got != 4 {
+		t.Fatalf("pxVal.typ offset = %d, want 4", got)
+	}
+	if got := unsafe.Offsetof(pxVal{}.value); got != 8 {
+		t.Fatalf("pxVal.value offset = %d, want 8", got)
+	}
+	if got := unsafe.Sizeof(pxVal{}); got != valueSize {
+		t.Fatalf("pxVal size = %d, want %d", got, valueSize)
+	}
+
+	if got := unsafe.Offsetof(pxStringValue{}.len); got != pointerSize {
+		t.Fatalf("pxStringValue.len offset = %d, want %d", got, pointerSize)
+	}
+	if got := unsafe.Sizeof(pxStringValue{}); got != stringSize {
+		t.Fatalf("pxStringValue size = %d, want %d", got, stringSize)
+	}
+}
+
+func TestCStringIsBounded(t *testing.T) {
+	value := []byte("Code\x00ignored")
+	got, err := cString(&value[0])
+	if err != nil {
+		t.Fatalf("cString(valid) error = %v", err)
+	}
+	if got != "Code" {
+		t.Fatalf("cString(valid) = %q, want Code", got)
+	}
+
+	got, err = cString(nil)
+	if err != nil || got != "" {
+		t.Fatalf("cString(nil) = %q, %v; want empty, nil", got, err)
+	}
+
+	unterminated := make([]byte, maxNativeFieldNameBytes)
+	for i := range unterminated {
+		unterminated[i] = 'x'
+	}
+	if _, err := cString(&unterminated[0]); err == nil {
+		t.Fatal("cString accepted a field name without a bounded terminator")
+	}
+}
+
+func TestNativeRecordValuesValidatesArray(t *testing.T) {
+	first := &pxVal{}
+	third := &pxVal{}
+	native := []*pxVal{first, nil, third}
+
+	got, err := nativeRecordValues(&native[0], len(native))
+	if err != nil {
+		t.Fatalf("nativeRecordValues(valid) error = %v", err)
+	}
+	if len(got) != len(native) || got[0] != first || got[1] != nil || got[2] != third {
+		t.Fatalf("nativeRecordValues(valid) = %#v, want %#v", got, native)
+	}
+	if got, err := nativeRecordValues(nil, 0); err != nil || got != nil {
+		t.Fatalf("nativeRecordValues(nil, 0) = %#v, %v; want nil, nil", got, err)
+	}
+	if _, err := nativeRecordValues(nil, 1); err == nil {
+		t.Fatal("nativeRecordValues accepted a null non-empty array")
+	}
+	if _, err := nativeRecordValues(&native[0], -1); err == nil {
+		t.Fatal("nativeRecordValues accepted a negative field count")
+	}
+	if _, err := nativeRecordValues(&native[0], maxNativeFields+1); err == nil {
+		t.Fatal("nativeRecordValues accepted a field count above the Paradox limit")
+	}
+}
+
+func TestPxStringValidatesDescriptor(t *testing.T) {
+	value := &pxVal{}
+	setPxStringForTest(value, nil, 3)
+	if _, err := pxString(value); err == nil {
+		t.Fatal("pxString accepted null data with a positive length")
+	}
+
+	setPxStringForTest(value, nil, -1)
+	if _, err := pxString(value); err == nil {
+		t.Fatal("pxString accepted a negative length")
+	}
+
+	data := []byte("Patris")
+	setPxStringForTest(value, &data[0], int32(len(data)))
+	got, err := pxString(value)
+	runtime.KeepAlive(data)
+	if err != nil {
+		t.Fatalf("pxString(valid) error = %v", err)
+	}
+	if got != "Patris" {
+		t.Fatalf("pxString(valid) = %q, want Patris", got)
+	}
+}
+
+func TestGetFieldValueUsesAuditedUnionMember(t *testing.T) {
+	value := &pxVal{}
+	*(*float64)(unsafe.Pointer(&value.value[0])) = 123.5
+	got, err := getFieldValue(value, pxfTimestamp)
+	if err != nil {
+		t.Fatalf("getFieldValue(timestamp) error = %v", err)
+	}
+	if got != 123.5 {
+		t.Fatalf("getFieldValue(timestamp) = %#v, want 123.5", got)
+	}
+
+	got, err = getFieldValue(value, 0x7f)
+	if err != nil || got != nil {
+		t.Fatalf("getFieldValue(unknown) = %#v, %v; want nil, nil", got, err)
+	}
+
+	value.isNull = 1
+	got, err = getFieldValue(value, pxfAlpha)
+	if err != nil || got != nil {
+		t.Fatalf("getFieldValue(null) = %#v, %v; want nil, nil", got, err)
+	}
+}
+
+func TestNativeCountsRejectMalformedValues(t *testing.T) {
+	if _, err := nonNegativeNativeCount("record", -1); err == nil {
+		t.Fatal("nonNegativeNativeCount accepted a negative record count")
+	}
+	if _, err := nativeFieldCount(-1); err == nil {
+		t.Fatal("nativeFieldCount accepted a negative field count")
+	}
+}
+
+func TestNativeFieldMetadataRejectsInvalidValues(t *testing.T) {
+	if _, err := nativeFieldName(nil); err == nil {
+		t.Fatal("nativeFieldName accepted null metadata")
+	}
+
+	name := []byte("Code\x00")
+	field := &pxField{name: &name[0], length: 4}
+	got, err := nativeFieldName(field)
+	if err != nil || got != "Code" {
+		t.Fatalf("nativeFieldName(valid) = %q, %v; want Code, nil", got, err)
+	}
+
+	field.length = -1
+	if _, err := nativeFieldName(field); err == nil {
+		t.Fatal("nativeFieldName accepted a negative field length")
+	}
+	field.length = maxNativeFieldBytes + 1
+	if _, err := nativeFieldName(field); err == nil {
+		t.Fatal("nativeFieldName accepted a field length above TFldInfoRec.fSize")
+	}
+}
+
+func setPxStringForTest(value *pxVal, ptr *byte, length int32) {
+	descriptor := (*pxStringValue)(unsafe.Pointer(&value.value[0]))
+	descriptor.ptr = ptr
+	descriptor.len = length
+}
 
 func TestOpenReportsMissingNativeRuntime(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_PXLIB_LIBRARY", filepath.Join(t.TempDir(), "missing-pxlib-runtime.dll"))

--- a/pkg/paradox/native_test.go
+++ b/pkg/paradox/native_test.go
@@ -147,6 +147,19 @@ func TestGetFieldValueUsesAuditedUnionMember(t *testing.T) {
 	}
 }
 
+func TestPxLongSignExtendsNativeNegativeValue(t *testing.T) {
+	value := &pxVal{}
+	if runtime.GOOS == "windows" || unsafe.Sizeof(uintptr(0)) == 4 {
+		*(*int32)(unsafe.Pointer(&value.value[0])) = -1
+	} else {
+		*(*int64)(unsafe.Pointer(&value.value[0])) = -1
+	}
+
+	if got := pxLong(value); got != -1 {
+		t.Fatalf("pxLong(native -1) = %d, want -1", got)
+	}
+}
+
 func TestNativeCountsRejectMalformedValues(t *testing.T) {
 	if _, err := nonNegativeNativeCount("record", -1); err == nil {
 		t.Fatal("nonNegativeNativeCount accepted a negative record count")

--- a/pkg/paradox/native_unix.go
+++ b/pkg/paradox/native_unix.go
@@ -29,5 +29,11 @@ func prepareLibraryLoad() {
 }
 
 func pxLong(value *pxVal) int64 {
+	// C long follows the platform data model: four bytes on ILP32 and eight
+	// bytes on LP64. Reading eight bytes on a 32-bit target loses the sign when
+	// the adjacent union storage is zero, for example -1 becomes 4294967295.
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		return int64(*(*int32)(unsafe.Pointer(&value.value[0])))
+	}
 	return *(*int64)(unsafe.Pointer(&value.value[0]))
 }


### PR DESCRIPTION
## Summary
- keep pxlib data pointers typed from the purego return boundary through field/value decoding; library and symbol handles remain `uintptr`
- mirror the audited `pxfield_t`/`pxval_t` layouts on release LLP64/LP64 targets and compile-audited ILP32, validate field/record/string bounds, and serialize `Close` against active native reads
- select Unix C `long` width by ILP32/LP64 so a 32-bit `-1` is sign-extended instead of decoded as `4294967295`
- replace the unbounded integer-address C-string scan with the pinned pxlib 300-byte contract and `unsafe.Add`
- document ABI, ownership, lifetime, and backend support boundaries, and add vet plus Linux/386 negative-long regression gates to CI

Progresses #181. The six reported default-backend warnings are fixed. Keep #181 open until the optional CGO backend from #176 is integrated and the same vet/real-database matrix is rerun for `pxlib_cgo` and `pxlib_cgo_static`; those backend files are not present on current `main`.

## Exact warning coverage
- record `pxval_t **` base no longer converts an integer address to `unsafe.Pointer`
- record entries are a typed `[]*pxVal`, eliminating each `uintptr`-held `pxval_t *`
- `px_field` name/type/length use one audited typed struct instead of three offset-based integer casts
- field names use a bounded `unsafe.Add` scan instead of incrementing a `uintptr`

## Verification
- `npm clean-install`, `npm test` (27/27), `npm run build`
- `go vet ./...`
- `go test ./...`
- `go test -race ./pkg/paradox`
- `go test -gcflags=all=-d=checkptr=2 ./pkg/paradox`
- Windows amd64 runtime-dynamic build
- Linux amd64 runtime-dynamic cross-build with `CGO_ENABLED=0`, plus Linux-target `go vet ./pkg/paradox`
- Linux/386 test binary compiled locally; CI runs `GOOS=linux GOARCH=386 CGO_ENABLED=0 go test ./pkg/paradox -run '^TestPxLongSignExtendsNativeNegativeValue$' -count=1`
- pinned local pxlib DLL smoke against checked-in `testdata/kala.db`: 354 records, 28 fields, records decoded

### Reviewed live source comparison

Re-ran the comparison after the ILP32 fix against `origin/main` (`f085dc344bd54fc2a2bda8d99dfd0c112384216b`) and `C:\Patris\data4\kala.db`, using the pinned local pxlib runtime and normal temporary-copy path. The source stayed stable during both reads.

- both read 1,002 records and 28 fields
- all 28 field definition lines were identical (including `Code` long/4, `Name` alpha/55, `Invahed` number/8, and `Sefaresh` long/4)
- complete `--raw` JSON outputs were byte-identical
- both SHA-256: `539274E6452480557799C7B7B6D6E6BA81F5A2FF4ED7C69A2F7EE773CC32E63E`

## Backend and architecture note

`runtime-dynamic` remains the default and no native artifact is promoted. Windows amd64 and Linux amd64 are the release/runtime targets. Linux/386 is exercised only for the focused ILP32 regression. Windows/386 runtime-dynamic is explicitly unsupported and unverified: pxlib WIN32 is `__cdecl`, and cross-compilation cannot prove purego `RegisterFunc` calling-convention behavior.

When #176 lands, its CGO wrappers must implement the new pointer-typed function fields directly (without reintroducing `uintptr` data addresses), then run vet, real-database smoke, and the shared/static backend checks before #181 can close.