### PR TITLE
Add secure MySQL target foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- MySQL/MariaDB targets now have a shared bounded read-only connection probe,
+  protected custom-CA/server-name configuration, verified TLS 1.2+ connector,
+  and typed secret-safe retry diagnostics for future authenticated UI controls.
 - Product names and descriptions are checked for leading/trailing spaces,
   repeated spaces, and unseparated Persian/English/digit transitions. Stable
   warning codes are exported, summarized on the CLI, and highlighted in the
@@ -40,8 +43,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 
 - Browser configuration responses, initial WebSocket snapshots, and config
-  update events no longer expose the MySQL DSN; browser saves preserve the
-  protected server-side value and ignore client-supplied replacements.
+  update events no longer expose the MySQL DSN or protected TLS paths/names;
+  browser saves preserve the server-side values and ignore client-supplied
+  replacements.
 - Excel dashboard refresh now validates Code identity before mutating reviewed
   rows, rejects empty/non-JSON Digitalogic responses, uses deterministic
   canonical-over-legacy label precedence, and strips private Office path/author

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -921,6 +921,11 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 			Reconciliation: recordsink.ReconciliationMode(cfg.Export.Reconciliation),
 			DryRun:         cfg.Export.DryRun,
 			ProtectedKeys:  quarantinedCodes(result),
