### PR TITLE
Ignore Sort fields early and preserve description lines

### DIFF
--- a/pkg/converter/exporter.go
+++ b/pkg/converter/exporter.go
@@ -23,6 +23,13 @@ const (
 // Regular expression to match numbered ANBAR fields (ANBAR1, ANBAR2, etc.)
 var anbarFieldRegex = regexp.MustCompile(`^ANBAR\d+$`)
 
+// IsSortField reports whether a Paradox field is an internal sorting column.
+// These fields are transport metadata and must never be converted, exported,
+// or compared as business data.
+func IsSortField(field string) bool {
+	return strings.HasPrefix(field, "Sort")
+}
+
 // Exporter handles exporting Paradox database records
 type Exporter struct {
 	converter func(string) string
@@ -86,6 +93,8 @@ func (e *Exporter) ExportToJSONWriter(records []paradox.Record, writer io.Writer
 
 // ExportToCSVWriter exports records to CSV format writing to the provided io.Writer
 func (e *Exporter) ExportToCSVWriter(records []paradox.Record, fields []paradox.Field, writer io.Writer) error {
+	fields = exportFields(fields)
+
 	// Convert string fields if converter is set
 	if e.converter != nil {
 		records = e.ConvertRecords(records)
@@ -133,6 +142,11 @@ func (e *Exporter) ConvertRecords(records []paradox.Record) []paradox.Record {
 	for i, record := range records {
 		convertedRecord := make(paradox.Record)
 		for key, value := range record {
+			// Sort fields are internal Paradox indexes. Discard them before
+			// even inspecting/converting values to avoid needless work.
+			if IsSortField(key) {
+				continue
+			}
 			if strVal, ok := value.(string); ok {
 				// Only convert non-empty strings
 				if strings.TrimSpace(strVal) != "" {
@@ -201,8 +215,8 @@ func (e *Exporter) TransformRecordsMap(records []map[string]interface{}) map[str
 		// Create a copy of the record without Code field (it becomes the key)
 		transformedRecord := make(map[string]interface{})
 		for key, value := range record {
-			if key != "Code" {
-				transformedRecord[key] = value
+			if key != "Code" && !IsSortField(key) {
+				transformedRecord[key] = splitDescriptionLines(key, value)
 			}
 		}
 
@@ -237,7 +251,7 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 
 		for key, value := range record {
 			// Skip Sort fields
-			if strings.HasPrefix(key, "Sort") {
+			if IsSortField(key) {
 				continue
 			}
 
@@ -261,7 +275,7 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 			}
 
 			// Add all other fields
-			optimized[key] = value
+			optimized[key] = splitDescriptionLines(key, value)
 		}
 
 		// Add ANBAR array if we collected any, in sorted order by field number
@@ -282,6 +296,32 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 	}
 
 	return result
+}
+
+func exportFields(fields []paradox.Field) []paradox.Field {
+	filtered := make([]paradox.Field, 0, len(fields))
+	for _, field := range fields {
+		if !IsSortField(field.Name) {
+			filtered = append(filtered, field)
+		}
+	}
+	return filtered
+}
+
+func splitDescriptionLines(field string, value interface{}) interface{} {
+	if field != "Sharh1" && field != "Sharh2" {
+		return value
+	}
+	text, ok := value.(string)
+	if !ok {
+		return value
+	}
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	if !strings.Contains(text, "\n") {
+		return value
+	}
+	return strings.Split(text, "\n")
 }
 
 // makeArraysInline converts multi-line numeric arrays to single-line format

--- a/pkg/converter/exporter_test.go
+++ b/pkg/converter/exporter_test.go
@@ -51,8 +51,8 @@ func TestExportToJSONWriter(t *testing.T) {
 }`,
 		},
 		{
-			name:    "Empty records",
-			records: []paradox.Record{},
+			name:     "Empty records",
+			records:  []paradox.Record{},
 			expected: `{}`,
 		},
 		{
@@ -80,6 +80,23 @@ func TestExportToJSONWriter(t *testing.T) {
   "special": {
     "Code": "special",
     "Name": "Test \"quoted\" & <special>"
+  }
+}`,
+		},
+		{
+			name: "Multiline descriptions become arrays",
+			records: []paradox.Record{
+				{
+					"Code":   "multiline",
+					"Sharh1": "first\r\nsecond",
+					"Sharh2": "one\r\n\rthree",
+				},
+			},
+			expected: `{
+  "multiline": {
+    "Code": "multiline",
+    "Sharh1": ["first", "second"],
+    "Sharh2": ["one", "", "three"]
   }
 }`,
 		},
@@ -195,6 +212,25 @@ func TestExportToCSVWriter(t *testing.T) {
 			expectedRows: [][]string{
 				{"special", "Test \"quoted\", with, commas"},
 			},
+		},
+		{
+			name: "CSV excludes Sort fields",
+			records: []paradox.Record{
+				{
+					"Code":     "100",
+					"Sort":     "ignored",
+					"SortCode": "ignored too",
+					"Name":     "Kept",
+				},
+			},
+			fields: []paradox.Field{
+				{Name: "Code"},
+				{Name: "Sort"},
+				{Name: "SortCode"},
+				{Name: "Name"},
+			},
+			expectedHeaders: []string{"Code", "Name"},
+			expectedRows:    [][]string{{"100", "Kept"}},
 		},
 	}
 
@@ -324,4 +360,3 @@ func TestExportToCSVWriterError(t *testing.T) {
 		t.Errorf("Expected error message to contain 'failed to write CSV', got: %v", err)
 	}
 }
-

--- a/pkg/converter/patris2fa.go
+++ b/pkg/converter/patris2fa.go
@@ -33,6 +33,7 @@ var (
 	defaultMapping       CharMapping
 	dashFixEnabled       = true
 	rtlConversionEnabled = false
+	zwnjSpacingPattern   = regexp.MustCompile(`\[zwnj\][ \t\f\v]*`)
 )
 
 // LoadCharMapping loads the character mapping from a file
@@ -163,6 +164,10 @@ func Patris2FaWithMapping(value string, mapping CharMapping) string {
 		mapping = defaultMapping
 	}
 
+	// Patris uses both CR and LF as item separators. Normalize their encoding
+	// while retaining every logical line boundary for structured output.
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
 	valueBytes := []byte(value)
 
 	// Step 1: Replace dash marker if enabled
@@ -177,7 +182,7 @@ func Patris2FaWithMapping(value string, mapping CharMapping) string {
 	// Step 2: Reverse Patris-encoded segments
 	// Persian characters (0x9F-0xE0) and whitespace/punctuation are stored reversed
 	// English letters are NOT reversed, allowing mixed Persian/English text
-	valueBytes = reversePatrisSegments(valueBytes)
+	valueBytes = reversePatrisLines(valueBytes)
 
 	// Step 3: Map Patris bytes to UTF-8
 	var output strings.Builder
@@ -197,9 +202,9 @@ func Patris2FaWithMapping(value string, mapping CharMapping) string {
 
 	// Step 5: Clean up formatting
 	// Replace [zwnj] markers with spaces for proper Persian word spacing
-	result = regexp.MustCompile(`\[zwnj\]\s*`).ReplaceAllString(result, " ")
-	// Normalize whitespace
-	result = regexp.MustCompile(`\s+`).ReplaceAllString(result, " ")
+	result = zwnjSpacingPattern.ReplaceAllString(result, " ")
+	// Preserve internal spaces, tabs, blank lines, and line separators. Only
+	// outer padding is transport noise and remains safe to trim.
 	result = strings.TrimSpace(result)
 
 	if rtlConversionEnabled {
@@ -207,6 +212,22 @@ func Patris2FaWithMapping(value string, mapping CharMapping) string {
 	}
 
 	return result
+}
+
+// reversePatrisLines converts each Patris line independently so Persian
+// segments cannot move across CR/LF item boundaries.
+func reversePatrisLines(data []byte) []byte {
+	result := make([]byte, 0, len(data))
+	lineStart := 0
+	for index, b := range data {
+		if b != '\n' {
+			continue
+		}
+		result = append(result, reversePatrisSegments(data[lineStart:index])...)
+		result = append(result, '\n')
+		lineStart = index + 1
+	}
+	return append(result, reversePatrisSegments(data[lineStart:])...)
 }
 
 // reversePatrisSegments reverses byte segments containing Patris-encoded characters
@@ -322,7 +343,14 @@ func ConvertLTRVisualToRTL(text string) string {
 	if text == "" {
 		return text
 	}
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		lines[index] = convertLTRVisualLineToRTL(line)
+	}
+	return strings.Join(lines, "\n")
+}
 
+func convertLTRVisualLineToRTL(text string) string {
 	words := splitWords(text)
 	hasPersian := false
 	hasLatin := false
@@ -372,11 +400,24 @@ func reverseScriptGroups(words [][]rune) string {
 	var groups []wordGroup
 	var current wordGroup
 	inGroup := false
+	var leadingWhitespace []rune
+	var trailingWhitespace []rune
+	var separators [][]rune
+	var pendingWhitespace []rune
+	wordCount := 0
 
 	for _, word := range words {
 		if isSpaceWord(word) {
+			pendingWhitespace = append(pendingWhitespace, word...)
 			continue
 		}
+		if wordCount == 0 {
+			leadingWhitespace = append(leadingWhitespace, pendingWhitespace...)
+		} else {
+			separators = append(separators, append([]rune(nil), pendingWhitespace...))
+		}
+		pendingWhitespace = nil
+		wordCount++
 
 		wordIsRTL := isPersianOrArabic(word[0])
 		wordIsNumeric := isNumericWord(word)
@@ -395,22 +436,24 @@ func reverseScriptGroups(words [][]rune) string {
 	if inGroup {
 		groups = append(groups, current)
 	}
+	trailingWhitespace = append(trailingWhitespace, pendingWhitespace...)
 
 	var result [][]rune
 	for i := len(groups) - 1; i >= 0; i-- {
 		result = append(result, groups[i].words...)
 	}
-	return joinWords(result)
+	return joinWords(result, leadingWhitespace, separators, trailingWhitespace)
 }
 
-func joinWords(words [][]rune) string {
-	var output []rune
+func joinWords(words [][]rune, leading []rune, separators [][]rune, trailing []rune) string {
+	output := append([]rune(nil), leading...)
 	for i, word := range words {
 		if i > 0 {
-			output = append(output, ' ')
+			output = append(output, separators[i-1]...)
 		}
 		output = append(output, word...)
 	}
+	output = append(output, trailing...)
 	return string(output)
 }
 

--- a/pkg/converter/patris2fa_test.go
+++ b/pkg/converter/patris2fa_test.go
@@ -100,6 +100,21 @@ func TestPatris2Fa(t *testing.T) {
 	}
 }
 
+func TestPatris2FaPreservesLineBoundariesAndHorizontalWhitespace(t *testing.T) {
+	mapping := CharMapping{
+		0xa1: "A",
+		0xa2: "B",
+		0xa3: "C",
+		0xa4: "D",
+	}
+
+	input := "\xa1\xa2\r\n\xa3\xa4  \tvalue\rplain\n\nlast"
+	want := "BA\nDC  \tvalue\nplain\n\nlast"
+	if got := Patris2FaWithMapping(input, mapping); got != want {
+		t.Fatalf("Patris2FaWithMapping(%#v) = %q, want %q", []byte(input), got, want)
+	}
+}
+
 func TestLoadCharMapping(t *testing.T) {
 	mapping, err := LoadCharMapping("farsi_chars.txt")
 	if err != nil {

--- a/pkg/converter/rtl_test.go
+++ b/pkg/converter/rtl_test.go
@@ -37,6 +37,14 @@ func TestConvertLTRVisualToRTL(t *testing.T) {
 	}
 }
 
+func TestConvertLTRVisualToRTLPreservesLineAndWhitespaceStructure(t *testing.T) {
+	input := "LAN  \t\u0645\u062a\u0646\nNEXT\t\u0641\u0627\u0631\u0633\u06cc"
+	want := "\u0645\u062a\u0646  \tLAN\n\u0641\u0627\u0631\u0633\u06cc\tNEXT"
+	if got := ConvertLTRVisualToRTL(input); got != want {
+		t.Fatalf("ConvertLTRVisualToRTL(%q) = %q, want %q", input, got, want)
+	}
+}
+
 func TestRTLConversionOptIn(t *testing.T) {
 	originalMapping := DefaultCharMapping()
 	defer SetDefaultMapping(originalMapping)

--- a/pkg/converter/transform_test.go
+++ b/pkg/converter/transform_test.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
@@ -210,5 +212,54 @@ func TestTransformRecords(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConvertRecordsSkipsSortFieldsBeforeConversion(t *testing.T) {
+	calls := 0
+	exp := NewExporter(func(value string) string {
+		calls++
+		if strings.Contains(value, "must not convert") {
+			t.Fatalf("converter was called for an ignored Sort field: %q", value)
+		}
+		return strings.ToUpper(value)
+	})
+	records := []paradox.Record{{
+		"Code":     "100",
+		"Name":     "kept",
+		"Sort":     "must not convert",
+		"SortCode": "must not convert either",
+	}}
+
+	got := exp.ConvertRecords(records)
+	if calls != 2 {
+		t.Fatalf("converter calls = %d, want 2 for Code and Name only", calls)
+	}
+	if got[0]["Code"] != "100" || got[0]["Name"] != "KEPT" {
+		t.Fatalf("kept fields were not converted: %#v", got[0])
+	}
+	for _, field := range []string{"Sort", "SortCode"} {
+		if _, exists := got[0][field]; exists {
+			t.Fatalf("ignored field %s survived conversion: %#v", field, got[0])
+		}
+		if _, exists := records[0][field]; !exists {
+			t.Fatalf("ConvertRecords mutated the caller's input: %#v", records[0])
+		}
+	}
+}
+
+func TestTransformRecordsSplitsMultilineDescriptions(t *testing.T) {
+	exp := NewExporter(nil)
+	got := exp.TransformRecords([]paradox.Record{{
+		"Code":   "100",
+		"Sharh1": "first\r\nsecond",
+		"Sharh2": "one\r\n\rthree",
+	}})
+	record := got["100"].(map[string]interface{})
+	if want := []string{"first", "second"}; !reflect.DeepEqual(record["Sharh1"], want) {
+		t.Fatalf("Sharh1 = %#v, want %#v", record["Sharh1"], want)
+	}
+	if want := []string{"one", "", "three"}; !reflect.DeepEqual(record["Sharh2"], want) {
+		t.Fatalf("Sharh2 = %#v, want %#v", record["Sharh2"], want)
 	}
 }

--- a/pkg/recorddiff/diff.go
+++ b/pkg/recorddiff/diff.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/converter"
 )
 
 // RecordChange describes one modified record while preserving the legacy
@@ -140,12 +142,12 @@ func indexRows(rows []map[string]interface{}, keyField string) (map[string]map[s
 func changedValues(oldRecord, newRecord map[string]interface{}, keyField string) ([]string, map[string]interface{}, map[string]interface{}) {
 	fields := make(map[string]struct{}, len(oldRecord)+len(newRecord))
 	for field := range oldRecord {
-		if field != keyField {
+		if field != keyField && !converter.IsSortField(field) {
 			fields[field] = struct{}{}
 		}
 	}
 	for field := range newRecord {
-		if field != keyField {
+		if field != keyField && !converter.IsSortField(field) {
 			fields[field] = struct{}{}
 		}
 	}
@@ -191,7 +193,9 @@ func copyRows(rows []map[string]interface{}) []map[string]interface{} {
 func copyRecord(record map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{}, len(record))
 	for key, value := range record {
-		result[key] = value
+		if !converter.IsSortField(key) {
+			result[key] = value
+		}
 	}
 	return result
 }

--- a/pkg/recorddiff/diff_test.go
+++ b/pkg/recorddiff/diff_test.go
@@ -87,3 +87,44 @@ func TestBetweenIsStableAndDoesNotMutateInputs(t *testing.T) {
 		t.Fatalf("unexpected counts: %d %d %d", added, modified, deleted)
 	}
 }
+
+func TestBetweenIgnoresSortFieldsAndOmitsThemFromPayloads(t *testing.T) {
+	at := time.Unix(1, 0)
+	previous := []map[string]interface{}{{"Code": "100", "Name": "Old", "Sort": "a", "SortCode": "1"}}
+	current := []map[string]interface{}{{"Code": "100", "Name": "New", "Sort": "b", "SortCode": "2"}}
+
+	changes := Between(previous, current, "Code", at)
+	if len(changes.Modified) != 1 {
+		t.Fatalf("modified changes = %#v, want one non-Sort change", changes.Modified)
+	}
+	modified := changes.Modified[0]
+	if !reflect.DeepEqual(modified.ChangedFields, []string{"Name"}) {
+		t.Fatalf("changed fields = %#v, want only Name", modified.ChangedFields)
+	}
+	for _, field := range []string{"Sort", "SortCode"} {
+		if _, exists := modified.Record[field]; exists {
+			t.Fatalf("ignored field %s leaked into modified record: %#v", field, modified.Record)
+		}
+		if _, exists := modified.OldValues[field]; exists {
+			t.Fatalf("ignored field %s leaked into old values: %#v", field, modified.OldValues)
+		}
+		if _, exists := modified.NewValues[field]; exists {
+			t.Fatalf("ignored field %s leaked into new values: %#v", field, modified.NewValues)
+		}
+	}
+
+	onlySortChanged := Between(previous, []map[string]interface{}{{"Code": "100", "Name": "Old", "Sort": "changed"}}, "Code", at)
+	if !onlySortChanged.Empty() {
+		t.Fatalf("Sort-only mutation produced a change: %#v", onlySortChanged)
+	}
+
+	initial := Between(nil, current, "Code", at)
+	if len(initial.Added) != 1 {
+		t.Fatalf("initial added rows = %#v", initial.Added)
+	}
+	for _, field := range []string{"Sort", "SortCode"} {
+		if _, exists := initial.Added[0][field]; exists {
+			t.Fatalf("ignored field %s leaked into initial payload: %#v", field, initial.Added[0])
+		}
+	}
+}

--- a/pkg/recordpipe/pipeline.go
+++ b/pkg/recordpipe/pipeline.go
@@ -37,7 +37,7 @@ func Build(rawRows []map[string]interface{}, source string, options Options) Res
 
 func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source string, options Options) Result {
 	if options.Raw {
-		rows := recordmap.CopyRows(rawRows)
+		rows := copyRowsWithoutSortFields(rawRows)
 		return Result{
 			Rows:     rows,
 			Payload:  rows,
@@ -70,6 +70,20 @@ func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source 
 		KeyField: keyField,
 		Raw:      false,
 	}
+}
+
+func copyRowsWithoutSortFields(records []map[string]interface{}) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		row := make(map[string]interface{}, len(record))
+		for field, value := range record {
+			if !converter.IsSortField(field) {
+				row[field] = value
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 func paradoxToRows(records []paradox.Record) []map[string]interface{} {

--- a/pkg/recordpipe/pipeline_test.go
+++ b/pkg/recordpipe/pipeline_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBuildRawSkipsTransformAndMapping(t *testing.T) {
-	rows := []map[string]interface{}{{"Code": "100", "Name": "Raw", "ANBAR1": 2}}
+	rows := []map[string]interface{}{{"Code": "100", "Name": "Raw", "ANBAR1": 2, "Sort": "ignored", "SortCode": "ignored too"}}
 	result := Build(rows, "kala.db", Options{
 		Raw: true,
 		Mapping: recordmap.Config{
@@ -36,6 +36,11 @@ func TestBuildRawSkipsTransformAndMapping(t *testing.T) {
 	}
 	if _, exists := result.Rows[0]["ANBAR1"]; !exists {
 		t.Fatal("raw mode should keep numbered ANBAR fields")
+	}
+	for _, field := range []string{"Sort", "SortCode"} {
+		if _, exists := result.Rows[0][field]; exists {
+			t.Fatalf("raw mode leaked ignored field %s: %#v", field, result.Rows[0])
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #20
Closes #21

## Summary
- discard `Sort` and every `Sort*` field before string conversion, including raw and structured export paths
- remove ignored sorting fields from CSV schemas and incremental add/modify payloads so sort-only mutations produce no business change
- preserve CR/LF item boundaries, blank lines, tabs, and internal spacing during Patris decoding
- convert multiline `Sharh1` and `Sharh2` values into arrays in structured JSON output while retaining multiline CSV cells
- keep Persian segment reversal and optional RTL conversion scoped to each line

## Root cause
`ConvertRecords` converted every string before `TransformRecords` discarded `Sort*`, while CSV and diff paths bypassed that final filter. `Patris2Fa` then collapsed every whitespace run with a single regular expression and reversed Persian segments across line boundaries.

## Validation
- `go test ./... -count=1` with the runtime-dynamic pxlib fixture
- `go vet ./...`
- converter, recorddiff, and recordpipe focused tests
- web test suite: 40 passing; production bundle built
- remote delivery adapter suite: 13 passing
- JavaScript host checks and suite: 29 passing
- `git diff --check`

Pending owner review after merge; comment `@codex` with any required corrections.