### PR TITLE
ci(sql): verify MySQL and MariaDB compatibility

### DIFF
--- a/.github/workflows/sql-integration.yml
+++ b/.github/workflows/sql-integration.yml
@@ -1,0 +1,67 @@
+name: SQL Target Compatibility
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sql-target-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    name: ${{ matrix.name }} compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: MySQL 8.4
+            image: mysql:8.4
+            health_cmd: mysqladmin ping -h 127.0.0.1 -uroot -ppatris_root_test --silent
+          - name: MariaDB 11.4
+            image: mariadb:11.4
+            health_cmd: healthcheck.sh --connect --innodb_initialized
+
+    services:
+      sql:
+        image: ${{ matrix.image }}
+        env:
+          MYSQL_ROOT_PASSWORD: patris_root_test
+          MYSQL_DATABASE: patris_test
+          MYSQL_USER: patris_test
+          MYSQL_PASSWORD: patris_test
+          MARIADB_ROOT_PASSWORD: patris_root_test
+          MARIADB_DATABASE: patris_test
+          MARIADB_USER: patris_test
+          MARIADB_PASSWORD: patris_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "${{ matrix.health_cmd }}"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      PATRIS_EXPORT_TEST_MYSQL_DSN: patris_test:patris_test@tcp(127.0.0.1:3306)/patris_test?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify transactional SQL parity and compatibility
+        run: go test -race -count=1 -run '^TestSQLTargetMatrixParitySchemaEvolutionAndRollback$' -v ./pkg/recordsink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Pull requests now prove SQL sink parity and transactional rollback against
+  disposable MySQL 8.4, MariaDB 11.4, and SQLite targets while preserving
+  leading-zero keys, additive schemas, and user-owned columns.
 - MySQL/MariaDB targets now have a shared bounded read-only connection probe,
   protected custom-CA/server-name configuration, verified TLS 1.2+ connector,
   and typed secret-safe retry diagnostics for future authenticated UI controls.

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -184,8 +184,16 @@ Remove-Item Env:PATRIS_EXPORT_TEST_MYSQL_DSN
 
 The MariaDB test is skipped unless its dedicated test DSN is present and drops
 only the uniquely named table it creates. Authenticated browser connection-test
-and manual-sync controls, `soft_delete_missing`, and the broader database CI
-matrix remain separate follow-up work.
+and manual-sync controls plus `soft_delete_missing` remain separate follow-up
+work.
+
+Every pull request also runs a disposable compatibility matrix against MySQL
+8.4 and MariaDB 11.4. The matrix proves parity with the same SQLite fixture,
+leading-zero key preservation, additive schema evolution without changing
+user-owned columns, and transactional rollback on a later batch failure.
+Matrix credentials are test-only values inside isolated CI service containers;
+production DSNs remain protected configuration and are never stored in the
+repository or returned to a browser.
 
 ## Watch and Send Updates
 

