### PR TITLE
Keep MySQL DSN out of browser configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Browser configuration responses, initial WebSocket snapshots, and config
+  update events no longer expose the MySQL DSN; browser saves preserve the
+  protected server-side value and ignore client-supplied replacements.
 - Excel dashboard refresh now validates Code identity before mutating reviewed
   rows, rejects empty/non-JSON Digitalogic responses, uses deterministic
   canonical-over-legacy label precedence, and strips private Office path/author

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -319,6 +319,14 @@ func (s *Server) Config() appconfig.Config {
 	return s.config.Get()
 }
 
+// browserConfig returns the configuration shape that may be sent to the Web
+// UI. Database credentials remain server-side and can only be supplied through
+// protected config files, environment variables, or command-line options.
+func browserConfig(cfg appconfig.Config) appconfig.Config {
+	cfg.Export.MySQLDSN = ""
+	return cfg
+}
+
 func (s *Server) currentDBPath() string {
 	s.dataSourceMu.RLock()
 	defer s.dataSourceMu.RUnlock()
@@ -849,10 +857,10 @@ func (s *Server) appMetadata() map[string]interface{} {
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	if s.config == nil {
-		writeJSON(w, appconfig.Default())
+		writeJSON(w, browserConfig(appconfig.Default()))
 		return
 	}
-	writeJSON(w, s.config.Get())
+	writeJSON(w, browserConfig(s.config.Get()))
 }
 
 func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
@@ -865,6 +873,10 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to decode config: %v", err), http.StatusBadRequest)
 		return
 	}
+	// The browser is not a credential-management surface. Preserve the
+	// protected server-side DSN even if an old cached config or a crafted
+	// request includes a mysql_dsn value.
+	cfg.Export.MySQLDSN = s.config.Get().Export.MySQLDSN
 	cfg, err := s.ReplaceConfig(cfg)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)
@@ -872,7 +884,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, map[string]interface{}{
 		"success": true,
-		"config":  cfg,
+		"config":  browserConfig(cfg),
 	})
 }
 
@@ -1275,7 +1287,7 @@ func (s *Server) initialSnapshotMessage(result recordpipe.Result, dbPath, reason
 		message["source_changed"] = true
 	}
 	if s.config != nil {
-		message["config"] = s.config.Get()
+		message["config"] = browserConfig(s.config.Get())
 	}
 	if result.Contract != nil {
 		message["contract"] = result.SyncEnvelope(nil)
@@ -1869,7 +1881,7 @@ func (s *Server) broadcastConfig(cfg appconfig.Config) {
 	message := map[string]interface{}{
 		"type":      "config_update",
 		"timestamp": time.Now().Format(time.RFC3339),
-		"config":    cfg,
+		"config":    browserConfig(cfg),
 	}
 	s.broadcastMessage(message)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -544,6 +544,80 @@ func TestServerJSON(t *testing.T) {
 	})
 }
 
+func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "patris-export.json")
+	manager, err := appconfig.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config manager: %v", err)
+	}
+	const protectedDSN = "protected-dsn-test-value"
+	if err := manager.Update(func(cfg *appconfig.Config) {
+		cfg.Export.MySQLDSN = protectedDSN
+	}); err != nil {
+		t.Fatalf("store protected DSN: %v", err)
+	}
+
+	jsonPath := filepath.Join(tmpDir, "records.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"001":{"Code":"001","Name":"Test"}}`), 0600); err != nil {
+		t.Fatalf("write test records: %v", err)
+	}
+	srv, err := NewServerWithOptions(jsonPath, nil, Options{Config: manager}, false)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+	defer srv.Close()
+
+	assertRedacted := func(t *testing.T, value interface{}) {
+		t.Helper()
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal browser payload: %v", err)
+		}
+		body := string(data)
+		if strings.Contains(body, protectedDSN) || strings.Contains(body, `"mysql_dsn"`) {
+			t.Fatalf("browser payload exposed protected SQL configuration: %s", body)
+		}
+	}
+
+	get := httptest.NewRecorder()
+	srv.router.ServeHTTP(get, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /api/config status = %d: %s", get.Code, get.Body.String())
+	}
+	assertRedacted(t, json.RawMessage(get.Body.Bytes()))
+
+	initial := srv.initialSnapshotMessage(recordpipe.Result{Rows: []map[string]interface{}{}, KeyField: "Code"}, jsonPath, "")
+	assertRedacted(t, initial)
+
+	events, unsubscribe := srv.SubscribeEvents(1)
+	defer unsubscribe()
+	srv.broadcastConfig(manager.Get())
+	select {
+	case event := <-events:
+		assertRedacted(t, event)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for config broadcast")
+	}
+
+	clientConfig := browserConfig(manager.Get())
+	clientConfig.UI.Theme = "dark"
+	clientConfig.Export.MySQLDSN = "browser-supplied-dsn-must-be-ignored"
+	body, err := json.Marshal(clientConfig)
+	if err != nil {
+		t.Fatalf("marshal browser update: %v", err)
+	}
+	put := httptest.NewRecorder()
+	srv.router.ServeHTTP(put, httptest.NewRequest(http.MethodPut, "/api/config", bytes.NewReader(body)))
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config status = %d: %s", put.Code, put.Body.String())
+	}
+	assertRedacted(t, json.RawMessage(put.Body.Bytes()))
+	if got := manager.Get(); got.Export.MySQLDSN != protectedDSN || got.UI.Theme != "dark" {
+		t.Fatalf("browser update did not preserve protected DSN and apply UI setting: DSN preserved=%t theme=%q", got.Export.MySQLDSN == protectedDSN, got.UI.Theme)
+	}
+}
+
 func TestCanonicalKalaParityAcrossRESTCSVXLSXAndWebSocket(t *testing.T) {
 	configPath := filepath.Join("..", "..", "testdata", "canonical-static-config.json")
 	manager, err := appconfig.Load(configPath)


### PR DESCRIPTION
## Summary
- remove `export.mysql_dsn` from GET `/api/config`
- redact it from initial WebSocket snapshots and config-update events
- preserve the protected server-side DSN when browser settings are saved, ignoring client-supplied replacements
- cover REST, WebSocket payload, broadcast, and persistence behavior with a regression test

## Why
Issue #6 requires database credentials to remain in protected config/environment state and never be returned to the browser. The SQL sink already accepts protected configuration, but the general config API still serialized the DSN.

## Validation
- `go test ./pkg/server -run 'TestBrowserConfigRedactsAndPreservesMySQLDSN|TestServerJSON' -count=1`
- `go test ./pkg/server -count=1` with the approved runtime-dynamic `libpxlib.dll`
- `go test ./pkg/appconfig -count=1`
- `go vet ./pkg/server`
- `npm test` (51/51)
- `git diff --check`

Refs #6