### PR TITLE
Add canonical snapshot identity verifier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+testdata/*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 !testdata/*.txt
 !testdata/canonical-static-config.json
 !testdata/patris-product-sync.synthetic.json
+!testdata/patris-product-sync.standalone.json
 
 # Web/Node.js
 web/node_modules/

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -269,7 +269,7 @@ Set GITHUB_TOKEN for private repositories and higher API rate limits.`,
 	updateCmd.Flags().String("api-url", "", "Update from a Patris Export API base URL using /api/update/manifest")
 	updateCmd.Flags().String("manifest-url", "", "Update from an explicit Patris Export executable manifest URL")
 
-	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, viewCmd, serveCmd, stubCmd, ipcCmd, tuiCmd, updateCmd, newLicenseCommand())
+	rootCmd.AddCommand(convertCmd, infoCmd, companyCmd, viewCmd, serveCmd, stubCmd, ipcCmd, tuiCmd, updateCmd, newVerifyCommand(), newLicenseCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		nativeui.ShowNativeDependencyError(err)

--- a/cmd/patris-export/verify.go
+++ b/cmd/patris-export/verify.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/atomicdeploy/patris-export/pkg/canonical"
+	"github.com/spf13/cobra"
+)
+
+const maxCanonicalSnapshotBytes int64 = canonical.MaxSnapshotBytes
+
+func newVerifyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:           "verify <snapshot.json|->",
+		Short:         "Verify a canonical product-sync snapshot without applying it",
+		Args:          cobra.ExactArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := readVerifyInput(cmd, args[0])
+			if err != nil {
+				return err
+			}
+			_, summary, err := canonical.VerifySnapshotJSON(data)
+			if err != nil {
+				return fmt.Errorf("snapshot verification failed: %w", err)
+			}
+			_, err = fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"valid snapshot: products=%d categories=%d excluded=%d quarantined=%d warnings=%d source=%q/%q revision=%s event=%s\n",
+				summary.Products,
+				summary.Categories,
+				summary.ExcludedCodes,
+				summary.QuarantinedCodes,
+				summary.Warnings,
+				summary.SourceID,
+				summary.SourceDataset,
+				summary.SourceRevision,
+				summary.EventID,
+			)
+			return err
+		},
+	}
+}
+
+func readVerifyInput(cmd *cobra.Command, source string) ([]byte, error) {
+	if source == "-" {
+		return readBoundedSnapshot(cmd.InOrStdin())
+	}
+
+	path := filepath.Clean(source)
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect snapshot: %w", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("snapshot path must not be a symbolic link")
+	}
+	if !before.Mode().IsRegular() {
+		return nil, fmt.Errorf("snapshot path must be a regular file")
+	}
+	if before.Size() > maxCanonicalSnapshotBytes {
+		return nil, fmt.Errorf("snapshot exceeds the %d-byte limit", maxCanonicalSnapshotBytes)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot: %w", err)
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect opened snapshot: %w", err)
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return nil, fmt.Errorf("snapshot changed before it could be read")
+	}
+
+	data, err := readBoundedSnapshot(file)
+	if err != nil {
+		return nil, err
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect read snapshot: %w", err)
+	}
+	if !os.SameFile(opened, after) || opened.Size() != after.Size() || !opened.ModTime().Equal(after.ModTime()) {
+		return nil, fmt.Errorf("snapshot changed while it was being read")
+	}
+	return data, nil
+}
+
+func readBoundedSnapshot(reader io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxCanonicalSnapshotBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read snapshot: %w", err)
+	}
+	if int64(len(data)) > maxCanonicalSnapshotBytes {
+		return nil, fmt.Errorf("snapshot exceeds the %d-byte limit", maxCanonicalSnapshotBytes)
+	}
+	return data, nil
+}

--- a/cmd/patris-export/verify_test.go
+++ b/cmd/patris-export/verify_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyCommandAcceptsExactSnapshotBytesFromStdin(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("..", "..", "testdata", "patris-product-sync.synthetic.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := newVerifyCommand()
+	cmd.SetArgs([]string{"-"})
+	cmd.SetIn(bytes.NewReader(fixture))
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("verify stdin: %v", err)
+	}
+	text := output.String()
+	for _, expected := range []string{"valid snapshot:", "products=2", "categories=2", `source="synthetic-fixture"/"synthetic-kala.db"`} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("summary %q does not contain %q", text, expected)
+		}
+	}
+}
+
+func TestVerifyCommandReadsRegularFileWithoutMutation(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("..", "..", "testdata", "patris-product-sync.synthetic.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+	if err := os.WriteFile(path, fixture, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newVerifyCommand()
+	cmd.SetArgs([]string{path})
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("verify file: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, fixture) {
+		t.Fatal("verify modified the snapshot")
+	}
+}
+
+func TestVerifyCommandFailsClosed(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("..", "..", "testdata", "patris-product-sync.synthetic.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := map[string][]byte{
+		"hash mismatch": bytes.Replace(fixture, []byte(`"event_id": "sha256:`), []byte(`"event_id": "sha256:0`), 1),
+		"oversized":     bytes.Repeat([]byte("x"), int(maxCanonicalSnapshotBytes+1)),
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := newVerifyCommand()
+			cmd.SetArgs([]string{"-"})
+			cmd.SetIn(bytes.NewReader(input))
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			if err := cmd.Execute(); err == nil {
+				t.Fatal("invalid snapshot was accepted")
+			}
+			if strings.Contains(output.String(), "valid snapshot:") {
+				t.Fatalf("invalid snapshot emitted a success summary: %q", output.String())
+			}
+		})
+	}
+}
+
+func TestVerifyCommandRejectsNonRegularPath(t *testing.T) {
+	cmd := newVerifyCommand()
+	cmd.SetArgs([]string{t.TempDir()})
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("directory error = %v", err)
+	}
+}

--- a/pkg/canonical/canonical_test.go
+++ b/pkg/canonical/canonical_test.go
@@ -417,6 +417,7 @@ func TestProductSyncDecoderRequiresCanonicalShippingPair(t *testing.T) {
 		"lowercase currency":  `{"product_code":"A","shipping_price_per_kg":120,"shipping_price_per_kg_currency":"cny"}`,
 		"other currency":      `{"product_code":"A","shipping_price_per_kg":120,"shipping_price_per_kg_currency":"USD"}`,
 		"whitespace currency": `{"product_code":"A","shipping_price_per_kg":120,"shipping_price_per_kg_currency":" CNY "}`,
+		"quoted price":        `{"product_code":"A","shipping_price_per_kg":"120","shipping_price_per_kg_currency":"CNY"}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			var product Product

--- a/pkg/canonical/contract.go
+++ b/pkg/canonical/contract.go
@@ -77,6 +77,7 @@ type Envelope struct {
 	DeletedCodes     []Tombstone `json:"deleted_codes,omitempty"`
 	QuarantinedCodes []string    `json:"quarantined_codes"`
 	Warnings         []string    `json:"warnings"`
+	fieldPresence    map[string]fieldPresence
 }
 
 func (envelope *Envelope) UnmarshalJSON(data []byte) error {
@@ -97,6 +98,16 @@ func (envelope *Envelope) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*envelope = Envelope(decoded)
+	envelope.fieldPresence = make(map[string]fieldPresence, 3)
+	for _, field := range []string{"local_currency", "formula_id", "deleted_codes"} {
+		if value, exists := raw[field]; exists {
+			if strings.TrimSpace(string(value)) == "null" {
+				envelope.fieldPresence[field] = fieldNull
+			} else {
+				envelope.fieldPresence[field] = fieldValue
+			}
+		}
+	}
 	return nil
 }
 
@@ -248,8 +259,8 @@ func eventID(envelope *Envelope) string {
 	type identity struct {
 		Schema           string      `json:"schema"`
 		EventType        string      `json:"event_type"`
-		LocalCurrency    string      `json:"local_currency"`
-		FormulaID        string      `json:"formula_id"`
+		LocalCurrency    string      `json:"local_currency,omitempty"`
+		FormulaID        string      `json:"formula_id,omitempty"`
 		Source           Source      `json:"source"`
 		GeneratedAt      string      `json:"generated_at"`
 		Products         []string    `json:"products"`
@@ -289,9 +300,19 @@ func cloneEnvelope(value *Envelope) *Envelope {
 	copy := *value
 	copy.Products = cloneProducts(value.Products)
 	copy.Categories = cloneCategories(value.Categories)
-	copy.ExcludedCodes = append([]string(nil), value.ExcludedCodes...)
+	if value.ExcludedCodes != nil {
+		copy.ExcludedCodes = append(make([]string, 0, len(value.ExcludedCodes)), value.ExcludedCodes...)
+	}
 	copy.DeletedCodes = append([]Tombstone(nil), value.DeletedCodes...)
-	copy.QuarantinedCodes = append([]string(nil), value.QuarantinedCodes...)
+	if value.QuarantinedCodes != nil {
+		copy.QuarantinedCodes = append(make([]string, 0, len(value.QuarantinedCodes)), value.QuarantinedCodes...)
+	}
+	if value.fieldPresence != nil {
+		copy.fieldPresence = make(map[string]fieldPresence, len(value.fieldPresence))
+		for field, state := range value.fieldPresence {
+			copy.fieldPresence[field] = state
+		}
+	}
 	if value.Warnings != nil {
 		copy.Warnings = append(make([]string, 0, len(value.Warnings)), value.Warnings...)
 	}

--- a/pkg/canonical/kala.go
+++ b/pkg/canonical/kala.go
@@ -521,7 +521,7 @@ func parseKalaProduct(ctx context.Context, row map[string]interface{}, provider 
 // required by the existing spreadsheet and SQL sink boundary.
 func (product Product) Map() map[string]interface{} {
 	row := map[string]interface{}{"product_code": product.ProductCode}
-	putString(row, "category_code", product.CategoryCode, fieldAbsent)
+	putString(row, "category_code", product.CategoryCode, product.presence("category_code"))
 	putString(row, "name", product.Name, product.presence("name"))
 	putString(row, "serial", product.Serial, product.presence("serial"))
 	putString(row, "unit", product.Unit, product.presence("unit"))
@@ -584,7 +584,7 @@ func (product *Product) UnmarshalJSON(data []byte) error {
 
 	product.fieldPresence = map[string]fieldPresence{}
 	for _, field := range []string{
-		"name", "serial", "unit", "sale_price_source", "purchase_price_source",
+		"category_code", "name", "serial", "unit", "sale_price_source", "purchase_price_source",
 		"warehouse_stock", "total_stock", "minimum_stock", "foreign_currency", "foreign_price",
 		"weight_grams", "location", "source_updated_at", "shipping_method_id",
 		"shipping_price_per_kg", "shipping_price_per_kg_currency", "markup_percent", "irt_per_cny",
@@ -607,6 +607,14 @@ func (product *Product) UnmarshalJSON(data []byte) error {
 	if shippingCurrencyPresent && product.presence("shipping_price_per_kg_currency") != fieldNull {
 		if product.ShippingPricePerKgCurrency != pricingcatalog.CurrencyCNY && product.ShippingPricePerKgCurrency != pricingcatalog.CurrencyIRR {
 			return fmt.Errorf("product shipping_price_per_kg_currency must be CNY or IRR")
+		}
+	}
+	for _, field := range []string{"foreign_price", "weight_grams", "shipping_price_per_kg", "markup_percent", "irt_per_cny"} {
+		if value, exists := raw[field]; exists {
+			value = bytes.TrimSpace(value)
+			if len(value) > 0 && value[0] == '"' {
+				return fmt.Errorf("product %s must be a JSON number or null", field)
+			}
 		}
 	}
 	product.warehouseNulls = map[string]bool{}

--- a/pkg/canonical/verify.go
+++ b/pkg/canonical/verify.go
@@ -1,0 +1,508 @@
+package canonical
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
+)
+
+const (
+	// MaxSnapshotBytes matches the receiver boundary for a single product-sync
+	// request and keeps verification memory use bounded.
+	MaxSnapshotBytes      = 8 * 1024 * 1024
+	maxEnvelopeProducts   = 10000
+	maxEnvelopeCategories = 10000
+	maxIdentityCodeLength = 191
+	maxWarningLength      = 255
+)
+
+// VerificationSummary is a compact, non-mutating description of a verified
+// canonical snapshot.
+type VerificationSummary struct {
+	Schema           string
+	EventType        string
+	EventID          string
+	SourceID         string
+	SourceDataset    string
+	SourceRevision   string
+	GeneratedAt      string
+	Products         int
+	Categories       int
+	ExcludedCodes    int
+	QuarantinedCodes int
+	Warnings         int
+}
+
+// VerifySnapshotJSON decodes a strict product-sync snapshot and verifies every
+// identity that can be derived without receiver state. Unknown fields, malformed
+// sparse records, duplicate Codes, and any record/source/event hash mismatch
+// fail closed.
+func VerifySnapshotJSON(data []byte) (*Envelope, VerificationSummary, error) {
+	if len(data) > MaxSnapshotBytes {
+		return nil, VerificationSummary{}, fmt.Errorf("canonical snapshot exceeds the %d-byte limit", MaxSnapshotBytes)
+	}
+	if err := rejectDuplicateJSONFields(data); err != nil {
+		return nil, VerificationSummary{}, fmt.Errorf("decode canonical snapshot: %w", err)
+	}
+	var envelope Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, VerificationSummary{}, fmt.Errorf("decode canonical snapshot: %w", err)
+	}
+	if err := ValidateEnvelopeIdentity(&envelope); err != nil {
+		return nil, VerificationSummary{}, err
+	}
+	return &envelope, verificationSummary(&envelope), nil
+}
+
+func rejectDuplicateJSONFields(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := walkJSONValue(decoder, 0); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple top-level JSON values are not allowed")
+		}
+		return err
+	}
+	return nil
+}
+
+func walkJSONValue(decoder *json.Decoder, depth int) error {
+	if depth > 64 {
+		return fmt.Errorf("JSON nesting exceeds the verification limit")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, compound := token.(json.Delim)
+	if !compound {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("JSON object key must be a string")
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return fmt.Errorf("duplicate JSON field %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := walkJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim('}') {
+			return fmt.Errorf("JSON object is not closed")
+		}
+	case '[':
+		for decoder.More() {
+			if err := walkJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim(']') {
+			return fmt.Errorf("JSON array is not closed")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+	return nil
+}
+
+// ValidateEnvelopeIdentity verifies a self-contained snapshot. Update events
+// require the receiver's previous state to validate their resulting source
+// revision, so they are deliberately rejected rather than partially trusted.
+func ValidateEnvelopeIdentity(envelope *Envelope) error {
+	if envelope == nil {
+		return fmt.Errorf("canonical snapshot is nil")
+	}
+	if envelope.Schema != ContractName {
+		return fmt.Errorf("schema must be %q", ContractName)
+	}
+	if envelope.EventType != "snapshot" {
+		return fmt.Errorf("event_type must be snapshot for standalone verification")
+	}
+	if !validSHA256Identity(envelope.EventID) {
+		return fmt.Errorf("event_id must be a lowercase sha256 identity")
+	}
+
+	hasCurrency, err := envelopeOptionalStringPresent(envelope, "local_currency", envelope.LocalCurrency)
+	if err != nil {
+		return err
+	}
+	hasFormula, err := envelopeOptionalStringPresent(envelope, "formula_id", envelope.FormulaID)
+	if err != nil {
+		return err
+	}
+	if hasCurrency != hasFormula {
+		return fmt.Errorf("local_currency and formula_id must be present together")
+	}
+	if hasCurrency && envelope.LocalCurrency != LocalCurrency {
+		return fmt.Errorf("local_currency must be %q when present", LocalCurrency)
+	}
+	if hasFormula && envelope.FormulaID != FormulaID {
+		return fmt.Errorf("formula_id must be %q when present", FormulaID)
+	}
+
+	if err := validateSourceIdentity(envelope.Source); err != nil {
+		return err
+	}
+	if _, err := time.Parse(time.RFC3339Nano, envelope.GeneratedAt); err != nil {
+		return fmt.Errorf("generated_at must be RFC3339: %w", err)
+	}
+	if envelope.Products == nil {
+		return fmt.Errorf("products must be an array")
+	}
+	if envelope.Categories == nil {
+		return fmt.Errorf("categories must be an array")
+	}
+	if envelope.ExcludedCodes == nil {
+		return fmt.Errorf("excluded_codes must be an array")
+	}
+	if envelope.QuarantinedCodes == nil {
+		return fmt.Errorf("quarantined_codes must be an array")
+	}
+	if envelope.Warnings == nil {
+		return fmt.Errorf("warnings must be an array")
+	}
+	if len(envelope.Products) > maxEnvelopeProducts {
+		return fmt.Errorf("products exceeds the %d-record limit", maxEnvelopeProducts)
+	}
+	if len(envelope.Categories) > maxEnvelopeCategories {
+		return fmt.Errorf("categories exceeds the %d-record limit", maxEnvelopeCategories)
+	}
+	if state, present := envelope.fieldPresence["deleted_codes"]; present && state == fieldNull {
+		return fmt.Errorf("deleted_codes must be an array when present")
+	}
+	if len(envelope.DeletedCodes) != 0 {
+		return fmt.Errorf("deleted_codes is only valid on update events")
+	}
+
+	if err := validateCanonicalStringSet("excluded_codes", envelope.ExcludedCodes, maxIdentityCodeLength); err != nil {
+		return err
+	}
+	if err := validateCanonicalStringSet("quarantined_codes", envelope.QuarantinedCodes, maxIdentityCodeLength); err != nil {
+		return err
+	}
+	if err := validateCanonicalStringSet("warnings", envelope.Warnings, maxWarningLength); err != nil {
+		return err
+	}
+
+	previousProductCode := ""
+	for index, product := range envelope.Products {
+		if err := validateProductIdentity(product, index); err != nil {
+			return err
+		}
+		if index > 0 && product.ProductCode <= previousProductCode {
+			return fmt.Errorf("products must be sorted by unique product_code")
+		}
+		previousProductCode = product.ProductCode
+	}
+
+	categoryCodes := make(map[string]Category, len(envelope.Categories))
+	previousCategoryCode := ""
+	for index, category := range envelope.Categories {
+		if err := validateCategoryIdentity(category, index); err != nil {
+			return err
+		}
+		if index > 0 && category.CategoryCode <= previousCategoryCode {
+			return fmt.Errorf("categories must be sorted by unique category_code")
+		}
+		previousCategoryCode = category.CategoryCode
+		categoryCodes[category.CategoryCode] = category
+	}
+	for _, category := range envelope.Categories {
+		if category.ParentCode == "" {
+			if category.Depth != 1 {
+				return fmt.Errorf("category %q depth must be 1 at the root", category.CategoryCode)
+			}
+			continue
+		}
+		parent, exists := categoryCodes[category.ParentCode]
+		if !exists {
+			return fmt.Errorf("category %q references missing parent %q", category.CategoryCode, category.ParentCode)
+		}
+		if category.Depth != parent.Depth+1 {
+			return fmt.Errorf("category %q depth must be exactly one greater than its parent", category.CategoryCode)
+		}
+	}
+
+	excluded := make(map[string]struct{}, len(envelope.ExcludedCodes))
+	for _, code := range envelope.ExcludedCodes {
+		excluded[code] = struct{}{}
+		if _, exists := categoryCodes[code]; exists {
+			return fmt.Errorf("code %q cannot be both a category and excluded", code)
+		}
+	}
+	quarantined := make(map[string]struct{}, len(envelope.QuarantinedCodes))
+	for _, code := range envelope.QuarantinedCodes {
+		quarantined[code] = struct{}{}
+	}
+	for _, product := range envelope.Products {
+		if _, exists := categoryCodes[product.ProductCode]; exists {
+			return fmt.Errorf("code %q cannot be both a product and category", product.ProductCode)
+		}
+		if _, exists := excluded[product.ProductCode]; exists {
+			return fmt.Errorf("code %q cannot be both a product and excluded", product.ProductCode)
+		}
+		if _, exists := quarantined[product.ProductCode]; exists {
+			return fmt.Errorf("code %q cannot be both a product and quarantined", product.ProductCode)
+		}
+		if product.CategoryCode != "" {
+			if _, exists := categoryCodes[product.CategoryCode]; !exists {
+				return fmt.Errorf("product %q references missing category %q", product.ProductCode, product.CategoryCode)
+			}
+		}
+	}
+	expectedRevision := sourceRevision(envelope.Products, envelope.Categories, envelope.ExcludedCodes, envelope.QuarantinedCodes)
+	if envelope.Source.Revision != expectedRevision {
+		return fmt.Errorf("source.revision mismatch: expected %s", expectedRevision)
+	}
+	expectedEventID := eventID(envelope)
+	if envelope.EventID != expectedEventID {
+		return fmt.Errorf("event_id mismatch: expected %s", expectedEventID)
+	}
+	return nil
+}
+
+func verificationSummary(envelope *Envelope) VerificationSummary {
+	return VerificationSummary{
+		Schema:           envelope.Schema,
+		EventType:        envelope.EventType,
+		EventID:          envelope.EventID,
+		SourceID:         envelope.Source.ID,
+		SourceDataset:    envelope.Source.Dataset,
+		SourceRevision:   envelope.Source.Revision,
+		GeneratedAt:      envelope.GeneratedAt,
+		Products:         len(envelope.Products),
+		Categories:       len(envelope.Categories),
+		ExcludedCodes:    len(envelope.ExcludedCodes),
+		QuarantinedCodes: len(envelope.QuarantinedCodes),
+		Warnings:         len(envelope.Warnings),
+	}
+}
+
+func envelopeOptionalStringPresent(envelope *Envelope, field, value string) (bool, error) {
+	if state, tracked := envelope.fieldPresence[field]; tracked {
+		if state == fieldNull {
+			return false, fmt.Errorf("%s must be a string when present", field)
+		}
+		return true, nil
+	}
+	return value != "", nil
+}
+
+func validateSourceIdentity(source Source) error {
+	for _, item := range []struct {
+		field string
+		value string
+	}{{"id", source.ID}, {"dataset", source.Dataset}} {
+		field, value := item.field, item.value
+		if value == "" || strings.TrimSpace(value) != value {
+			return fmt.Errorf("source.%s must be a non-empty trimmed string", field)
+		}
+		if len(value) > maxIdentityCodeLength {
+			return fmt.Errorf("source.%s exceeds %d bytes", field, maxIdentityCodeLength)
+		}
+	}
+	if !validSHA256Identity(source.Revision) {
+		return fmt.Errorf("source.revision must be a lowercase sha256 identity")
+	}
+	return nil
+}
+
+func validateProductIdentity(product Product, index int) error {
+	path := fmt.Sprintf("products[%d]", index)
+	if err := validateCode(path+".product_code", product.ProductCode); err != nil {
+		return err
+	}
+	if product.CategoryCode != "" {
+		if err := validateCode(path+".category_code", product.CategoryCode); err != nil {
+			return err
+		}
+	}
+	if product.Warnings == nil {
+		return fmt.Errorf("%s.warnings must be an array", path)
+	}
+	if err := validateCanonicalStringSet(path+".warnings", product.Warnings, maxWarningLength); err != nil {
+		return err
+	}
+	if (product.ForeignCurrency != "" || product.presence("foreign_currency") == fieldValue) && product.ForeignCurrency != "CNY" {
+		return fmt.Errorf("%s.foreign_currency must be CNY or null when present", path)
+	}
+	if product.ShippingMethodID != "" && (strings.TrimSpace(product.ShippingMethodID) != product.ShippingMethodID || len(product.ShippingMethodID) > maxIdentityCodeLength) {
+		return fmt.Errorf("%s.shipping_method_id must be a trimmed string within the code limit or null", path)
+	}
+
+	hasShippingPrice := product.ShippingPricePerKg != nil || product.presence("shipping_price_per_kg") != fieldAbsent
+	hasShippingCurrency := product.ShippingPricePerKgCurrency != "" || product.presence("shipping_price_per_kg_currency") != fieldAbsent
+	if hasShippingPrice != hasShippingCurrency {
+		return fmt.Errorf("%s shipping_price_per_kg and currency must be present together", path)
+	}
+	if (product.ShippingPricePerKgCurrency != "" || product.presence("shipping_price_per_kg_currency") == fieldValue) && product.ShippingPricePerKgCurrency != "CNY" && product.ShippingPricePerKgCurrency != "IRR" {
+		return fmt.Errorf("%s.shipping_price_per_kg_currency must be CNY, IRR, or null", path)
+	}
+
+	for field, value := range map[string]*float64{
+		"sale_price_source":     product.SalePriceSource,
+		"purchase_price_source": product.PurchasePriceSource,
+		"total_stock":           product.TotalStock,
+		"minimum_stock":         product.MinimumStock,
+	} {
+		if value != nil && (math.IsNaN(*value) || math.IsInf(*value, 0)) {
+			return fmt.Errorf("%s.%s must be finite", path, field)
+		}
+	}
+	for warehouse, stock := range product.WarehouseStock {
+		if warehouse == "" || strings.TrimSpace(warehouse) != warehouse || math.IsNaN(stock) || math.IsInf(stock, 0) {
+			return fmt.Errorf("%s.warehouse_stock must map non-empty trimmed keys to finite numbers or null", path)
+		}
+	}
+	for warehouse := range product.warehouseNulls {
+		if warehouse == "" || strings.TrimSpace(warehouse) != warehouse {
+			return fmt.Errorf("%s.warehouse_stock contains an invalid null-valued key", path)
+		}
+	}
+	if err := validatePositiveDecimal(path+".foreign_price", product.ForeignPrice); err != nil {
+		return err
+	}
+	if err := validatePositiveDecimal(path+".weight_grams", product.WeightGrams); err != nil {
+		return err
+	}
+	if err := validatePositiveDecimal(path+".shipping_price_per_kg", product.ShippingPricePerKg); err != nil {
+		return err
+	}
+	if err := validatePositiveDecimal(path+".irt_per_cny", product.IRTPerCNY); err != nil {
+		return err
+	}
+	if product.MarkupPercent != nil {
+		value, ok := product.MarkupPercent.Rat()
+		if !ok || value.Sign() < 0 {
+			return fmt.Errorf("%s.markup_percent must be a non-negative decimal", path)
+		}
+	}
+	if product.presence("final_price") == fieldNull {
+		return fmt.Errorf("%s.final_price must be omitted when unavailable, not null", path)
+	}
+	if product.FinalPrice != nil && *product.FinalPrice < 0 {
+		return fmt.Errorf("%s.final_price must be a non-negative integer", path)
+	}
+	if !validSHA256Identity(product.RecordHash) {
+		return fmt.Errorf("%s.record_hash must be a lowercase sha256 identity", path)
+	}
+	expected := recordHash(product)
+	if product.RecordHash != expected {
+		return fmt.Errorf("%s.record_hash mismatch: expected %s", path, expected)
+	}
+	return nil
+}
+
+func validateCategoryIdentity(category Category, index int) error {
+	path := fmt.Sprintf("categories[%d]", index)
+	if err := validateCode(path+".category_code", category.CategoryCode); err != nil {
+		return err
+	}
+	if category.ParentCode != "" {
+		if err := validateCode(path+".parent_code", category.ParentCode); err != nil {
+			return err
+		}
+		if category.ParentCode == category.CategoryCode {
+			return fmt.Errorf("%s.parent_code must differ from category_code", path)
+		}
+	}
+	if category.Depth <= 0 {
+		return fmt.Errorf("%s.depth must be a positive integer", path)
+	}
+	if category.Name == "" && category.fieldPresence["name"] == fieldAbsent {
+		return fmt.Errorf("%s.name must be present as a string or explicit null", path)
+	}
+	if category.Warnings == nil {
+		return fmt.Errorf("%s.warnings must be an array", path)
+	}
+	if err := validateCanonicalStringSet(path+".warnings", category.Warnings, maxWarningLength); err != nil {
+		return err
+	}
+	if !validSHA256Identity(category.RecordHash) {
+		return fmt.Errorf("%s.record_hash must be a lowercase sha256 identity", path)
+	}
+	expected := categoryRecordHash(category)
+	if category.RecordHash != expected {
+		return fmt.Errorf("%s.record_hash mismatch: expected %s", path, expected)
+	}
+	return nil
+}
+
+func validateCode(path, value string) error {
+	if value == "" || strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s must be a non-empty trimmed string", path)
+	}
+	if len(value) > maxIdentityCodeLength {
+		return fmt.Errorf("%s exceeds %d bytes", path, maxIdentityCodeLength)
+	}
+	return nil
+}
+
+func validateCanonicalStringSet(path string, values []string, maxLength int) error {
+	previous := ""
+	for index, value := range values {
+		if value == "" || strings.TrimSpace(value) != value {
+			return fmt.Errorf("%s[%d] must be a non-empty trimmed string", path, index)
+		}
+		if len(value) > maxLength {
+			return fmt.Errorf("%s[%d] exceeds %d bytes", path, index, maxLength)
+		}
+		if index > 0 && value <= previous {
+			return fmt.Errorf("%s must contain sorted unique strings", path)
+		}
+		previous = value
+	}
+	return nil
+}
+
+func validSHA256Identity(value string) bool {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	digest := value[len("sha256:"):]
+	if digest != strings.ToLower(digest) {
+		return false
+	}
+	decoded, err := hex.DecodeString(digest)
+	return err == nil && len(decoded) == 32
+}
+
+func validatePositiveDecimal(path string, value *pricingcatalog.Decimal) error {
+	if value == nil {
+		return nil
+	}
+	decimal, ok := value.Rat()
+	if !ok || decimal.Sign() <= 0 {
+		return fmt.Errorf("%s must be a positive decimal", path)
+	}
+	return nil
+}

--- a/pkg/canonical/verify_test.go
+++ b/pkg/canonical/verify_test.go
@@ -1,0 +1,166 @@
+package canonical
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const emptySourceRevision = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestStandaloneProductSyncGoldenFixture(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "patris-product-sync.standalone.json")
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope, _, err := VerifySnapshotJSON(expected)
+	if err != nil {
+		t.Fatalf("standalone fixture did not verify: %v", err)
+	}
+	encoded, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := append(encoded, '\n')
+	if !bytes.Equal(actual, expected) {
+		t.Fatalf("standalone product-sync fixture is not the producer's canonical JSON: %s", path)
+	}
+}
+
+func TestEventIdentityOmitsAbsentOptionalPricingFields(t *testing.T) {
+	envelope := emptyIdentityFixture(false)
+	const expected = "sha256:ab188e19ce426fdb627306f2a0d95dfb4049012a097cb0f303c578da089faa63"
+	if envelope.EventID != expected {
+		t.Fatalf("standalone event_id = %q, want %q", envelope.EventID, expected)
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), `"local_currency"`) || strings.Contains(string(encoded), `"formula_id"`) {
+		t.Fatalf("absent optional fields leaked onto the wire: %s", encoded)
+	}
+	if _, _, err := VerifySnapshotJSON(encoded); err != nil {
+		t.Fatalf("standalone identity did not verify: %v", err)
+	}
+}
+
+func TestIntegratedEventIdentityIncludesPresentPricingFields(t *testing.T) {
+	envelope := emptyIdentityFixture(true)
+	const expected = "sha256:fc48b56e2c9fa6edec5c9d2828389f492ea0464c9780a91e656c6df97839cb71"
+	if envelope.EventID != expected {
+		t.Fatalf("integrated event_id = %q, want %q", envelope.EventID, expected)
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range []string{`"local_currency":"IRT"`, `"formula_id":"landed_price"`} {
+		if !strings.Contains(string(encoded), member) {
+			t.Fatalf("present pricing identity field %s is missing: %s", member, encoded)
+		}
+	}
+	if _, _, err := VerifySnapshotJSON(encoded); err != nil {
+		t.Fatalf("integrated identity did not verify: %v", err)
+	}
+}
+
+func TestValidateEnvelopeIdentityChecksEveryIdentityLayer(t *testing.T) {
+	valid := syntheticGoldenEnvelope()
+	if err := ValidateEnvelopeIdentity(valid); err != nil {
+		t.Fatalf("valid producer snapshot was rejected: %v", err)
+	}
+
+	tests := map[string]struct {
+		mutate func(*Envelope)
+		want   string
+	}{
+		"product record hash": {
+			mutate: func(value *Envelope) { value.Products[0].RecordHash = hashBytes([]byte("tampered")) },
+			want:   "record_hash mismatch",
+		},
+		"category record hash": {
+			mutate: func(value *Envelope) { value.Categories[0].RecordHash = hashBytes([]byte("tampered")) },
+			want:   "record_hash mismatch",
+		},
+		"source revision": {
+			mutate: func(value *Envelope) { value.Source.Revision = hashBytes([]byte("tampered")) },
+			want:   "source.revision mismatch",
+		},
+		"event id": {
+			mutate: func(value *Envelope) { value.EventID = hashBytes([]byte("tampered")) },
+			want:   "event_id mismatch",
+		},
+		"duplicate product": {
+			mutate: func(value *Envelope) {
+				value.Products = append(value.Products, cloneProduct(value.Products[len(value.Products)-1]))
+			},
+			want: "sorted by unique product_code",
+		},
+		"null warnings shape": {
+			mutate: func(value *Envelope) { value.Warnings = nil },
+			want:   "warnings must be an array",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := cloneEnvelope(valid)
+			test.mutate(candidate)
+			err := ValidateEnvelopeIdentity(candidate)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifySnapshotJSONRejectsExplicitEmptyOptionalIdentityFields(t *testing.T) {
+	payload := `{
+  "schema":"patris.product-sync",
+  "event_type":"snapshot",
+  "event_id":"sha256:ab188e19ce426fdb627306f2a0d95dfb4049012a097cb0f303c578da089faa63",
+  "local_currency":"",
+  "formula_id":"",
+  "source":{"id":"fixture","dataset":"kala.json","revision":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+  "generated_at":"2026-07-21T00:00:00Z",
+  "products":[],
+  "categories":[],
+  "excluded_codes":[],
+  "quarantined_codes":[],
+  "warnings":[]
+}`
+	if _, _, err := VerifySnapshotJSON([]byte(payload)); err == nil || !strings.Contains(err.Error(), "local_currency must be") {
+		t.Fatalf("explicit empty optional fields were not rejected: %v", err)
+	}
+}
+
+func TestVerifySnapshotJSONRejectsDuplicateObjectFields(t *testing.T) {
+	payload := `{"schema":"patris.product-sync","schema":"patris.product-sync"}`
+	if _, _, err := VerifySnapshotJSON([]byte(payload)); err == nil || !strings.Contains(err.Error(), "duplicate JSON field") {
+		t.Fatalf("duplicate object member was not rejected: %v", err)
+	}
+}
+
+func emptyIdentityFixture(withPricing bool) *Envelope {
+	envelope := &Envelope{
+		Schema:           ContractName,
+		EventType:        "snapshot",
+		Source:           Source{ID: "fixture", Dataset: "kala.json", Revision: emptySourceRevision},
+		GeneratedAt:      "2026-07-21T00:00:00Z",
+		Products:         []Product{},
+		Categories:       []Category{},
+		ExcludedCodes:    []string{},
+		QuarantinedCodes: []string{},
+		Warnings:         []string{},
+	}
+	if withPricing {
+		envelope.LocalCurrency = LocalCurrency
+		envelope.FormulaID = FormulaID
+	}
+	envelope.EventID = eventID(envelope)
+	return envelope
+}

--- a/testdata/patris-product-sync.standalone.json
+++ b/testdata/patris-product-sync.standalone.json
@@ -1,0 +1,16 @@
+{
+  "schema": "patris.product-sync",
+  "event_type": "snapshot",
+  "event_id": "sha256:ab188e19ce426fdb627306f2a0d95dfb4049012a097cb0f303c578da089faa63",
+  "source": {
+    "id": "fixture",
+    "dataset": "kala.json",
+    "revision": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "generated_at": "2026-07-21T00:00:00Z",
+  "products": [],
+  "categories": [],
+  "excluded_codes": [],
+  "quarantined_codes": [],
+  "warnings": []
+}


### PR DESCRIPTION
Closes #190.

## What changed

- add the read-only `patris-export verify <snapshot.json|->` command;
- strictly verify duplicate JSON members, sparse field types, ordering, uniqueness, record/category hashes, source revision, and event identity;
- reject isolated update events because their resulting identity needs receiver state;
- make absent optional pricing members truly absent from the event identity, with no compatibility selector or fallback;
- preserve explicit source null separately from omission;
- add standalone/integrated identity fixtures and CLI coverage.

## Verification

- `go test ./... -count=1`
- `go vet ./pkg/canonical ./cmd/patris-export`
- receiver parity tests for standalone and integrated snapshots
- Windows file and byte-exact stdin smoke tests
- Windows executable SHA-256: `c56247100e3634b0ca1c916817bcb691dd6e451932ab8091f58babca8632f940`