--- a/pkg/recordsink/sql_matrix_integration_test.go
+++ b/pkg/recordsink/sql_matrix_integration_test.go
@@ -1,0 +1,190 @@
+package recordsink
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type matrixProduct struct {
+	Code           string
+	Name           string
+	FinalPrice     int64
+	WarehouseStock int64
+}
+
+func TestSQLTargetMatrixParitySchemaEvolutionAndRollback(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("PATRIS_EXPORT_TEST_MYSQL_DSN"))
+	if dsn == "" {
+		t.Skip("set PATRIS_EXPORT_TEST_MYSQL_DSN to run the disposable MySQL/MariaDB compatibility proof")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	mysqlDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal("open disposable SQL target:", err)
+	}
+	defer mysqlDB.Close()
+	if err := mysqlDB.PingContext(ctx); err != nil {
+		t.Fatal("ping disposable SQL target:", err)
+	}
+	var version string
+	if err := mysqlDB.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version); err != nil {
+		t.Fatal("read disposable SQL target version:", err)
+	}
+	t.Logf("verifying SQL target %s", version)
+
+	table := fmt.Sprintf("patris_matrix_%d", time.Now().UTC().UnixNano())
+	quotedTable := quoteIdent("mysql", table)
+	defer func() {
+		_, _ = mysqlDB.Exec("DROP TABLE IF EXISTS " + quotedTable)
+	}()
+
+	sqlitePath := filepath.Join(t.TempDir(), "matrix.sqlite")
+	options := SQLOptions{
+		Driver:         "mysql",
+		DSN:            dsn,
+		Table:          table,
+		KeyField:       "product_code",
+		Batch:          1,
+		ConnectTimeout: 5 * time.Second,
+	}
+	initial := []map[string]interface{}{
+		{"product_code": "0001", "name": "Alpha", "final_price": int64(100)},
+		{"product_code": "0002", "name": "Beta", "final_price": int64(200)},
+	}
+
+	mysqlResult, err := SyncSQLWithResult(ctx, options, initial)
+	if err != nil {
+		t.Fatal("initial MySQL/MariaDB sync:", err)
+	}
+	assertSQLResultCounts(t, mysqlResult, 2, 0, 0, 0, 0)
+	sqliteResult, err := SyncSQLite(ctx, sqlitePath, SQLOptions{
+		Table: table, KeyField: "product_code", Batch: 1,
+	}, initial)
+	if err != nil {
+		t.Fatal("initial SQLite parity sync:", err)
+	}
+	assertSQLResultCounts(t, sqliteResult, 2, 0, 0, 0, 0)
+
+	if _, err := mysqlDB.ExecContext(ctx, "ALTER TABLE "+quotedTable+" ADD COLUMN `operator_notes` VARCHAR(255) NULL, ADD COLUMN `rollback_guard` VARCHAR(64) NULL CHECK (`rollback_guard` <> 'reject')"); err != nil {
+		t.Fatal("add MySQL/MariaDB user-owned columns:", err)
+	}
+	if _, err := mysqlDB.ExecContext(ctx, "UPDATE "+quotedTable+" SET `operator_notes` = 'preserve me', `rollback_guard` = CONCAT('guard-', `product_code`)"); err != nil {
+		t.Fatal("seed MySQL/MariaDB user-owned columns:", err)
+	}
+
+	sqliteDB, err := sql.Open("sqlite3", sqlitePath)
+	if err != nil {
+		t.Fatal("open SQLite parity target:", err)
+	}
+	defer sqliteDB.Close()
+	if _, err := sqliteDB.ExecContext(ctx, "ALTER TABLE "+quoteIdent("sqlite", table)+" ADD COLUMN `operator_notes` TEXT NULL"); err != nil {
+		t.Fatal("add SQLite user-owned notes column:", err)
+	}
+	if _, err := sqliteDB.ExecContext(ctx, "ALTER TABLE "+quoteIdent("sqlite", table)+" ADD COLUMN `rollback_guard` TEXT NULL CHECK (`rollback_guard` <> 'reject')"); err != nil {
+		t.Fatal("add SQLite rollback column:", err)
+	}
+	if _, err := sqliteDB.ExecContext(ctx, "UPDATE "+quoteIdent("sqlite", table)+" SET `operator_notes` = 'preserve me', `rollback_guard` = 'guard-' || `product_code`"); err != nil {
+		t.Fatal("seed SQLite user-owned columns:", err)
+	}
+
+	evolved := []map[string]interface{}{
+		{"product_code": "0001", "name": "Alpha", "final_price": int64(150), "warehouse_stock": int64(7)},
+		{"product_code": "0002", "name": "Beta", "final_price": int64(200), "warehouse_stock": int64(3)},
+	}
+	mysqlResult, err = SyncSQLWithResult(ctx, options, evolved)
+	if err != nil {
+		t.Fatal("evolved MySQL/MariaDB sync:", err)
+	}
+	assertSQLResultCounts(t, mysqlResult, 0, 2, 0, 0, 0)
+	sqliteResult, err = SyncSQLite(ctx, sqlitePath, SQLOptions{
+		Table: table, KeyField: "product_code", Batch: 1,
+	}, evolved)
+	if err != nil {
+		t.Fatal("evolved SQLite parity sync:", err)
+	}
+	assertSQLResultCounts(t, sqliteResult, 0, 2, 0, 0, 0)
+
+	mysqlProducts := readMatrixProducts(t, ctx, mysqlDB, "mysql", table)
+	sqliteProducts := readMatrixProducts(t, ctx, sqliteDB, "sqlite", table)
+	if !reflect.DeepEqual(mysqlProducts, sqliteProducts) {
+		t.Fatalf("canonical SQL parity mismatch: mysql=%+v sqlite=%+v", mysqlProducts, sqliteProducts)
+	}
+	if len(mysqlProducts) != 2 || mysqlProducts[0].Code != "0001" {
+		t.Fatalf("string keys with leading zeros were not preserved: %+v", mysqlProducts)
+	}
+	assertMatrixUserColumn(t, ctx, mysqlDB, "mysql", table, "0001")
+	assertMatrixUserColumn(t, ctx, sqliteDB, "sqlite", table, "0001")
+
+	failing := []map[string]interface{}{
+		{"product_code": "0001", "name": "Alpha", "final_price": int64(999), "warehouse_stock": int64(7), "rollback_guard": "accepted"},
+		{"product_code": "0003", "name": "Gamma", "final_price": int64(300), "warehouse_stock": int64(1), "rollback_guard": "reject"},
+	}
+	mysqlResult, err = SyncSQLWithResult(ctx, options, failing)
+	assertMatrixRollback(t, "MySQL/MariaDB", mysqlResult, err, len(failing))
+	sqliteResult, err = SyncSQLite(ctx, sqlitePath, SQLOptions{
+		Table: table, KeyField: "product_code", Batch: 1,
+	}, failing)
+	assertMatrixRollback(t, "SQLite", sqliteResult, err, len(failing))
+
+	if got := readMatrixProducts(t, ctx, mysqlDB, "mysql", table); !reflect.DeepEqual(got, mysqlProducts) {
+		t.Fatalf("MySQL/MariaDB batch failure did not roll back: got=%+v want=%+v", got, mysqlProducts)
+	}
+	if got := readMatrixProducts(t, ctx, sqliteDB, "sqlite", table); !reflect.DeepEqual(got, sqliteProducts) {
+		t.Fatalf("SQLite batch failure did not roll back: got=%+v want=%+v", got, sqliteProducts)
+	}
+}
+
+func readMatrixProducts(t *testing.T, ctx context.Context, db *sql.DB, driver, table string) []matrixProduct {
+	t.Helper()
+	query := "SELECT `product_code`, `name`, `final_price`, `warehouse_stock` FROM " + quoteIdent(driver, table) + " ORDER BY `product_code`"
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		t.Fatal("read matrix products:", err)
+	}
+	defer rows.Close()
+
+	products := make([]matrixProduct, 0)
+	for rows.Next() {
+		var product matrixProduct
+		if err := rows.Scan(&product.Code, &product.Name, &product.FinalPrice, &product.WarehouseStock); err != nil {
+			t.Fatal("scan matrix product:", err)
+		}
+		products = append(products, product)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal("iterate matrix products:", err)
+	}
+	return products
+}
+
+func assertMatrixUserColumn(t *testing.T, ctx context.Context, db *sql.DB, driver, table, code string) {
+	t.Helper()
+	query := "SELECT `operator_notes` FROM " + quoteIdent(driver, table) + " WHERE `product_code` = ?"
+	var notes string
+	if err := db.QueryRowContext(ctx, query, code).Scan(&notes); err != nil {
+		t.Fatal("read preserved user-owned column:", err)
+	}
+	if notes != "preserve me" {
+		t.Fatalf("user-owned column changed during additive evolution: %q", notes)
+	}
+}
+
+func assertMatrixRollback(t *testing.T, target string, result SQLResult, err error, requested int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s rejected batch unexpectedly succeeded", target)
+	}
+	if result.Inserted != 0 || result.Updated != 0 || result.Unchanged != 0 || result.Deleted != 0 || result.Failed != requested {
+		t.Fatalf("%s rollback result = %+v, want %d failed and no committed successes", target, result, requested)
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the missing disposable database compatibility gate for the SQL sink tracked in #6.

- runs every pull request against MySQL 8.4 and MariaDB 11.4 service containers
- compares both engines with the same SQLite fixture and canonical sink path
- proves leading-zero key preservation and bounded single-row batches
- proves additive schema evolution preserves user-owned columns
- forces a later-batch unique-key failure and verifies the whole transaction rolls back with zero committed-success counts
- uses isolated test-only service credentials; production DSNs remain protected and are never returned to clients

## Local validation

- full Go test suite passed with the guarded dynamic pxlib runtime
- full Go vet passed
- recordsink race suite passed
- web frontend: 52 tests passed and build completed
- diff hygiene passed

The new GitHub matrix is the authoritative live MySQL/MariaDB proof for this PR. Relates to #6; the issue remains open pending the authenticated operation UI and owner approval.