+			ConnectTimeout: recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout),
+			MySQLTLS: recordsink.MySQLTLSOptions{
+				CAFile:     cfg.Export.MySQLTLSCAFile,
+				ServerName: cfg.Export.MySQLTLSServerName,
+			},
 		}, result.Rows)
 		if err != nil {
 			return err

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -85,6 +85,27 @@ patris-export --mapping .\mapping.kala.json convert C:\Patris\data4\kala.db `
   --batch-size 250
 ```
 
+For a private certificate authority, keep the CA path and optional certificate
+server name in protected server configuration (or environment variables), not
+browser-managed configuration:
+
+```yaml
+export:
+  mysql_tls_ca_file: C:/Patris/certificates/database-ca.pem
+  mysql_tls_server_name: mysql.service.internal
+  mysql_connect_timeout: 10s
+```
+
+The equivalent environment variables are
+`PATRIS_EXPORT_MYSQL_TLS_CA_FILE`,
+`PATRIS_EXPORT_MYSQL_TLS_SERVER_NAME`, and
+`PATRIS_EXPORT_MYSQL_CONNECT_TIMEOUT`. A CA file is read with a 4 MiB bound,
+added to the operating-system trust roots, and forces verified TLS 1.2 or
+newer. It overrides `tls=preferred`, `tls=skip-verify`, or plaintext fallback
+from the DSN. Do not use an insecure TLS mode in production. Browser config,
+WebSocket snapshots, config broadcasts, and browser saves omit and preserve the
+DSN, CA path, and server-name override.
+
 `--xlsx-language auto` follows `ui.language`; `--xlsx-mode precalculated`
 writes the transformed final values, while `formula` emits auditable Excel
 formulas that remain blank until every required input is numeric. Warehouse
@@ -125,6 +146,22 @@ The result line reports `inserted`, `updated`, `unchanged`, `deleted`, `failed`,
 and `elapsed` milliseconds; it never includes the DSN. A dry run against a
 missing SQLite path does not create the file or its parent directory.
 
+MySQL/MariaDB connections use a finite 10-second connection bound by default
+(configurable from 100 ms through 2 minutes) in addition to any DSN I/O
+timeouts and caller cancellation. Connection, TLS, authentication, permission,
+constraint, timeout, cancellation, transient, unavailable, schema, and unknown
+failures are converted to typed secret-safe diagnostics. Raw driver messages
+are retained only as an in-process wrapped cause and are never serialized or
+printed by the SQL target API. Classification does not automatically replay a
+whole transaction: a lost connection during commit can have an ambiguous
+outcome and must be reconciled before retrying.
+
+The shared `recordsink.ProbeSQLTarget` operation is non-mutating: it performs a
+bounded ping plus `SELECT VERSION()` and a best-effort session TLS-status read.
+Its result contains only connection state, driver/vendor, a bounded printable
+version, TLS state, and elapsed time. It is the backend primitive for the
+authenticated connection-test UI follow-up.
+
 Watch mode uses this same `recordpipe` -> `recordsink` route for its initial
 write and every debounced update; there is no separate live SQL implementation:
 
@@ -146,9 +183,9 @@ Remove-Item Env:PATRIS_EXPORT_TEST_MYSQL_DSN
 ```
 
 The MariaDB test is skipped unless its dedicated test DSN is present and drops
-only the uniquely named table it creates. A browser connection test, manual UI
-sync controls, custom-CA TLS registration, and `soft_delete_missing` remain
-separate follow-up work.
+only the uniquely named table it creates. Authenticated browser connection-test
+and manual-sync controls, `soft_delete_missing`, and the broader database CI
+matrix remain separate follow-up work.
 
 ## Watch and Send Updates
 

--- a/installer/windows/config.example.toml
+++ b/installer/windows/config.example.toml
@@ -16,6 +16,11 @@ rtl_text_direction = false
 xlsx_language = "auto"
 xlsx_mode = "precalculated"
 xlsx_zebra_rows = true
+# Keep MySQL credentials in PATRIS_EXPORT_MYSQL_DSN. For a private CA, uncomment
+# these protected local settings; they are redacted from browser configuration.
+# mysql_tls_ca_file = 'C:\Patris\certificates\database-ca.pem'
+# mysql_tls_server_name = "mysql.service.internal"
+mysql_connect_timeout = "10s"
 
 [runtime]
 debug = false

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -87,16 +87,19 @@ type ConvertConfig struct {
 }
 
 type ExportConfig struct {
-	SQLitePath     string `json:"sqlite_path,omitempty" yaml:"sqlite_path,omitempty" toml:"sqlite_path,omitempty"`
-	SQLiteTable    string `json:"sqlite_table,omitempty" yaml:"sqlite_table,omitempty" toml:"sqlite_table,omitempty"`
-	MySQLDSN       string `json:"mysql_dsn,omitempty" yaml:"mysql_dsn,omitempty" toml:"mysql_dsn,omitempty"`
-	MySQLTable     string `json:"mysql_table,omitempty" yaml:"mysql_table,omitempty" toml:"mysql_table,omitempty"`
-	BatchSize      int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
-	Reconciliation string `json:"reconciliation,omitempty" yaml:"reconciliation,omitempty" toml:"reconciliation,omitempty"`
-	DryRun         bool   `json:"dry_run,omitempty" yaml:"dry_run,omitempty" toml:"dry_run,omitempty"`
-	XLSXLanguage   string `json:"xlsx_language,omitempty" yaml:"xlsx_language,omitempty" toml:"xlsx_language,omitempty"`
-	XLSXMode       string `json:"xlsx_mode,omitempty" yaml:"xlsx_mode,omitempty" toml:"xlsx_mode,omitempty"`
-	XLSXZebraRows  bool   `json:"xlsx_zebra_rows" yaml:"xlsx_zebra_rows" toml:"xlsx_zebra_rows"`
+	SQLitePath          string `json:"sqlite_path,omitempty" yaml:"sqlite_path,omitempty" toml:"sqlite_path,omitempty"`
+	SQLiteTable         string `json:"sqlite_table,omitempty" yaml:"sqlite_table,omitempty" toml:"sqlite_table,omitempty"`
+	MySQLDSN            string `json:"mysql_dsn,omitempty" yaml:"mysql_dsn,omitempty" toml:"mysql_dsn,omitempty"`
+	MySQLTable          string `json:"mysql_table,omitempty" yaml:"mysql_table,omitempty" toml:"mysql_table,omitempty"`
+	MySQLTLSCAFile      string `json:"mysql_tls_ca_file,omitempty" yaml:"mysql_tls_ca_file,omitempty" toml:"mysql_tls_ca_file,omitempty"`
+	MySQLTLSServerName  string `json:"mysql_tls_server_name,omitempty" yaml:"mysql_tls_server_name,omitempty" toml:"mysql_tls_server_name,omitempty"`
+	MySQLConnectTimeout string `json:"mysql_connect_timeout,omitempty" yaml:"mysql_connect_timeout,omitempty" toml:"mysql_connect_timeout,omitempty"`
+	BatchSize           int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
+	Reconciliation      string `json:"reconciliation,omitempty" yaml:"reconciliation,omitempty" toml:"reconciliation,omitempty"`
+	DryRun              bool   `json:"dry_run,omitempty" yaml:"dry_run,omitempty" toml:"dry_run,omitempty"`
+	XLSXLanguage        string `json:"xlsx_language,omitempty" yaml:"xlsx_language,omitempty" toml:"xlsx_language,omitempty"`
+	XLSXMode            string `json:"xlsx_mode,omitempty" yaml:"xlsx_mode,omitempty" toml:"xlsx_mode,omitempty"`
+	XLSXZebraRows       bool   `json:"xlsx_zebra_rows" yaml:"xlsx_zebra_rows" toml:"xlsx_zebra_rows"`
 }
 
 type EdgeConfig struct {
@@ -197,11 +200,12 @@ func Default() Config {
 			Debounce: "1s",
 		},
 		Export: ExportConfig{
-			BatchSize:      500,
-			Reconciliation: "upsert_only",
-			XLSXLanguage:   "auto",
-			XLSXMode:       "precalculated",
-			XLSXZebraRows:  true,
+			MySQLConnectTimeout: "10s",
+			BatchSize:           500,
+			Reconciliation:      "upsert_only",
+			XLSXLanguage:        "auto",
+			XLSXMode:            "precalculated",
+			XLSXZebraRows:       true,
 		},
 		Canonical: canonical.DefaultConfig(),
 		SendUpdates: updateout.Config{
@@ -817,6 +821,15 @@ func ApplyEnv(cfg *Config) {
 	if value := os.Getenv("PATRIS_EXPORT_MYSQL_TABLE"); strings.TrimSpace(value) != "" {
 		cfg.Export.MySQLTable = strings.TrimSpace(value)
 	}
+	if value := os.Getenv("PATRIS_EXPORT_MYSQL_TLS_CA_FILE"); strings.TrimSpace(value) != "" {
+		cfg.Export.MySQLTLSCAFile = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_MYSQL_TLS_SERVER_NAME"); strings.TrimSpace(value) != "" {
+		cfg.Export.MySQLTLSServerName = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_MYSQL_CONNECT_TIMEOUT"); strings.TrimSpace(value) != "" {
+		cfg.Export.MySQLConnectTimeout = strings.TrimSpace(value)
+	}
 	if value := os.Getenv("PATRIS_EXPORT_BATCH_SIZE"); strings.TrimSpace(value) != "" {
 		if batch, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
 			cfg.Export.BatchSize = batch
@@ -989,6 +1002,9 @@ func normalize(cfg *Config) {
 	if cfg.Export.BatchSize <= 0 {
 		cfg.Export.BatchSize = 500
 	}
+	cfg.Export.MySQLTLSCAFile = strings.TrimSpace(cfg.Export.MySQLTLSCAFile)
+	cfg.Export.MySQLTLSServerName = strings.TrimSpace(cfg.Export.MySQLTLSServerName)
+	cfg.Export.MySQLConnectTimeout = normalizeDuration(cfg.Export.MySQLConnectTimeout, 10*time.Second, 100*time.Millisecond, 2*time.Minute)
 	cfg.Export.XLSXLanguage = strings.ToLower(strings.TrimSpace(cfg.Export.XLSXLanguage))
 	if cfg.Export.XLSXLanguage != "fa" && cfg.Export.XLSXLanguage != "en" {
 		cfg.Export.XLSXLanguage = "auto"
@@ -1189,6 +1205,20 @@ func setAddr(cfg *Config, addr string) {
 		cfg.Server.Host = host
 		cfg.Server.Port = port
 	}
+}
+
+func normalizeDuration(value string, fallback, minimum, maximum time.Duration) string {
+	duration, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil || duration <= 0 {
+		duration = fallback
+	}
+	if minimum > 0 && duration < minimum {
+		duration = minimum
+	}
+	if maximum > 0 && duration > maximum {
+		duration = maximum
+	}
+	return duration.String()
 }
 
 func parseBool(value string, fallback bool) bool {

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -262,22 +262,36 @@ func TestApplyEnvRuntimeTempPolicy(t *testing.T) {
 
 func TestSQLExportDefaultsAndEnvironmentOverrides(t *testing.T) {
 	cfg := Default()
-	if cfg.Export.BatchSize != 500 || cfg.Export.Reconciliation != "upsert_only" || cfg.Export.DryRun {
+	if cfg.Export.BatchSize != 500 || cfg.Export.Reconciliation != "upsert_only" || cfg.Export.DryRun || cfg.Export.MySQLConnectTimeout != "10s" {
 		t.Fatalf("unsafe SQL export defaults: %+v", cfg.Export)
 	}
 
 	t.Setenv("PATRIS_EXPORT_BATCH_SIZE", "17")
 	t.Setenv("PATRIS_EXPORT_SQL_RECONCILIATION", "DELETE_MISSING")
 	t.Setenv("PATRIS_EXPORT_SQL_DRY_RUN", "true")
+	t.Setenv("PATRIS_EXPORT_MYSQL_TLS_CA_FILE", " C:/protected/mysql/ca.pem ")
+	t.Setenv("PATRIS_EXPORT_MYSQL_TLS_SERVER_NAME", " db.internal.example ")
+	t.Setenv("PATRIS_EXPORT_MYSQL_CONNECT_TIMEOUT", "250ms")
 	ApplyEnv(&cfg)
-	if cfg.Export.BatchSize != 17 || cfg.Export.Reconciliation != "delete_missing" || !cfg.Export.DryRun {
+	if cfg.Export.BatchSize != 17 || cfg.Export.Reconciliation != "delete_missing" || !cfg.Export.DryRun ||
+		cfg.Export.MySQLTLSCAFile != "C:/protected/mysql/ca.pem" || cfg.Export.MySQLTLSServerName != "db.internal.example" ||
+		cfg.Export.MySQLConnectTimeout != "250ms" {
 		t.Fatalf("SQL export environment was not applied: %+v", cfg.Export)
 	}
 
 	cfg.Export.Reconciliation = "typo_that_must_not_delete"
+	cfg.Export.MySQLConnectTimeout = "24h"
 	normalize(&cfg)
 	if cfg.Export.Reconciliation != "upsert_only" {
 		t.Fatalf("invalid reconciliation did not fail safe: %q", cfg.Export.Reconciliation)
+	}
+	if cfg.Export.MySQLConnectTimeout != "2m0s" {
+		t.Fatalf("SQL connection timeout was not bounded: %q", cfg.Export.MySQLConnectTimeout)
+	}
+	cfg.Export.MySQLConnectTimeout = "not-a-duration"
+	normalize(&cfg)
+	if cfg.Export.MySQLConnectTimeout != "10s" {
+		t.Fatalf("invalid SQL connection timeout did not use the safe default: %q", cfg.Export.MySQLConnectTimeout)
 	}
 }
 

--- a/pkg/recordsink/mysql_target.go
+++ b/pkg/recordsink/mysql_target.go
@@ -1,0 +1,277 @@
+package recordsink
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+const (
+	defaultSQLConnectTimeout  = 10 * time.Second
+	minimumSQLConnectTimeout  = 100 * time.Millisecond
+	maximumSQLConnectTimeout  = 2 * time.Minute
+	maximumCustomCABytes      = 4 * 1024 * 1024
+	maximumServerVersionRunes = 128
+)
+
+// MySQLTLSOptions contains protected connection material. These values may be
+// loaded from server-side configuration or environment variables, but must not
+// be copied into browser configuration or outward diagnostics.
+type MySQLTLSOptions struct {
+	CAFile     string `json:"-"`
+	ServerName string `json:"-"`
+}
+
+// SQLTLSState reports only whether the established connection is encrypted.
+// It never includes certificate names, paths, ciphers, or target addresses.
+type SQLTLSState string
+
+const (
+	SQLTLSUnknown   SQLTLSState = "unknown"
+	SQLTLSEncrypted SQLTLSState = "encrypted"
+	SQLTLSPlaintext SQLTLSState = "plaintext"
+)
+
+// SQLProbeResult is a bounded, non-secret result suitable for a future
+// authenticated status API. The probe performs no schema or data mutation.
+type SQLProbeResult struct {
+	Connected     bool        `json:"connected"`
+	Driver        string      `json:"driver"`
+	Vendor        string      `json:"vendor,omitempty"`
+	ServerVersion string      `json:"server_version,omitempty"`
+	TLS           SQLTLSState `json:"tls"`
+	ElapsedMS     int64       `json:"elapsed_ms"`
+}
+
+// ParseSQLConnectTimeout applies the same finite bounds used by config
+// normalization. Invalid or empty values use the safe default.
+func ParseSQLConnectTimeout(value string) time.Duration {
+	duration, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil || duration <= 0 {
+		duration = defaultSQLConnectTimeout
+	}
+	if duration < minimumSQLConnectTimeout {
+		return minimumSQLConnectTimeout
+	}
+	if duration > maximumSQLConnectTimeout {
+		return maximumSQLConnectTimeout
+	}
+	return duration
+}
+
+// ProbeSQLTarget opens the configured target, applies a finite connection
+// deadline, and performs only ping and read-only server metadata queries.
+func ProbeSQLTarget(ctx context.Context, options SQLOptions) (SQLProbeResult, error) {
+	started := time.Now()
+	driverName := normalizedSQLDriver(options.Driver)
+	result := SQLProbeResult{Driver: driverName, TLS: SQLTLSUnknown}
+
+	connectCtx, cancel := sqlConnectContext(ctx, options.ConnectTimeout)
+	defer cancel()
+	db, err := openSQLTarget(options)
+	if err != nil {
+		result.ElapsedMS = time.Since(started).Milliseconds()
+		return result, err
+	}
+	defer db.Close()
+
+	result, err = ProbeSQLDB(connectCtx, db, driverName)
+	result.ElapsedMS = time.Since(started).Milliseconds()
+	return result, err
+}
+
+// ProbeSQLDB performs the non-mutating portion of a connection probe against
+// an already-open database. It is exported so server/IPC layers can inject a
+// managed connection without creating another probe implementation.
+func ProbeSQLDB(ctx context.Context, db *sql.DB, driverName string) (result SQLProbeResult, err error) {
+	started := time.Now()
+	result.Driver = normalizedSQLDriver(driverName)
+	result.TLS = SQLTLSUnknown
+	defer func() { result.ElapsedMS = time.Since(started).Milliseconds() }()
+
+	if db == nil {
+		return result, ClassifySQLError(SQLStageConfiguration, errors.New("nil SQL database"))
+	}
+	connection, err := db.Conn(ctx)
+	if err != nil {
+		return result, ClassifySQLError(SQLStageConnect, err)
+	}
+	defer connection.Close()
+	if err := connection.PingContext(ctx); err != nil {
+		return result, ClassifySQLError(SQLStageConnect, err)
+	}
+	result.Connected = true
+	if result.Driver != "mysql" {
+		result.Vendor = result.Driver
+		return result, nil
+	}
+
+	var version string
+	if err := connection.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version); err != nil {
+		return result, ClassifySQLError(SQLStageProbe, err)
+	}
+	result.ServerVersion = safeServerVersion(version)
+	result.Vendor = mysqlVendor(version)
+
+	var statusName string
+	var cipher sql.NullString
+	if err := connection.QueryRowContext(ctx, "SHOW SESSION STATUS LIKE 'Ssl_cipher'").Scan(&statusName, &cipher); err == nil {
+		if cipher.Valid && strings.TrimSpace(cipher.String) != "" {
+			result.TLS = SQLTLSEncrypted
+		} else {
+			result.TLS = SQLTLSPlaintext
+		}
+	} else if ctx.Err() != nil {
+		return result, ClassifySQLError(SQLStageProbe, ctx.Err())
+	}
+	return result, nil
+}
+
+func openSQLTarget(options SQLOptions) (*sql.DB, error) {
+	driverName := normalizedSQLDriver(options.Driver)
+	if strings.TrimSpace(options.DSN) == "" {
+		return nil, ClassifySQLError(SQLStageConfiguration, errors.New("SQL DSN is required"))
+	}
+	if driverName != "mysql" {
+		db, err := sql.Open(driverName, options.DSN)
+		if err != nil {
+			return nil, ClassifySQLError(SQLStageConfiguration, err)
+		}
+		return db, nil
+	}
+
+	config, err := mysqlConnectorConfig(options)
+	if err != nil {
+		return nil, err
+	}
+	connector, err := mysql.NewConnector(config)
+	if err != nil {
+		return nil, ClassifySQLError(SQLStageConfiguration, err)
+	}
+	return sql.OpenDB(connector), nil
+}
+
+func mysqlConnectorConfig(options SQLOptions) (*mysql.Config, error) {
+	config, err := mysql.ParseDSN(options.DSN)
+	if err != nil {
+		return nil, ClassifySQLError(SQLStageConfiguration, err)
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = normalizedSQLConnectTimeout(options.ConnectTimeout)
+	}
+
+	tlsOptions := options.MySQLTLS
+	tlsOptions.CAFile = strings.TrimSpace(tlsOptions.CAFile)
+	tlsOptions.ServerName = strings.TrimSpace(tlsOptions.ServerName)
+	if tlsOptions.CAFile == "" && tlsOptions.ServerName == "" {
+		return config, nil
+	}
+
+	tlsConfig, err := verifiedMySQLTLSConfig(tlsOptions)
+	if err != nil {
+		return nil, ClassifySQLError(SQLStageTLS, err)
+	}
+	// A protected CA/server-name setting always selects verified TLS and
+	// disables any plaintext fallback or insecure mode present in the DSN.
+	config.TLSConfig = ""
+	config.TLS = tlsConfig
+	config.AllowFallbackToPlaintext = false
+	return config, nil
+}
+
+func verifiedMySQLTLSConfig(options MySQLTLSOptions) (*tls.Config, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil || rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if options.CAFile != "" {
+		pemBytes, err := readBoundedCustomCA(options.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		if !rootCAs.AppendCertsFromPEM(pemBytes) {
+			return nil, errors.New("custom CA file does not contain a valid PEM certificate")
+		}
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
+		ServerName: strings.TrimSpace(options.ServerName),
+	}, nil
+}
+
+func readBoundedCustomCA(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open custom CA: %w", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maximumCustomCABytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read custom CA: %w", err)
+	}
+	if len(data) > maximumCustomCABytes {
+		return nil, errors.New("custom CA exceeds the size limit")
+	}
+	return data, nil
+}
+
+func sqlConnectContext(ctx context.Context, requested time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithTimeout(ctx, normalizedSQLConnectTimeout(requested))
+}
+
+func normalizedSQLConnectTimeout(requested time.Duration) time.Duration {
+	if requested <= 0 {
+		requested = defaultSQLConnectTimeout
+	}
+	if requested < minimumSQLConnectTimeout {
+		return minimumSQLConnectTimeout
+	}
+	if requested > maximumSQLConnectTimeout {
+		return maximumSQLConnectTimeout
+	}
+	return requested
+}
+
+func normalizedSQLDriver(driverName string) string {
+	driverName = strings.ToLower(strings.TrimSpace(driverName))
+	if driverName == "" {
+		return "mysql"
+	}
+	return driverName
+}
+
+func mysqlVendor(version string) string {
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return "mariadb"
+	}
+	return "mysql"
+}
+
+func safeServerVersion(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) && r != '\r' && r != '\n' {
+			return r
+		}
+		return -1
+	}, strings.TrimSpace(value))
+	if utf8.RuneCountInString(value) <= maximumServerVersionRunes {
+		return value
+	}
+	runes := []rune(value)
+	return string(runes[:maximumServerVersionRunes])
+}

--- a/pkg/recordsink/mysql_target_test.go
+++ b/pkg/recordsink/mysql_target_test.go
@@ -1,0 +1,346 @@
+package recordsink
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestMySQLConnectorConfigUsesVerifiedCustomCAAndBoundedTimeout(t *testing.T) {
+	caPath, certificate := writeTestCA(t)
+	options := SQLOptions{
+		DSN:            "test_user:test_password@tcp(db.internal.example:3306)/shop?tls=skip-verify",
+		ConnectTimeout: 25 * time.Millisecond,
+		MySQLTLS: MySQLTLSOptions{
+			CAFile:     caPath,
+			ServerName: "mysql.service.internal",
+		},
+	}
+	config, err := mysqlConnectorConfig(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Timeout != minimumSQLConnectTimeout {
+		t.Fatalf("connector timeout = %s, want bounded minimum %s", config.Timeout, minimumSQLConnectTimeout)
+	}
+	if config.TLS == nil || config.TLS.MinVersion != tls.VersionTLS12 || config.TLS.InsecureSkipVerify {
+		t.Fatalf("connector did not require verified TLS 1.2+: %+v", config.TLS)
+	}
+	if config.TLS.ServerName != "mysql.service.internal" || config.TLSConfig != "" || config.AllowFallbackToPlaintext {
+		t.Fatalf("connector retained an insecure/fallback TLS mode: TLSConfig=%q fallback=%t server=%q", config.TLSConfig, config.AllowFallbackToPlaintext, config.TLS.ServerName)
+	}
+	if _, err := certificate.Verify(x509.VerifyOptions{Roots: config.TLS.RootCAs}); err != nil {
+		t.Fatalf("custom CA was not added to the trust pool: %v", err)
+	}
+}
+
+func TestMySQLConnectorConfigRespectsExplicitDSNTimeoutWithoutCustomTLS(t *testing.T) {
+	config, err := mysqlConnectorConfig(SQLOptions{
+		DSN:            "user:password@tcp(localhost:3306)/shop?timeout=3s&tls=true",
+		ConnectTimeout: 20 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Timeout != 3*time.Second {
+		t.Fatalf("explicit DSN timeout = %s, want 3s", config.Timeout)
+	}
+	if config.TLSConfig != "true" || config.TLS == nil || config.TLS.InsecureSkipVerify {
+		t.Fatalf("built-in verified DSN TLS mode was unexpectedly rewritten: TLSConfig=%q TLS=%+v", config.TLSConfig, config.TLS)
+	}
+}
+
+func TestCustomCAFailuresReturnOnlySafeTypedDiagnostics(t *testing.T) {
+	privatePath := filepath.Join(t.TempDir(), "private-customer-ca-name.pem")
+	if err := os.WriteFile(privatePath, []byte("not a certificate; private contents"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	const dsn = "private_user:private_password@tcp(private-db.internal:3306)/private_schema"
+	db, err := openSQLTarget(SQLOptions{DSN: dsn, MySQLTLS: MySQLTLSOptions{CAFile: privatePath}})
+	if db != nil {
+		db.Close()
+		t.Fatal("invalid custom CA unexpectedly opened a target")
+	}
+	var failure *SQLFailure
+	if !errors.As(err, &failure) || failure.Code != SQLFailureTLSVerification || failure.Stage != SQLStageTLS || failure.Retryable {
+		t.Fatalf("invalid custom CA failure = %#v", err)
+	}
+	encoded, marshalErr := json.Marshal(failure)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	outward := failure.Error() + string(encoded)
+	for _, forbidden := range []string{privatePath, dsn, "private_password", "private-db", "private_schema", "private contents"} {
+		if strings.Contains(outward, forbidden) {
+			t.Fatalf("custom CA diagnostic exposed %q: %s", forbidden, outward)
+		}
+	}
+}
+
+func TestSQLOptionsJSONCannotExposeProtectedConnectionMaterial(t *testing.T) {
+	const dsn = "private_user:private_password@tcp(private-db.internal:3306)/private_schema"
+	const caPath = "C:/protected/private-ca.pem"
+	const serverName = "private-db.internal"
+	encoded, err := json.Marshal(SQLOptions{
+		Driver: "mysql",
+		DSN:    dsn,
+		MySQLTLS: MySQLTLSOptions{
+			CAFile:     caPath,
+			ServerName: serverName,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{dsn, caPath, serverName, "DSN", "MySQLTLS", "CAFile", "ServerName"} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("serialized SQL options exposed %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestCustomCAReadIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized-ca.pem")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maximumCustomCABytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readBoundedCustomCA(path); err == nil {
+		t.Fatal("oversized custom CA was accepted")
+	}
+}
+
+func TestProbeSQLDBUsesOnlyReadOnlyQueriesAndReturnsSanitizedState(t *testing.T) {
+	state := &probeDriverState{
+		version: strings.Repeat("10.11.6-MariaDB ", 20) + "\nprivate-control-text",
+		cipher:  "TLS_AES_256_GCM_SHA384",
+	}
+	db := sql.OpenDB(probeConnector{state: state})
+	defer db.Close()
+
+	result, err := ProbeSQLDB(context.Background(), db, "mysql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Connected || result.Driver != "mysql" || result.Vendor != "mariadb" || result.TLS != SQLTLSEncrypted {
+		t.Fatalf("probe result = %+v", result)
+	}
+	if strings.ContainsAny(result.ServerVersion, "\r\n") || utf8.RuneCountInString(result.ServerVersion) > maximumServerVersionRunes {
+		t.Fatalf("server version was not sanitized and bounded: %q", result.ServerVersion)
+	}
+	if state.pings != 1 || state.execs != 0 {
+		t.Fatalf("probe activity: pings=%d execs=%d", state.pings, state.execs)
+	}
+	wantQueries := []string{"SELECT VERSION()", "SHOW SESSION STATUS LIKE 'Ssl_cipher'"}
+	if len(state.queries) != len(wantQueries) {
+		t.Fatalf("probe queries = %#v", state.queries)
+	}
+	for index, query := range wantQueries {
+		if state.queries[index] != query {
+			t.Fatalf("probe query %d = %q, want %q", index, state.queries[index], query)
+		}
+	}
+}
+
+func TestProbeSQLDBTreatsTLSStatusAsBestEffortAndHonorsCancellation(t *testing.T) {
+	t.Run("TLS status unavailable", func(t *testing.T) {
+		state := &probeDriverState{version: "8.4.0", statusErr: errors.New("status unavailable")}
+		db := sql.OpenDB(probeConnector{state: state})
+		defer db.Close()
+		result, err := ProbeSQLDB(context.Background(), db, "mysql")
+		if err != nil || !result.Connected || result.Vendor != "mysql" || result.TLS != SQLTLSUnknown {
+			t.Fatalf("best-effort TLS status result=%+v err=%v", result, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		state := &probeDriverState{pingWait: true}
+		db := sql.OpenDB(probeConnector{state: state})
+		defer db.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		result, err := ProbeSQLDB(ctx, db, "mysql")
+		var failure *SQLFailure
+		if result.Connected || !errors.As(err, &failure) || failure.Code != SQLFailureTimeout || !failure.Retryable {
+			t.Fatalf("cancelled probe result=%+v err=%#v", result, err)
+		}
+	})
+
+	t.Run("deadline during metadata", func(t *testing.T) {
+		state := &probeDriverState{version: "8.4.0", statusWait: true}
+		db := sql.OpenDB(probeConnector{state: state})
+		defer db.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		result, err := ProbeSQLDB(ctx, db, "mysql")
+		var failure *SQLFailure
+		if !result.Connected || !errors.As(err, &failure) || failure.Code != SQLFailureTimeout || !failure.Retryable {
+			t.Fatalf("metadata timeout result=%+v err=%#v", result, err)
+		}
+	})
+}
+
+func TestProbeSQLTargetRejectsMissingDSNWithoutTargetDetails(t *testing.T) {
+	result, err := ProbeSQLTarget(context.Background(), SQLOptions{Driver: "mysql"})
+	var failure *SQLFailure
+	if result.Connected || result.Driver != "mysql" || !errors.As(err, &failure) || failure.Code != SQLFailureInvalidConfiguration {
+		t.Fatalf("missing target probe result=%+v err=%#v", result, err)
+	}
+}
+
+func TestParseSQLConnectTimeoutUsesFiniteBounds(t *testing.T) {
+	tests := map[string]time.Duration{
+		"":        defaultSQLConnectTimeout,
+		"invalid": defaultSQLConnectTimeout,
+		"1ms":     minimumSQLConnectTimeout,
+		"5s":      5 * time.Second,
+		"24h":     maximumSQLConnectTimeout,
+	}
+	for input, expected := range tests {
+		if got := ParseSQLConnectTimeout(input); got != expected {
+			t.Fatalf("ParseSQLConnectTimeout(%q) = %s, want %s", input, got, expected)
+		}
+	}
+}
+
+func writeTestCA(t *testing.T) (string, *x509.Certificate) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Patris test CA"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	block := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, block, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path, certificate
+}
+
+type probeDriverState struct {
+	version    string
+	cipher     string
+	statusErr  error
+	pingWait   bool
+	statusWait bool
+	pings      int
+	queries    []string
+	execs      int
+}
+
+type probeConnector struct {
+	state *probeDriverState
+}
+
+func (connector probeConnector) Connect(context.Context) (driver.Conn, error) {
+	return &probeConn{state: connector.state}, nil
+}
+
+func (connector probeConnector) Driver() driver.Driver { return probeDriver{} }
+
+type probeDriver struct{}
+
+func (probeDriver) Open(string) (driver.Conn, error) { return nil, errors.New("use connector") }
+
+type probeConn struct {
+	state *probeDriverState
+}
+
+func (conn *probeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("probe must not prepare statements")
+}
+func (conn *probeConn) Close() error { return nil }
+func (conn *probeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("probe must not begin transactions")
+}
+
+func (conn *probeConn) Ping(ctx context.Context) error {
+	conn.state.pings++
+	if conn.state.pingWait {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (conn *probeConn) QueryContext(ctx context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	conn.state.queries = append(conn.state.queries, query)
+	switch query {
+	case "SELECT VERSION()":
+		return &probeRows{columns: []string{"VERSION()"}, values: [][]driver.Value{{conn.state.version}}}, nil
+	case "SHOW SESSION STATUS LIKE 'Ssl_cipher'":
+		if conn.state.statusWait {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		if conn.state.statusErr != nil {
+			return nil, conn.state.statusErr
+		}
+		return &probeRows{columns: []string{"Variable_name", "Value"}, values: [][]driver.Value{{"Ssl_cipher", conn.state.cipher}}}, nil
+	default:
+		return nil, errors.New("unexpected probe query")
+	}
+}
+
+func (conn *probeConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	conn.state.execs++
+	return nil, errors.New("probe must not execute statements")
+}
+
+type probeRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (rows *probeRows) Columns() []string { return rows.columns }
+func (rows *probeRows) Close() error      { return nil }
+func (rows *probeRows) Next(dest []driver.Value) error {
+	if rows.index >= len(rows.values) {
+		return io.EOF
+	}
+	copy(dest, rows.values[rows.index])
+	rows.index++
+	return nil
+}

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
@@ -25,13 +24,15 @@ import (
 
 type SQLOptions struct {
 	Driver         string
-	DSN            string
+	DSN            string `json:"-"`
 	Table          string
 	KeyField       string
 	Batch          int
 	Reconciliation ReconciliationMode
 	DryRun         bool
 	ProtectedKeys  []string
+	ConnectTimeout time.Duration
+	MySQLTLS       MySQLTLSOptions `json:"-"`
 }
 
 // ReconciliationMode controls what happens to destination rows that are not
@@ -156,23 +157,28 @@ func SyncSQL(ctx context.Context, options SQLOptions, rows []map[string]interfac
 // SyncSQLWithResult opens a configured SQL destination and reports the shared
 // sink result. The returned value deliberately has no connection fields.
 func SyncSQLWithResult(ctx context.Context, options SQLOptions, rows []map[string]interface{}) (SQLResult, error) {
-	driver := strings.ToLower(strings.TrimSpace(options.Driver))
-	if driver == "" {
-		driver = "mysql"
+	driver := normalizedSQLDriver(options.Driver)
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	if options.DSN == "" {
-		return SQLResult{}, fmt.Errorf("%s DSN is required", driver)
-	}
-	db, err := sql.Open(driver, options.DSN)
+	connectCtx, cancel := sqlConnectContext(ctx, options.ConnectTimeout)
+	db, err := openSQLTarget(options)
 	if err != nil {
+		cancel()
 		return SQLResult{}, err
 	}
 	defer db.Close()
-	if err := db.PingContext(ctx); err != nil {
-		return SQLResult{}, fmt.Errorf("connect to %s destination: %w", driver, err)
+	if err := db.PingContext(connectCtx); err != nil {
+		cancel()
+		return SQLResult{}, ClassifySQLError(SQLStageConnect, err)
 	}
+	cancel()
 	options.Driver = driver
-	return SyncSQLDB(ctx, db, options, rows)
+	result, err := SyncSQLDB(ctx, db, options, rows)
+	if err != nil {
+		return result, ClassifySQLError(SQLStageSync, err)
+	}
+	return result, nil
 }
 
 // UpsertSQL writes a partial set of rows without deleting records that are not

--- a/pkg/recordsink/sql_diagnostic.go
+++ b/pkg/recordsink/sql_diagnostic.go
@@ -1,0 +1,199 @@
+package recordsink
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// SQLFailureStage identifies the operation boundary that failed without
+// exposing target details, SQL text, or driver messages.
+type SQLFailureStage string
+
+const (
+	SQLStageConfiguration SQLFailureStage = "configuration"
+	SQLStageTLS           SQLFailureStage = "tls"
+	SQLStageConnect       SQLFailureStage = "connect"
+	SQLStageProbe         SQLFailureStage = "probe"
+	SQLStageSchema        SQLFailureStage = "schema"
+	SQLStageSync          SQLFailureStage = "sync"
+)
+
+// SQLFailureCode is a stable, secret-safe category suitable for UI and API
+// diagnostics. It deliberately does not include server-supplied error text.
+type SQLFailureCode string
+
+const (
+	SQLFailureInvalidConfiguration SQLFailureCode = "invalid_configuration"
+	SQLFailureTLSVerification      SQLFailureCode = "tls_verification_failed"
+	SQLFailureAuthentication       SQLFailureCode = "authentication_failed"
+	SQLFailurePermission           SQLFailureCode = "permission_denied"
+	SQLFailureConstraint           SQLFailureCode = "constraint_rejected"
+	SQLFailureTimeout              SQLFailureCode = "timeout"
+	SQLFailureCancelled            SQLFailureCode = "cancelled"
+	SQLFailureTransient            SQLFailureCode = "transient_database_error"
+	SQLFailureUnavailable          SQLFailureCode = "database_unavailable"
+	SQLFailureSchema               SQLFailureCode = "schema_incompatible"
+	SQLFailureUnknown              SQLFailureCode = "unknown_database_error"
+)
+
+// SQLFailure is safe to serialize or log. The underlying cause remains
+// available to errors.Is/errors.As for in-process control flow, but is never
+// part of JSON or Error output.
+type SQLFailure struct {
+	Code      SQLFailureCode  `json:"code"`
+	Stage     SQLFailureStage `json:"stage"`
+	Retryable bool            `json:"retryable"`
+	Message   string          `json:"message"`
+
+	cause error
+}
+
+func (failure *SQLFailure) Error() string {
+	if failure == nil {
+		return ""
+	}
+	return fmt.Sprintf("SQL %s failed: %s (code=%s, retryable=%t)", failure.Stage, failure.Message, failure.Code, failure.Retryable)
+}
+
+func (failure *SQLFailure) Unwrap() error {
+	if failure == nil {
+		return nil
+	}
+	return failure.cause
+}
+
+// ClassifySQLError converts an internal driver or context failure into a
+// stable outward diagnostic. It never copies err.Error() into the result.
+func ClassifySQLError(stage SQLFailureStage, err error) *SQLFailure {
+	if err == nil {
+		return nil
+	}
+	var existing *SQLFailure
+	if errors.As(err, &existing) {
+		return existing
+	}
+
+	stage = normalizedSQLFailureStage(stage)
+	code := classifySQLFailureCode(stage, err)
+	return &SQLFailure{
+		Code:      code,
+		Stage:     stage,
+		Retryable: sqlFailureRetryable(code),
+		Message:   sqlFailureMessage(code),
+		cause:     err,
+	}
+}
+
+func normalizedSQLFailureStage(stage SQLFailureStage) SQLFailureStage {
+	switch stage {
+	case SQLStageConfiguration, SQLStageTLS, SQLStageConnect, SQLStageProbe, SQLStageSchema, SQLStageSync:
+		return stage
+	default:
+		return SQLStageSync
+	}
+}
+
+func classifySQLFailureCode(stage SQLFailureStage, err error) SQLFailureCode {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return SQLFailureCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		return SQLFailureTimeout
+	case errors.Is(err, driver.ErrBadConn), errors.Is(err, mysql.ErrInvalidConn):
+		return SQLFailureUnavailable
+	}
+
+	var mysqlError *mysql.MySQLError
+	if errors.As(err, &mysqlError) {
+		return classifyMySQLErrorNumber(mysqlError.Number)
+	}
+
+	var hostnameError x509.HostnameError
+	var authorityError x509.UnknownAuthorityError
+	var certificateError x509.CertificateInvalidError
+	var recordHeaderError tls.RecordHeaderError
+	if errors.As(err, &hostnameError) || errors.As(err, &authorityError) || errors.As(err, &certificateError) || errors.As(err, &recordHeaderError) {
+		return SQLFailureTLSVerification
+	}
+
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		if networkError.Timeout() {
+			return SQLFailureTimeout
+		}
+		return SQLFailureUnavailable
+	}
+
+	switch stage {
+	case SQLStageConfiguration:
+		return SQLFailureInvalidConfiguration
+	case SQLStageTLS:
+		return SQLFailureTLSVerification
+	case SQLStageSchema:
+		return SQLFailureSchema
+	default:
+		return SQLFailureUnknown
+	}
+}
+
+func classifyMySQLErrorNumber(number uint16) SQLFailureCode {
+	switch number {
+	case 1045, 1698:
+		return SQLFailureAuthentication
+	case 1044, 1142, 1143, 1227:
+		return SQLFailurePermission
+	case 1049:
+		return SQLFailureInvalidConfiguration
+	case 1048, 1062, 1364, 1406, 1451, 1452:
+		return SQLFailureConstraint
+	case 1053, 1158, 1159, 1160, 1161, 1205, 1213, 2006, 2013:
+		return SQLFailureTransient
+	case 1040:
+		return SQLFailureUnavailable
+	default:
+		return SQLFailureUnknown
+	}
+}
+
+func sqlFailureRetryable(code SQLFailureCode) bool {
+	switch code {
+	case SQLFailureTimeout, SQLFailureTransient, SQLFailureUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func sqlFailureMessage(code SQLFailureCode) string {
+	switch code {
+	case SQLFailureInvalidConfiguration:
+		return "The SQL target configuration is invalid."
+	case SQLFailureTLSVerification:
+		return "The SQL target TLS connection could not be verified."
+	case SQLFailureAuthentication:
+		return "The SQL target rejected authentication."
+	case SQLFailurePermission:
+		return "The SQL target denied the required operation."
+	case SQLFailureConstraint:
+		return "The SQL target rejected data under an existing constraint."
+	case SQLFailureTimeout:
+		return "The SQL target operation timed out."
+	case SQLFailureCancelled:
+		return "The SQL target operation was cancelled."
+	case SQLFailureTransient:
+		return "The SQL target reported a transient database failure."
+	case SQLFailureUnavailable:
+		return "The SQL target is temporarily unavailable."
+	case SQLFailureSchema:
+		return "The SQL target schema is incompatible."
+	default:
+		return "The SQL target operation failed."
+	}
+}

--- a/pkg/recordsink/sql_diagnostic_test.go
+++ b/pkg/recordsink/sql_diagnostic_test.go
@@ -1,0 +1,83 @@
+package recordsink
+
+import (
+	"context"
+	"crypto/x509"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestClassifySQLErrorUsesStableRetryCategories(t *testing.T) {
+	tests := []struct {
+		name      string
+		stage     SQLFailureStage
+		err       error
+		code      SQLFailureCode
+		retryable bool
+	}{
+		{name: "cancelled", stage: SQLStageProbe, err: context.Canceled, code: SQLFailureCancelled},
+		{name: "deadline", stage: SQLStageConnect, err: context.DeadlineExceeded, code: SQLFailureTimeout, retryable: true},
+		{name: "bad connection", stage: SQLStageSync, err: driver.ErrBadConn, code: SQLFailureUnavailable, retryable: true},
+		{name: "invalid connection", stage: SQLStageConnect, err: mysql.ErrInvalidConn, code: SQLFailureUnavailable, retryable: true},
+		{name: "authentication", stage: SQLStageConnect, err: &mysql.MySQLError{Number: 1045, Message: "secret account rejected"}, code: SQLFailureAuthentication},
+		{name: "permission", stage: SQLStageSchema, err: &mysql.MySQLError{Number: 1142, Message: "private table denied"}, code: SQLFailurePermission},
+		{name: "constraint", stage: SQLStageSync, err: &mysql.MySQLError{Number: 1062, Message: "duplicate private value"}, code: SQLFailureConstraint},
+		{name: "deadlock", stage: SQLStageSync, err: &mysql.MySQLError{Number: 1213, Message: "transaction details"}, code: SQLFailureTransient, retryable: true},
+		{name: "too many connections", stage: SQLStageConnect, err: &mysql.MySQLError{Number: 1040, Message: "server details"}, code: SQLFailureUnavailable, retryable: true},
+		{name: "network timeout", stage: SQLStageConnect, err: &net.DNSError{IsTimeout: true}, code: SQLFailureTimeout, retryable: true},
+		{name: "network unavailable", stage: SQLStageConnect, err: &net.DNSError{IsTemporary: true}, code: SQLFailureUnavailable, retryable: true},
+		{name: "certificate hostname", stage: SQLStageConnect, err: x509.HostnameError{Certificate: &x509.Certificate{}, Host: "private.internal"}, code: SQLFailureTLSVerification},
+		{name: "configuration", stage: SQLStageConfiguration, err: errors.New("raw config details"), code: SQLFailureInvalidConfiguration},
+		{name: "schema", stage: SQLStageSchema, err: errors.New("raw schema details"), code: SQLFailureSchema},
+		{name: "unknown", stage: SQLStageSync, err: errors.New("raw unknown details"), code: SQLFailureUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failure := ClassifySQLError(test.stage, fmt.Errorf("operation wrapper: %w", test.err))
+			if failure.Code != test.code || failure.Stage != test.stage || failure.Retryable != test.retryable {
+				t.Fatalf("classification = %+v, want code=%q stage=%q retryable=%t", failure, test.code, test.stage, test.retryable)
+			}
+			if !errors.Is(failure, test.err) {
+				t.Fatalf("classified failure did not retain errors.Is relationship to %T", test.err)
+			}
+		})
+	}
+}
+
+func TestSQLFailureSerializationAndTextNeverExposeCause(t *testing.T) {
+	const secret = "mysql-secret-user:password@private-db.internal/private_schema"
+	cause := fmt.Errorf("connect using %s: %w", secret, &mysql.MySQLError{Number: 1045, Message: secret})
+	failure := ClassifySQLError(SQLStageConnect, cause)
+	encoded, err := json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outward := failure.Error() + "\n" + string(encoded)
+	for _, forbidden := range []string{secret, "private-db", "private_schema", "password"} {
+		if strings.Contains(outward, forbidden) {
+			t.Fatalf("outward SQL diagnostic exposed %q: %s", forbidden, outward)
+		}
+	}
+	if !strings.Contains(outward, string(SQLFailureAuthentication)) || !strings.Contains(outward, `"retryable":false`) {
+		t.Fatalf("outward SQL diagnostic omitted stable fields: %s", outward)
+	}
+	if !errors.Is(failure, cause) {
+		t.Fatal("classified failure did not retain its internal cause")
+	}
+}
+
+func TestClassifySQLErrorPreservesAnExistingSafeFailure(t *testing.T) {
+	original := ClassifySQLError(SQLStageTLS, errors.New("private CA path"))
+	classified := ClassifySQLError(SQLStageSync, fmt.Errorf("outer: %w", original))
+	if classified != original {
+		t.Fatalf("existing safe failure was reclassified: got=%p want=%p", classified, original)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -324,6 +324,8 @@ func (s *Server) Config() appconfig.Config {
 // protected config files, environment variables, or command-line options.
 func browserConfig(cfg appconfig.Config) appconfig.Config {
 	cfg.Export.MySQLDSN = ""
+	cfg.Export.MySQLTLSCAFile = ""
+	cfg.Export.MySQLTLSServerName = ""
 	return cfg
 }
 
@@ -873,10 +875,13 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to decode config: %v", err), http.StatusBadRequest)
 		return
 	}
-	// The browser is not a credential-management surface. Preserve the
-	// protected server-side DSN even if an old cached config or a crafted
-	// request includes a mysql_dsn value.
-	cfg.Export.MySQLDSN = s.config.Get().Export.MySQLDSN
+	// The browser is not a connection-management surface. Preserve protected
+	// server-side connection material even if an old cache or crafted request
+	// includes replacement values.
+	protectedExport := s.config.Get().Export
+	cfg.Export.MySQLDSN = protectedExport.MySQLDSN
+	cfg.Export.MySQLTLSCAFile = protectedExport.MySQLTLSCAFile
+	cfg.Export.MySQLTLSServerName = protectedExport.MySQLTLSServerName
 	cfg, err := s.ReplaceConfig(cfg)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -544,7 +544,7 @@ func TestServerJSON(t *testing.T) {
 	})
 }
 
-func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
+func TestBrowserConfigRedactsAndPreservesProtectedMySQLConnectionConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "patris-export.json")
 	manager, err := appconfig.Load(configPath)
@@ -552,10 +552,14 @@ func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
 		t.Fatalf("load config manager: %v", err)
 	}
 	const protectedDSN = "protected-dsn-test-value"
+	const protectedCAPath = "C:/protected/mysql/private-ca-path.pem"
+	const protectedServerName = "private-db.internal.example"
 	if err := manager.Update(func(cfg *appconfig.Config) {
 		cfg.Export.MySQLDSN = protectedDSN
+		cfg.Export.MySQLTLSCAFile = protectedCAPath
+		cfg.Export.MySQLTLSServerName = protectedServerName
 	}); err != nil {
-		t.Fatalf("store protected DSN: %v", err)
+		t.Fatalf("store protected MySQL config: %v", err)
 	}
 
 	jsonPath := filepath.Join(tmpDir, "records.json")
@@ -575,8 +579,17 @@ func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
 			t.Fatalf("marshal browser payload: %v", err)
 		}
 		body := string(data)
-		if strings.Contains(body, protectedDSN) || strings.Contains(body, `"mysql_dsn"`) {
-			t.Fatalf("browser payload exposed protected SQL configuration: %s", body)
+		for _, forbidden := range []string{
+			protectedDSN,
+			protectedCAPath,
+			protectedServerName,
+			`"mysql_dsn"`,
+			`"mysql_tls_ca_file"`,
+			`"mysql_tls_server_name"`,
+		} {
+			if strings.Contains(body, forbidden) {
+				t.Fatalf("browser payload exposed protected SQL configuration %q: %s", forbidden, body)
+			}
 		}
 	}
 
@@ -603,6 +616,8 @@ func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
 	clientConfig := browserConfig(manager.Get())
 	clientConfig.UI.Theme = "dark"
 	clientConfig.Export.MySQLDSN = "browser-supplied-dsn-must-be-ignored"
+	clientConfig.Export.MySQLTLSCAFile = "browser-supplied-ca-must-be-ignored.pem"
+	clientConfig.Export.MySQLTLSServerName = "browser-supplied-name.invalid"
 	body, err := json.Marshal(clientConfig)
 	if err != nil {
 		t.Fatalf("marshal browser update: %v", err)
@@ -613,8 +628,14 @@ func TestBrowserConfigRedactsAndPreservesMySQLDSN(t *testing.T) {
 		t.Fatalf("PUT /api/config status = %d: %s", put.Code, put.Body.String())
 	}
 	assertRedacted(t, json.RawMessage(put.Body.Bytes()))
-	if got := manager.Get(); got.Export.MySQLDSN != protectedDSN || got.UI.Theme != "dark" {
-		t.Fatalf("browser update did not preserve protected DSN and apply UI setting: DSN preserved=%t theme=%q", got.Export.MySQLDSN == protectedDSN, got.UI.Theme)
+	if got := manager.Get(); got.Export.MySQLDSN != protectedDSN || got.Export.MySQLTLSCAFile != protectedCAPath ||
+		got.Export.MySQLTLSServerName != protectedServerName || got.UI.Theme != "dark" {
+		t.Fatalf("browser update did not preserve protected MySQL config and apply UI setting: DSN=%t CA=%t name=%t theme=%q",
+			got.Export.MySQLDSN == protectedDSN,
+			got.Export.MySQLTLSCAFile == protectedCAPath,
+			got.Export.MySQLTLSServerName == protectedServerName,
+			got.UI.Theme,
+		)
 	}
 }
 


### PR DESCRIPTION
﻿## Summary

- add a shared MySQL/MariaDB connector with finite connection bounds and verified custom-CA TLS 1.2+
- add a non-mutating connection probe that returns bounded, sanitized status only
- add stable typed failure and retry classification without exposing driver messages or protected connection material
- keep protected connection settings server-side across browser reads, broadcasts, and saves
- document operational limits and safe retry behavior

## Safety

- no production database operation was performed
- no automatic transaction replay was added
- no live executable was rebuilt or promoted in this foundation PR
- protected connection material and raw driver errors are excluded from outward results

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./pkg/recordsink ./pkg/appconfig ./pkg/server`
- `npm test` (52 tests)
- `npm run build`
- `git diff --check`

Progresses #6. The issue remains open for the authenticated UI/manual-sync flow, soft-delete behavior, broader database CI coverage, and owner approval.
