### PR TITLE
Add guarded SQL soft-delete reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Pull requests now prove SQL sink parity and transactional rollback against
   disposable MySQL 8.4, MariaDB 11.4, and SQLite targets while preserving
-  leading-zero keys, additive schemas, and user-owned columns.
+  leading-zero keys, additive schemas, user-owned columns, and guarded
+  soft-delete/restore behavior.
+- SQL targets now support guarded `soft_delete_missing` reconciliation through
+  a reserved boolean tombstone, non-mutating operator evidence, exact preview
+  confirmation, empty-source blocking, stale-plan detection, restoration, and
+  rollback-safe retries with fresh-preview idempotency.
 - MySQL/MariaDB targets now have a shared bounded read-only connection probe,
   protected custom-CA/server-name configuration, verified TLS 1.2+ connector,
   and typed secret-safe retry diagnostics for future authenticated UI controls.

--- a/README.md
+++ b/README.md
@@ -146,13 +146,21 @@ patris-export convert kala.db \
   --sqlite-table products \
   --batch-size 250
 
-# Preview authoritative reconciliation; upsert_only is the safe default.
+# Preview guarded soft deletion; upsert_only is the safe default.
 patris-export convert kala.db \
   -f sqlite \
   --sqlite-path output/patris-products.sqlite \
   --sqlite-table products \
-  --reconciliation delete_missing \
+  --reconciliation soft_delete_missing \
   --dry-run
+
+# Apply only the unchanged deletion keyset using the preview's sha256 digest.
+patris-export convert kala.db \
+  -f sqlite \
+  --sqlite-path output/patris-products.sqlite \
+  --sqlite-table products \
+  --reconciliation soft_delete_missing \
+  --reconciliation-token 'sha256:<exact-preview-digest>'
 
 # Watch and send canonical JSON changes to a configured receiver.
 # PATRIS_PRODUCT_SYNC_SECRET is injected into the process environment by

--- a/cmd/patris-export/main.go
+++ b/cmd/patris-export/main.go
@@ -72,6 +72,7 @@ var (
 	mysqlTable      string
 	exportBatchSize int
 	exportReconcile string
+	reconcileToken  string
 	exportDryRun    bool
 	xlsxLanguage    string
 	xlsxMode        string
@@ -162,7 +163,8 @@ Supports Persian/Farsi encoding conversion and file watching.
 	convertCmd.Flags().StringVar(&mysqlDSN, "mysql-dsn", "", "MySQL DSN for --format mysql (or PATRIS_EXPORT_MYSQL_DSN)")
 	convertCmd.Flags().StringVar(&mysqlTable, "mysql-table", "", "MySQL table name for --format mysql")
 	convertCmd.Flags().IntVar(&exportBatchSize, "batch-size", 0, "Maximum rows per prepared SQL batch")
-	convertCmd.Flags().StringVar(&exportReconcile, "reconciliation", "", "SQL reconciliation mode: upsert_only (safe default) or delete_missing")
+	convertCmd.Flags().StringVar(&exportReconcile, "reconciliation", "", "SQL reconciliation mode: upsert_only (safe default), soft_delete_missing, or delete_missing")
+	convertCmd.Flags().StringVar(&reconcileToken, "reconciliation-token", "", "Exact dry-run confirmation digest required to apply soft_delete_missing")
 	convertCmd.Flags().BoolVar(&exportDryRun, "dry-run", false, "Preview SQL insert/update/delete counts without changing the destination")
 	convertCmd.Flags().StringVar(&xlsxLanguage, "xlsx-language", "", "Excel header language: auto, en, or fa (auto follows the configured UI language)")
 	convertCmd.Flags().StringVar(&xlsxMode, "xlsx-mode", "", "Excel price output mode: precalculated or formula")
@@ -894,12 +896,13 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 			outputFile = filepath.Join(outputDir, baseName+".sqlite")
 		}
 		syncResult, err := recordsink.SyncSQLite(context.Background(), outputFile, recordsink.SQLOptions{
-			Table:          tableName,
-			KeyField:       result.KeyField,
-			Batch:          cfg.Export.BatchSize,
-			Reconciliation: recordsink.ReconciliationMode(cfg.Export.Reconciliation),
-			DryRun:         cfg.Export.DryRun,
-			ProtectedKeys:  quarantinedCodes(result),
+			Table:               tableName,
+			KeyField:            result.KeyField,
+			Batch:               cfg.Export.BatchSize,
+			Reconciliation:      recordsink.ReconciliationMode(cfg.Export.Reconciliation),
+			ReconciliationToken: reconcileToken,
+			DryRun:              cfg.Export.DryRun,
+			ProtectedKeys:       quarantinedCodes(result),
 		}, result.Rows)
 		if err != nil {
 			return err
@@ -913,15 +916,16 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 		syncResult, err := recordsink.SyncSQLWithResult(ctx, recordsink.SQLOptions{
-			Driver:         "mysql",
-			DSN:            dsn,
-			Table:          tableName,
-			KeyField:       result.KeyField,
-			Batch:          cfg.Export.BatchSize,
-			Reconciliation: recordsink.ReconciliationMode(cfg.Export.Reconciliation),
-			DryRun:         cfg.Export.DryRun,
-			ProtectedKeys:  quarantinedCodes(result),
-			ConnectTimeout: recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout),
+			Driver:              "mysql",
+			DSN:                 dsn,
+			Table:               tableName,
+			KeyField:            result.KeyField,
+			Batch:               cfg.Export.BatchSize,
+			Reconciliation:      recordsink.ReconciliationMode(cfg.Export.Reconciliation),
+			ReconciliationToken: reconcileToken,
+			DryRun:              cfg.Export.DryRun,
+			ProtectedKeys:       quarantinedCodes(result),
+			ConnectTimeout:      recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout),
 			MySQLTLS: recordsink.MySQLTLSOptions{
 				CAFile:     cfg.Export.MySQLTLSCAFile,
 				ServerName: cfg.Export.MySQLTLSServerName,
@@ -945,6 +949,24 @@ func writeConvertOutput(dbFile string, result recordpipe.Result, useStdout bool,
 			sqlResult.Reconciliation,
 			sqlResult.DryRun,
 		)
+		if evidence := sqlResult.ReconciliationEvidence; evidence != nil {
+			infoColor.Printf(
+				"Reconciliation evidence: source=%d protected=%d target=%d missing=%d would_soft_delete=%d already_soft_deleted=%d would_restore=%d partial_source_risk=%t apply_allowed=%t guard=%s\n",
+				evidence.SourceRows,
+				evidence.ProtectedRows,
+				evidence.TargetRows,
+				evidence.MissingRows,
+				evidence.WouldSoftDelete,
+				evidence.AlreadySoftDeleted,
+				evidence.WouldRestore,
+				evidence.PartialSourceRisk,
+				evidence.ApplyAllowed,
+				evidence.GuardCode,
+			)
+			if evidence.ConfirmationToken != "" {
+				infoColor.Printf("Soft-delete confirmation token: %s\n", evidence.ConfirmationToken)
+			}
+		}
 		if sqlResult.DryRun {
 			successColor.Printf("SQL dry-run preview completed for: %s\n", outputFile)
 			return nil

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -128,23 +128,63 @@ export:
 ```
 
 `upsert_only` inserts and updates supplied Codes but preserves destination rows
-that are absent from the current input. Use `delete_missing` only for a known
-complete authoritative snapshot. Canonical quarantine/protected Codes remain
-preserved even in `delete_missing` mode.
+that are absent from the current input. `soft_delete_missing` sets the reserved
+boolean `patris_export_deleted` column for absent rows and clears it when a row
+returns. The column is additive, non-null, defaults to false, and cannot be
+supplied or mapped by source records. Identifier aliases that normalize to that
+reserved name are rejected too. A pre-existing reserved column is accepted only
+when it has a compatible boolean type, is non-null, and defaults to false.
+`delete_missing` remains the explicit hard deletion mode. Canonical
+quarantine/protected Codes are retained by both modes.
 
-Preview the exact operation counts without changing the destination:
+Soft-delete apply is a two-step operation. First preview the deletion keyset and
+operation counts without changing data or schema:
 
 ```powershell
 patris-export convert C:\Patris\data4\kala.db -f sqlite `
   --sqlite-path .\exports\patris-products.sqlite `
   --sqlite-table products `
-  --reconciliation delete_missing `
+  --reconciliation soft_delete_missing `
   --dry-run
 ```
 
-The result line reports `inserted`, `updated`, `unchanged`, `deleted`, `failed`,
-and `elapsed` milliseconds; it never includes the DSN. A dry run against a
-missing SQLite path does not create the file or its parent directory.
+The evidence line reports source, protected, target, missing, newly marked,
+already marked, and restored counts, plus `partial_source_risk` and whether
+apply is allowed. It prints a `sha256:` confirmation digest only when the source
+is non-empty. Review those counts, then apply the unchanged plan with that exact
+digest:
+
+```powershell
+patris-export convert C:\Patris\data4\kala.db -f sqlite `
+  --sqlite-path .\exports\patris-products.sqlite `
+  --sqlite-table products `
+  --reconciliation soft_delete_missing `
+  --reconciliation-token 'sha256:<exact digest from the preview>'
+```
+
+The digest binds the mode, table, key field, deterministic prepared source
+fields and typed values, source and protected keys, and every destination key
+plus its tombstone state without serializing any of them. An empty source is
+always blocked and never receives a digest. A same-key source-value change, a
+changed or partial source, a newly added target row, a target tombstone change,
+or a changed protected set invalidates the prior digest before schema or data
+mutation. This makes an accidental partial read or stale preview visible and
+requires a new preview rather than silently applying a different plan.
+
+For `soft_delete_missing`, the result's `deleted` count means rows newly marked
+as deleted; already marked rows are not counted again. The same digest can be
+retried after a confirmed rollback because source and destination state did not
+change. A successful apply changes the bound destination state and therefore
+requires a fresh preview; applying that fresh no-op plan is idempotent. A
+returning source row is restored by setting `patris_export_deleted` to false and
+is reported in evidence. After an ambiguous commit outcome, run a new preview
+and inspect live state before retry.
+
+The standard result also reports `inserted`, `updated`, `unchanged`, `failed`,
+and `elapsed` milliseconds; it never includes connection material or keys. A
+dry run against a missing SQLite path does not create the file or its parent
+directory. Hard `delete_missing` should be used only for a separately verified,
+complete authoritative snapshot.
 
 MySQL/MariaDB connections use a finite 10-second connection bound by default
 (configurable from 100 ms through 2 minutes) in addition to any DSN I/O
@@ -175,7 +215,7 @@ Reproduce the SQLite initial-write/update proof locally, and optionally run the
 same proof against a disposable MariaDB/MySQL database:
 
 ```powershell
-go test ./pkg/recordsink -run TestSQLiteSyncInitialUpdateDryRunAndProtectedDelete -v
+go test ./pkg/recordsink -run 'TestSQLiteSoftDelete|TestSoftDelete' -v
 
 $env:PATRIS_EXPORT_TEST_MYSQL_DSN = "test_user:test_password@tcp(127.0.0.1:3306)/patris_test?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s"
 go test ./pkg/recordsink -run TestMariaDBSyncInitialWriteAndUpdate -v
@@ -184,13 +224,13 @@ Remove-Item Env:PATRIS_EXPORT_TEST_MYSQL_DSN
 
 The MariaDB test is skipped unless its dedicated test DSN is present and drops
 only the uniquely named table it creates. Authenticated browser connection-test
-and manual-sync controls plus `soft_delete_missing` remain separate follow-up
-work.
+and manual-sync controls remain separate follow-up work.
 
 Every pull request also runs a disposable compatibility matrix against MySQL
 8.4 and MariaDB 11.4. The matrix proves parity with the same SQLite fixture,
 leading-zero key preservation, additive schema evolution without changing
-user-owned columns, and transactional rollback on a later batch failure.
+user-owned columns, guarded soft-delete/restore behavior, and transactional
+rollback on a later batch failure.
 Matrix credentials are test-only values inside isolated CI service containers;
 production DSNs remain protected configuration and are never stored in the
 repository or returned to a browser.

--- a/installer/windows/config.example.toml
+++ b/installer/windows/config.example.toml
@@ -16,6 +16,9 @@ rtl_text_direction = false
 xlsx_language = "auto"
 xlsx_mode = "precalculated"
 xlsx_zebra_rows = true
+# SQL reconciliation defaults to upsert_only. soft_delete_missing must first be
+# previewed with --dry-run and then applied with --reconciliation-token.
+reconciliation = "upsert_only"
 # Keep MySQL credentials in PATRIS_EXPORT_MYSQL_DSN. For a private CA, uncomment
 # these protected local settings; they are redacted from browser configuration.
 # mysql_tls_ca_file = 'C:\Patris\certificates\database-ca.pem'

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -1020,7 +1020,7 @@ func normalize(cfg *Config) {
 	switch cfg.Export.Reconciliation {
 	case "", "upsert_only":
 		cfg.Export.Reconciliation = "upsert_only"
-	case "delete_missing":
+	case "soft_delete_missing", "delete_missing":
 	default:
 		// Unknown modes fail toward the non-destructive behavior. The sink also
 		// validates direct API use rather than silently deleting records.

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -293,6 +293,11 @@ func TestSQLExportDefaultsAndEnvironmentOverrides(t *testing.T) {
 	if cfg.Export.MySQLConnectTimeout != "10s" {
 		t.Fatalf("invalid SQL connection timeout did not use the safe default: %q", cfg.Export.MySQLConnectTimeout)
 	}
+	cfg.Export.Reconciliation = "SOFT_DELETE_MISSING"
+	normalize(&cfg)
+	if cfg.Export.Reconciliation != "soft_delete_missing" {
+		t.Fatalf("soft-delete reconciliation was not preserved: %q", cfg.Export.Reconciliation)
+	}
 }
 
 func TestXLSXExportDefaultsConfigAndEnvironment(t *testing.T) {

--- a/pkg/recordsink/mysql_target_test.go
+++ b/pkg/recordsink/mysql_target_test.go
@@ -98,8 +98,9 @@ func TestSQLOptionsJSONCannotExposeProtectedConnectionMaterial(t *testing.T) {
 	const caPath = "C:/protected/private-ca.pem"
 	const serverName = "private-db.internal"
 	encoded, err := json.Marshal(SQLOptions{
-		Driver: "mysql",
-		DSN:    dsn,
+		Driver:              "mysql",
+		DSN:                 dsn,
+		ReconciliationToken: "sha256:private-plan-token",
 		MySQLTLS: MySQLTLSOptions{
 			CAFile:     caPath,
 			ServerName: serverName,
@@ -108,7 +109,7 @@ func TestSQLOptionsJSONCannotExposeProtectedConnectionMaterial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, forbidden := range []string{dsn, caPath, serverName, "DSN", "MySQLTLS", "CAFile", "ServerName"} {
+	for _, forbidden := range []string{dsn, caPath, serverName, "sha256:private-plan-token", "DSN", "MySQLTLS", "CAFile", "ServerName", "ReconciliationToken"} {
 		if strings.Contains(string(encoded), forbidden) {
 			t.Fatalf("serialized SQL options exposed %q: %s", forbidden, encoded)
 		}

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -23,16 +23,17 @@ import (
 )
 
 type SQLOptions struct {
-	Driver         string
-	DSN            string `json:"-"`
-	Table          string
-	KeyField       string
-	Batch          int
-	Reconciliation ReconciliationMode
-	DryRun         bool
-	ProtectedKeys  []string
-	ConnectTimeout time.Duration
-	MySQLTLS       MySQLTLSOptions `json:"-"`
+	Driver              string
+	DSN                 string `json:"-"`
+	Table               string
+	KeyField            string
+	Batch               int
+	Reconciliation      ReconciliationMode
+	ReconciliationToken string `json:"-"`
+	DryRun              bool
+	ProtectedKeys       []string
+	ConnectTimeout      time.Duration
+	MySQLTLS            MySQLTLSOptions `json:"-"`
 }
 
 // ReconciliationMode controls what happens to destination rows that are not
@@ -41,26 +42,28 @@ type SQLOptions struct {
 type ReconciliationMode string
 
 const (
-	UpsertOnly    ReconciliationMode = "upsert_only"
-	DeleteMissing ReconciliationMode = "delete_missing"
+	UpsertOnly        ReconciliationMode = "upsert_only"
+	SoftDeleteMissing ReconciliationMode = "soft_delete_missing"
+	DeleteMissing     ReconciliationMode = "delete_missing"
 )
 
 // SQLResult is safe to return to callers and UI layers: it contains operation
 // diagnostics only and never includes the destination DSN.
 type SQLResult struct {
-	Inserted       int                `json:"inserted"`
-	Updated        int                `json:"updated"`
-	Unchanged      int                `json:"unchanged"`
-	Deleted        int                `json:"deleted"`
-	Failed         int                `json:"failed"`
-	ElapsedMS      int64              `json:"elapsed_ms"`
-	DryRun         bool               `json:"dry_run"`
-	Reconciliation ReconciliationMode `json:"reconciliation"`
+	Inserted               int                        `json:"inserted"`
+	Updated                int                        `json:"updated"`
+	Unchanged              int                        `json:"unchanged"`
+	Deleted                int                        `json:"deleted"`
+	Failed                 int                        `json:"failed"`
+	ElapsedMS              int64                      `json:"elapsed_ms"`
+	DryRun                 bool                       `json:"dry_run"`
+	Reconciliation         ReconciliationMode         `json:"reconciliation"`
+	ReconciliationEvidence *SQLReconciliationEvidence `json:"reconciliation_evidence,omitempty"`
 }
 
 // SnapshotOptions configures the compatibility WriteSQLite/SyncSnapshotSQL
-// wrappers. WriteSQLite remains upsert_only unless Reconciliation is explicitly
-// DeleteMissing. ProtectedKeys are retained during that opt-in reconciliation.
+// wrappers. Use SyncSQLite or SyncSQLDB directly when a soft-delete preview and
+// its confirmation evidence are required.
 type SnapshotOptions struct {
 	ProtectedKeys  []string
 	Batch          int
@@ -209,8 +212,9 @@ func SyncSnapshotSQL(ctx context.Context, db *sql.DB, driver, table, keyField st
 }
 
 // SyncSQLDB executes the common SQLite/MySQL sink against an already-open
-// database. Data writes and delete_missing reconciliation share one
-// transaction; schema evolution remains additive and is performed before it.
+// database. Data writes and reconciliation share one transaction; schema
+// evolution remains additive and is performed before it. Soft-delete apply
+// requires the digest returned by an exact dry-run preview.
 func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[string]interface{}) (result SQLResult, err error) {
 	started := time.Now()
 	result.DryRun = options.DryRun
@@ -251,18 +255,29 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	if keyField == "" {
 		if len(fields) > 0 {
 			keyField = fields[0]
-		} else if len(options.ProtectedKeys) > 0 || result.Reconciliation == DeleteMissing {
+		} else if len(options.ProtectedKeys) > 0 || result.Reconciliation != UpsertOnly {
 			return result, fmt.Errorf("SQL key field is required for reconciliation")
 		}
+	}
+	if result.Reconciliation == SoftDeleteMissing {
+		rows, err = prepareSoftDeleteRows(rows, keyField)
+		if err != nil {
+			return result, err
+		}
+		fields = recordmap.Fields(rows, keyField)
 	}
 	keys, err := snapshotKeys(rows, keyField, nil)
 	if err != nil {
 		return result, err
 	}
-	if result.Reconciliation == UpsertOnly && len(rows) == 0 {
-		return result, nil
+	keepKeys := keys
+	if result.Reconciliation != UpsertOnly {
+		keepKeys, err = appendProtectedKeys(keys, options.ProtectedKeys)
+		if err != nil {
+			return result, err
+		}
 	}
-	if !tableExists && len(rows) == 0 {
+	if result.Reconciliation == UpsertOnly && len(rows) == 0 {
 		return result, nil
 	}
 
@@ -278,6 +293,32 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 		if keyField != "" && !beforeColumns[strings.ToLower(keyField)] {
 			return result, fmt.Errorf("existing table %q has no key column %q", table, keyField)
 		}
+	}
+	// Authorize before any additive schema change. A second check inside the
+	// data transaction closes the race between preview validation and apply.
+	if result.Reconciliation == SoftDeleteMissing && (!options.DryRun || !tableExists) {
+		evidence, expectedToken, evidenceErr := buildSoftDeleteEvidence(
+			ctx,
+			db,
+			driver,
+			table,
+			keyField,
+			tableExists,
+			beforeColumns[strings.ToLower(SoftDeleteColumn)],
+			rows,
+			keys,
+			keepKeys,
+		)
+		if evidenceErr != nil {
+			return result, evidenceErr
+		}
+		result.ReconciliationEvidence = &evidence
+		if err := authorizeSoftDelete(result.ReconciliationEvidence, expectedToken, options.ReconciliationToken, options.DryRun); err != nil {
+			return result, err
+		}
+	}
+	if !tableExists && len(rows) == 0 {
+		return result, nil
 	}
 
 	if !options.DryRun && len(rows) > 0 {
@@ -313,6 +354,27 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 			_ = tx.Rollback()
 		}
 	}()
+	if result.Reconciliation == SoftDeleteMissing {
+		evidence, expectedToken, evidenceErr := buildSoftDeleteEvidence(
+			ctx,
+			tx,
+			driver,
+			table,
+			keyField,
+			true,
+			beforeColumns[strings.ToLower(SoftDeleteColumn)],
+			rows,
+			keys,
+			keepKeys,
+		)
+		if evidenceErr != nil {
+			return result, evidenceErr
+		}
+		result.ReconciliationEvidence = &evidence
+		if err := authorizeSoftDelete(result.ReconciliationEvidence, expectedToken, options.ReconciliationToken, options.DryRun); err != nil {
+			return result, err
+		}
+	}
 
 	toWrite, counts, err := classifyRows(ctx, tx, driver, table, keyField, fields, rows, beforeColumns, batch)
 	if err != nil {
@@ -322,18 +384,15 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	result.Updated = counts.Updated
 	result.Unchanged = counts.Unchanged
 
-	keepKeys := keys
 	if result.Reconciliation == DeleteMissing {
-		keepKeys, err = appendProtectedKeys(keys, options.ProtectedKeys)
-		if err != nil {
-			return result, err
-		}
 		if options.DryRun {
 			result.Deleted, err = countRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keepKeys)
 			if err != nil {
 				return result, err
 			}
 		}
+	} else if result.Reconciliation == SoftDeleteMissing && options.DryRun {
+		result.Deleted = result.ReconciliationEvidence.WouldSoftDelete
 	}
 	if options.DryRun {
 		return result, nil
@@ -346,6 +405,11 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	}
 	if result.Reconciliation == DeleteMissing {
 		result.Deleted, err = deleteRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keepKeys, options.Batch)
+		if err != nil {
+			return result, err
+		}
+	} else if result.Reconciliation == SoftDeleteMissing {
+		result.Deleted, err = softDeleteRowsAbsentFromSnapshot(ctx, tx, driver, table, keyField, keepKeys, options.Batch)
 		if err != nil {
 			return result, err
 		}
@@ -399,6 +463,8 @@ func normalizeReconciliation(value ReconciliationMode) (ReconciliationMode, erro
 	switch ReconciliationMode(strings.ToLower(strings.TrimSpace(string(value)))) {
 	case "", UpsertOnly:
 		return UpsertOnly, nil
+	case SoftDeleteMissing:
+		return SoftDeleteMissing, nil
 	case DeleteMissing:
 		return DeleteMissing, nil
 	default:
@@ -553,6 +619,11 @@ func queryExistingRows(ctx context.Context, tx *sql.Tx, query string, fields []s
 func rowMatchesExisting(row, existing map[string]interface{}, fields []string, existingColumns map[string]bool) bool {
 	for _, field := range fields {
 		if !existingColumns[strings.ToLower(field)] {
+			// Applying soft-delete adds this reserved column with a false default,
+			// so a dry run must model the additive schema change accurately.
+			if strings.EqualFold(field, SoftDeleteColumn) && booleanText(row[field]) == "0" {
+				continue
+			}
 			if row[field] != nil {
 				return false
 			}
@@ -747,61 +818,11 @@ func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table
 		count, err := result.RowsAffected()
 		return int(count), err
 	}
-	tempTable := "_patris_snapshot_keys"
-	drop := fmt.Sprintf("DROP TEMPORARY TABLE IF EXISTS %s", quoteIdent(driver, tempTable))
-	if isSQLite(driver) {
-		drop = fmt.Sprintf("DROP TABLE IF EXISTS temp.%s", quoteIdent(driver, tempTable))
-	}
-	if _, err := tx.ExecContext(ctx, drop); err != nil {
+	tempTable, cleanup, err := stageSnapshotKeys(ctx, tx, driver, keyField, keys, requestedBatch)
+	if err != nil {
 		return 0, err
 	}
-	createPrefix := "CREATE TEMP TABLE"
-	if !isSQLite(driver) {
-		createPrefix = "CREATE TEMPORARY TABLE"
-	}
-	create := fmt.Sprintf(
-		"%s %s (%s %s PRIMARY KEY)",
-		createPrefix,
-		quoteIdent(driver, tempTable),
-		quoteIdent(driver, "snapshot_key"),
-		columnType(driver, keyField, keyField, nil),
-	)
-	if _, err := tx.ExecContext(ctx, create); err != nil {
-		return 0, err
-	}
-	defer func() { _, _ = tx.ExecContext(context.Background(), drop) }()
-
-	batch := effectiveBatchSize(driver, requestedBatch, 1)
-	for start := 0; start < len(keys); start += batch {
-		end := start + batch
-		if end > len(keys) {
-			end = len(keys)
-		}
-		chunk := keys[start:end]
-		placeholders := strings.TrimSuffix(strings.Repeat("(?),", len(chunk)), ",")
-		insert := fmt.Sprintf(
-			"INSERT INTO %s (%s) VALUES %s",
-			quoteIdent(driver, tempTable),
-			quoteIdent(driver, "snapshot_key"),
-			placeholders,
-		)
-		stmt, err := tx.PrepareContext(ctx, insert)
-		if err != nil {
-			return 0, err
-		}
-		values := make([]interface{}, len(chunk))
-		for i, key := range chunk {
-			values[i] = key
-		}
-		_, execErr := stmt.ExecContext(ctx, values...)
-		closeErr := stmt.Close()
-		if execErr != nil {
-			return 0, execErr
-		}
-		if closeErr != nil {
-			return 0, closeErr
-		}
-	}
+	defer cleanup()
 
 	target := quoteIdent(driver, table)
 	targetKey := quoteIdent(driver, keyField)
@@ -825,6 +846,8 @@ func createTable(ctx context.Context, db *sql.DB, driver, table string, fields [
 		def := fmt.Sprintf("%s %s", quoteIdent(driver, field), columnType(driver, field, keyField, rows))
 		if field == keyField {
 			def += " PRIMARY KEY"
+		} else if strings.EqualFold(field, SoftDeleteColumn) {
+			def += " NOT NULL DEFAULT 0"
 		}
 		cols = append(cols, def)
 	}
@@ -846,6 +869,9 @@ func ensureColumns(ctx context.Context, db *sql.DB, driver, table string, fields
 			continue
 		}
 		definition := fmt.Sprintf("%s %s", quoteIdent(driver, field), columnType(driver, field, keyField, rows))
+		if strings.EqualFold(field, SoftDeleteColumn) {
+			definition += " NOT NULL DEFAULT 0"
+		}
 		query := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", quoteIdent(driver, table), definition)
 		if _, err := db.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("add %s.%s column: %w", table, field, err)
@@ -937,6 +963,8 @@ func columnType(driver, field, keyField string, rows []map[string]interface{}) s
 
 func canonicalFieldKind(field string) valueKind {
 	switch strings.ToLower(strings.TrimSpace(field)) {
+	case SoftDeleteColumn:
+		return valueKindBoolean
 	case "final_price":
 		return valueKindInteger
 	case "sale_price_source", "purchase_price_source", "total_stock", "minimum_stock", "foreign_price", "weight_grams", "shipping_price_per_kg", "markup_percent", "irt_per_cny":

--- a/pkg/recordsink/soft_delete.go
+++ b/pkg/recordsink/soft_delete.go
@@ -1,0 +1,505 @@
+package recordsink
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/recordmap"
+)
+
+// SoftDeleteColumn is reserved for recordsink-managed tombstone state. Source
+// records may not define or map a field with this name.
+const SoftDeleteColumn = "patris_export_deleted"
+
+const (
+	// SoftDeleteConfirmationTokenPrefix identifies the only accepted digest
+	// format for an exact soft-delete preview.
+	SoftDeleteConfirmationTokenPrefix = "sha256:"
+	// SoftDeleteConfirmationTokenLength is the exact byte length of the prefix
+	// plus a lowercase SHA-256 hexadecimal digest.
+	SoftDeleteConfirmationTokenLength = len(SoftDeleteConfirmationTokenPrefix) + sha256.Size*2
+)
+
+// ReconciliationGuardCode is a stable, non-secret reason why a soft-delete
+// plan cannot be applied.
+type ReconciliationGuardCode string
+
+const (
+	ReconciliationGuardEmptySource      ReconciliationGuardCode = "empty_source"
+	ReconciliationGuardPreviewRequired  ReconciliationGuardCode = "preview_required"
+	ReconciliationGuardPreviewMismatch  ReconciliationGuardCode = "preview_mismatch"
+	ReconciliationGuardReservedField    ReconciliationGuardCode = "reserved_field_collision"
+	ReconciliationGuardInvalidTombstone ReconciliationGuardCode = "invalid_tombstone_state"
+	ReconciliationGuardUnknown          ReconciliationGuardCode = "safety_guard"
+)
+
+// SQLReconciliationEvidence is safe for operator output. It contains counts
+// and an aggregate confirmation digest, never destination keys or connection
+// material.
+type SQLReconciliationEvidence struct {
+	SourceRows           int                     `json:"source_rows"`
+	ProtectedRows        int                     `json:"protected_rows"`
+	TargetRows           int                     `json:"target_rows"`
+	MissingRows          int                     `json:"missing_rows"`
+	WouldSoftDelete      int                     `json:"would_soft_delete"`
+	AlreadySoftDeleted   int                     `json:"already_soft_deleted"`
+	WouldRestore         int                     `json:"would_restore"`
+	PartialSourceRisk    bool                    `json:"partial_source_risk"`
+	ConfirmationRequired bool                    `json:"confirmation_required"`
+	ApplyAllowed         bool                    `json:"apply_allowed"`
+	ConfirmationToken    string                  `json:"confirmation_token,omitempty"`
+	GuardCode            ReconciliationGuardCode `json:"guard_code,omitempty"`
+}
+
+// ReconciliationGuardError deliberately excludes plan contents and supplied
+// confirmation text from Error output.
+type ReconciliationGuardError struct {
+	Code ReconciliationGuardCode
+}
+
+func (err *ReconciliationGuardError) Error() string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("SQL reconciliation blocked by safety guard (code=%s)", normalizedReconciliationGuardCode(err.Code))
+}
+
+type sqlQueryer interface {
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+}
+
+func prepareSoftDeleteRows(rows []map[string]interface{}, keyField string) ([]map[string]interface{}, error) {
+	if isSoftDeleteIdentifier(keyField) {
+		return nil, &ReconciliationGuardError{Code: ReconciliationGuardReservedField}
+	}
+	prepared := make([]map[string]interface{}, len(rows))
+	for index, row := range rows {
+		copyRow := make(map[string]interface{}, len(row)+1)
+		for field, value := range row {
+			if isSoftDeleteIdentifier(field) {
+				return nil, &ReconciliationGuardError{Code: ReconciliationGuardReservedField}
+			}
+			copyRow[field] = value
+		}
+		copyRow[SoftDeleteColumn] = false
+		prepared[index] = copyRow
+	}
+	return prepared, nil
+}
+
+func buildSoftDeleteEvidence(
+	ctx context.Context,
+	queryer sqlQueryer,
+	driver, table, keyField string,
+	tableExists, markerExists bool,
+	sourceRows []map[string]interface{},
+	sourceKeys, keepKeys []string,
+) (SQLReconciliationEvidence, string, error) {
+	evidence := SQLReconciliationEvidence{
+		SourceRows:           len(sourceKeys),
+		ProtectedRows:        len(keepKeys) - len(sourceKeys),
+		ConfirmationRequired: true,
+		ApplyAllowed:         len(sourceKeys) > 0,
+	}
+	if !tableExists {
+		token := softDeleteConfirmationToken(table, keyField, sourceRows, sourceKeys, keepKeys, nil)
+		return evidence, token, nil
+	}
+	if markerExists {
+		if err := validateSoftDeleteColumn(ctx, queryer, driver, table); err != nil {
+			return evidence, "", err
+		}
+	}
+
+	sourceSet := stringSet(sourceKeys)
+	keepSet := stringSet(keepKeys)
+	fields := quoteIdent(driver, keyField)
+	if markerExists {
+		fields += ", " + quoteIdent(driver, SoftDeleteColumn)
+	}
+	query := fmt.Sprintf("SELECT %s FROM %s", fields, quoteIdent(driver, table))
+	rows, err := queryer.QueryContext(ctx, query)
+	if err != nil {
+		return evidence, "", err
+	}
+	defer rows.Close()
+
+	targetStates := make([]softDeleteTargetState, 0)
+	for rows.Next() {
+		var keyValue interface{}
+		var markerValue interface{}
+		if markerExists {
+			err = rows.Scan(&keyValue, &markerValue)
+		} else {
+			err = rows.Scan(&keyValue)
+		}
+		if err != nil {
+			return evidence, "", err
+		}
+		key := databaseKey(keyValue)
+		if strings.TrimSpace(key) == "" {
+			return evidence, "", errors.New("soft-delete target contains an empty key")
+		}
+		deleted, err := softDeleteMarkerState(markerValue, markerExists)
+		if err != nil {
+			return evidence, "", err
+		}
+		targetStates = append(targetStates, softDeleteTargetState{Key: key, Deleted: deleted})
+		if _, present := sourceSet[key]; present && deleted {
+			evidence.WouldRestore++
+		}
+		if _, retained := keepSet[key]; retained {
+			continue
+		}
+		evidence.MissingRows++
+		if deleted {
+			evidence.AlreadySoftDeleted++
+		} else {
+			evidence.WouldSoftDelete++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return evidence, "", err
+	}
+	evidence.TargetRows = len(targetStates)
+	evidence.PartialSourceRisk = evidence.MissingRows > 0
+	token := softDeleteConfirmationToken(table, keyField, sourceRows, sourceKeys, keepKeys, targetStates)
+	return evidence, token, nil
+}
+
+func authorizeSoftDelete(evidence *SQLReconciliationEvidence, expectedToken, suppliedToken string, dryRun bool) error {
+	evidence.ConfirmationToken = ""
+	evidence.GuardCode = ""
+	if evidence.SourceRows == 0 {
+		evidence.ApplyAllowed = false
+		evidence.GuardCode = ReconciliationGuardEmptySource
+		if dryRun {
+			return nil
+		}
+		return &ReconciliationGuardError{Code: evidence.GuardCode}
+	}
+	evidence.ApplyAllowed = true
+	if dryRun {
+		evidence.ConfirmationToken = expectedToken
+		return nil
+	}
+	if strings.TrimSpace(suppliedToken) == "" {
+		evidence.ApplyAllowed = false
+		evidence.GuardCode = ReconciliationGuardPreviewRequired
+		return &ReconciliationGuardError{Code: evidence.GuardCode}
+	}
+	if suppliedToken != expectedToken {
+		evidence.ApplyAllowed = false
+		evidence.GuardCode = ReconciliationGuardPreviewMismatch
+		return &ReconciliationGuardError{Code: evidence.GuardCode}
+	}
+	return nil
+}
+
+func softDeleteMarkerState(value interface{}, columnExists bool) (bool, error) {
+	if !columnExists || value == nil {
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(databaseText(value))) {
+	case "", "0", "false":
+		return false, nil
+	case "1", "true":
+		return true, nil
+	default:
+		return false, &ReconciliationGuardError{Code: ReconciliationGuardInvalidTombstone}
+	}
+}
+
+func validateSoftDeleteColumn(ctx context.Context, queryer sqlQueryer, driver, table string) error {
+	if isSQLite(driver) {
+		rows, err := queryer.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", quoteIdent(driver, table)))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var cid, notNull, primaryKey int
+			var name, dataType string
+			var defaultValue interface{}
+			if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &primaryKey); err != nil {
+				return err
+			}
+			if !strings.EqualFold(name, SoftDeleteColumn) {
+				continue
+			}
+			normalized := strings.ToUpper(strings.TrimSpace(dataType))
+			typeCompatible := strings.Contains(normalized, "INT") || strings.Contains(normalized, "BOOL")
+			if typeCompatible && notNull == 1 && primaryKey == 0 && softDeleteDefaultIsFalse(defaultValue) {
+				return nil
+			}
+			return &ReconciliationGuardError{Code: ReconciliationGuardInvalidTombstone}
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return &ReconciliationGuardError{Code: ReconciliationGuardInvalidTombstone}
+	}
+
+	rows, err := queryer.QueryContext(ctx, fmt.Sprintf("SHOW COLUMNS FROM %s", quoteIdent(driver, table)))
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var field, dataType, nullable, key string
+		var defaultValue, extra interface{}
+		if err := rows.Scan(&field, &dataType, &nullable, &key, &defaultValue, &extra); err != nil {
+			return err
+		}
+		if !strings.EqualFold(field, SoftDeleteColumn) {
+			continue
+		}
+		normalized := strings.ToLower(strings.TrimSpace(dataType))
+		typeCompatible := strings.HasPrefix(normalized, "tinyint") || normalized == "bool" || normalized == "boolean"
+		keyCompatible := !strings.EqualFold(key, "PRI") && !strings.EqualFold(key, "UNI")
+		if typeCompatible && strings.EqualFold(nullable, "NO") && keyCompatible && softDeleteDefaultIsFalse(defaultValue) {
+			return nil
+		}
+		return &ReconciliationGuardError{Code: ReconciliationGuardInvalidTombstone}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return &ReconciliationGuardError{Code: ReconciliationGuardInvalidTombstone}
+}
+
+func isSoftDeleteIdentifier(value string) bool {
+	return strings.EqualFold(sanitizeIdentifier(value), SoftDeleteColumn)
+}
+
+func softDeleteDefaultIsFalse(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(databaseText(value)))
+	for len(normalized) >= 2 && normalized[0] == '(' && normalized[len(normalized)-1] == ')' {
+		normalized = strings.TrimSpace(normalized[1 : len(normalized)-1])
+	}
+	if len(normalized) >= 2 {
+		first, last := normalized[0], normalized[len(normalized)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			normalized = strings.TrimSpace(normalized[1 : len(normalized)-1])
+		}
+	}
+	return normalized == "0" || normalized == "false"
+}
+
+func normalizedReconciliationGuardCode(value ReconciliationGuardCode) ReconciliationGuardCode {
+	switch value {
+	case ReconciliationGuardEmptySource,
+		ReconciliationGuardPreviewRequired,
+		ReconciliationGuardPreviewMismatch,
+		ReconciliationGuardReservedField,
+		ReconciliationGuardInvalidTombstone:
+		return value
+	default:
+		return ReconciliationGuardUnknown
+	}
+}
+
+type softDeleteTargetState struct {
+	Key     string
+	Deleted bool
+}
+
+func softDeleteConfirmationToken(
+	table, keyField string,
+	sourceRows []map[string]interface{},
+	sourceKeys, keepKeys []string,
+	targetStates []softDeleteTargetState,
+) string {
+	digest := sha256.New()
+	writeDigestPart(digest, "patris-soft-delete-v2")
+	writeDigestPart(digest, strings.ToLower(strings.TrimSpace(table)))
+	writeDigestPart(digest, strings.ToLower(strings.TrimSpace(keyField)))
+	writeSourceRowsDigest(digest, sourceRows, keyField)
+	writeDigestList(digest, sourceKeys)
+	writeDigestList(digest, keepKeys)
+	writeTargetStatesDigest(digest, targetStates)
+	return SoftDeleteConfirmationTokenPrefix + hex.EncodeToString(digest.Sum(nil))
+}
+
+func writeSourceRowsDigest(digest hash.Hash, rows []map[string]interface{}, keyField string) {
+	fields := recordmap.Fields(rows, keyField)
+	writeDigestCount(digest, len(fields))
+	for _, field := range fields {
+		writeDigestPart(digest, field)
+	}
+
+	ordered := append([]map[string]interface{}(nil), rows...)
+	sort.SliceStable(ordered, func(left, right int) bool {
+		return databaseKey(ordered[left][keyField]) < databaseKey(ordered[right][keyField])
+	})
+	writeDigestCount(digest, len(ordered))
+	for _, row := range ordered {
+		for _, field := range fields {
+			value, exists := row[field]
+			if !exists {
+				value = nil
+			}
+			typeName, text := softDeleteDigestValue(value)
+			writeDigestPart(digest, typeName)
+			writeDigestPart(digest, text)
+		}
+	}
+}
+
+func softDeleteDigestValue(value interface{}) (string, string) {
+	if value == nil {
+		return "nil", ""
+	}
+	if timestamp, ok := value.(time.Time); ok {
+		return "time.Time", timestamp.Format(time.RFC3339Nano)
+	}
+	return fmt.Sprintf("%T", value), databaseText(value)
+}
+
+func writeTargetStatesDigest(digest hash.Hash, states []softDeleteTargetState) {
+	ordered := append([]softDeleteTargetState(nil), states...)
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].Key < ordered[right].Key
+	})
+	writeDigestCount(digest, len(ordered))
+	for _, state := range ordered {
+		writeDigestPart(digest, state.Key)
+		if state.Deleted {
+			writeDigestPart(digest, "1")
+		} else {
+			writeDigestPart(digest, "0")
+		}
+	}
+}
+
+func writeDigestList(digest hash.Hash, values []string) {
+	ordered := append([]string(nil), values...)
+	sort.Strings(ordered)
+	writeDigestCount(digest, len(ordered))
+	for _, value := range ordered {
+		writeDigestPart(digest, value)
+	}
+}
+
+func writeDigestCount(digest hash.Hash, count int) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(count))
+	_, _ = digest.Write(length[:])
+}
+
+func writeDigestPart(digest hash.Hash, value string) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = digest.Write(length[:])
+	_, _ = digest.Write([]byte(value))
+}
+
+func stringSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func softDeleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string, requestedBatch int) (int, error) {
+	if len(keys) == 0 {
+		return 0, &ReconciliationGuardError{Code: ReconciliationGuardEmptySource}
+	}
+	tempTable, cleanup, err := stageSnapshotKeys(ctx, tx, driver, keyField, keys, requestedBatch)
+	if err != nil {
+		return 0, err
+	}
+	defer cleanup()
+
+	target := quoteIdent(driver, table)
+	targetKey := quoteIdent(driver, keyField)
+	marker := quoteIdent(driver, SoftDeleteColumn)
+	temp := quoteIdent(driver, tempTable)
+	tempKey := quoteIdent(driver, "snapshot_key")
+	update := fmt.Sprintf(
+		"UPDATE %s SET %s = ? WHERE (%s IS NULL OR %s = ?) AND NOT EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.%s)",
+		target, marker, marker, marker, temp, temp, tempKey, target, targetKey,
+	)
+	result, err := tx.ExecContext(ctx, update, true, false)
+	if err != nil {
+		return 0, err
+	}
+	count, err := result.RowsAffected()
+	return int(count), err
+}
+
+func stageSnapshotKeys(ctx context.Context, tx *sql.Tx, driver, keyField string, keys []string, requestedBatch int) (string, func(), error) {
+	tempTable := "_patris_snapshot_keys"
+	drop := fmt.Sprintf("DROP TEMPORARY TABLE IF EXISTS %s", quoteIdent(driver, tempTable))
+	if isSQLite(driver) {
+		drop = fmt.Sprintf("DROP TABLE IF EXISTS temp.%s", quoteIdent(driver, tempTable))
+	}
+	cleanup := func() { _, _ = tx.ExecContext(context.Background(), drop) }
+	if _, err := tx.ExecContext(ctx, drop); err != nil {
+		return "", func() {}, err
+	}
+	createPrefix := "CREATE TEMP TABLE"
+	if !isSQLite(driver) {
+		createPrefix = "CREATE TEMPORARY TABLE"
+	}
+	create := fmt.Sprintf(
+		"%s %s (%s %s PRIMARY KEY)",
+		createPrefix,
+		quoteIdent(driver, tempTable),
+		quoteIdent(driver, "snapshot_key"),
+		columnType(driver, keyField, keyField, nil),
+	)
+	if _, err := tx.ExecContext(ctx, create); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+
+	batch := effectiveBatchSize(driver, requestedBatch, 1)
+	for start := 0; start < len(keys); start += batch {
+		end := start + batch
+		if end > len(keys) {
+			end = len(keys)
+		}
+		chunk := keys[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("(?),", len(chunk)), ",")
+		insert := fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES %s",
+			quoteIdent(driver, tempTable),
+			quoteIdent(driver, "snapshot_key"),
+			placeholders,
+		)
+		stmt, err := tx.PrepareContext(ctx, insert)
+		if err != nil {
+			cleanup()
+			return "", func() {}, err
+		}
+		values := make([]interface{}, len(chunk))
+		for index, key := range chunk {
+			values[index] = key
+		}
+		_, execErr := stmt.ExecContext(ctx, values...)
+		closeErr := stmt.Close()
+		if execErr != nil {
+			cleanup()
+			return "", func() {}, execErr
+		}
+		if closeErr != nil {
+			cleanup()
+			return "", func() {}, closeErr
+		}
+	}
+	return tempTable, cleanup, nil
+}

--- a/pkg/recordsink/soft_delete_test.go
+++ b/pkg/recordsink/soft_delete_test.go
@@ -1,0 +1,638 @@
+package recordsink
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteSoftDeleteRequiresExactPreviewAndFreshNoOpRetry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "private-product-alpha", "final_price": int64(100)},
+		{"product_code": "private-product-beta", "final_price": int64(200)},
+		{"product_code": "private-product-gamma", "final_price": int64(300)},
+	}
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code",
+	}, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := []map[string]interface{}{
+		{"product_code": "private-product-beta", "final_price": int64(200)},
+		{"product_code": "private-product-gamma", "final_price": int64(350)},
+	}
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("soft-delete preview: %v", err)
+	}
+	assertSQLResultCounts(t, preview, 0, 1, 1, 1, 0)
+	assertSoftDeleteEvidence(t, preview.ReconciliationEvidence, 2, 3, 1, 1, 0, 0)
+	if !preview.ReconciliationEvidence.ApplyAllowed || !preview.ReconciliationEvidence.PartialSourceRisk ||
+		!strings.HasPrefix(preview.ReconciliationEvidence.ConfirmationToken, SoftDeleteConfirmationTokenPrefix) ||
+		len(preview.ReconciliationEvidence.ConfirmationToken) != SoftDeleteConfirmationTokenLength {
+		t.Fatalf("unsafe or incomplete preview evidence: %+v", preview.ReconciliationEvidence)
+	}
+	confirmation := preview.ReconciliationEvidence.ConfirmationToken
+	if _, exists := snapshot[0][SoftDeleteColumn]; exists {
+		t.Fatal("soft-delete preparation mutated the caller's source row")
+	}
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("dry-run preview evolved the destination schema")
+	}
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"private-product-alpha": {price: 100},
+		"private-product-beta":  {price: 200},
+		"private-product-gamma": {price: 300},
+	}, false)
+
+	blocked, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewRequired)
+	if blocked.ReconciliationEvidence == nil || blocked.ReconciliationEvidence.GuardCode != ReconciliationGuardPreviewRequired ||
+		blocked.ReconciliationEvidence.ConfirmationToken != "" {
+		t.Fatalf("missing-preview evidence exposed an apply token or omitted the guard: %+v", blocked.ReconciliationEvidence)
+	}
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("missing confirmation mutated the destination schema")
+	}
+
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: "sha256:not-the-previewed-plan",
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: " " + confirmation + " ",
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("mismatched confirmation mutated the destination schema")
+	}
+
+	applied, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: confirmation,
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("apply exact soft-delete preview: %v", err)
+	}
+	assertSQLResultCounts(t, applied, 0, 1, 1, 1, 0)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"private-product-alpha": {price: 100, deleted: true},
+		"private-product-beta":  {price: 200},
+		"private-product-gamma": {price: 350},
+	}, true)
+
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: confirmation,
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+
+	retryPreview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("preview already-applied soft-delete plan: %v", err)
+	}
+	assertSQLResultCounts(t, retryPreview, 0, 0, 2, 0, 0)
+	assertSoftDeleteEvidence(t, retryPreview.ReconciliationEvidence, 2, 3, 1, 0, 1, 0)
+	if retryPreview.ReconciliationEvidence.ConfirmationToken == confirmation {
+		t.Fatal("successful apply did not invalidate the pre-apply target-state token")
+	}
+	retried, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: retryPreview.ReconciliationEvidence.ConfirmationToken,
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("apply freshly previewed no-op retry: %v", err)
+	}
+	assertSQLResultCounts(t, retried, 0, 0, 2, 0, 0)
+
+	restore := []map[string]interface{}{
+		{"product_code": "private-product-alpha", "final_price": int64(100)},
+		{"product_code": "private-product-beta", "final_price": int64(200)},
+		{"product_code": "private-product-gamma", "final_price": int64(350)},
+	}
+	restorePreview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, restore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, restorePreview, 0, 1, 2, 0, 0)
+	assertSoftDeleteEvidence(t, restorePreview.ReconciliationEvidence, 3, 3, 0, 0, 0, 1)
+	if restorePreview.ReconciliationEvidence.ConfirmationToken == confirmation {
+		t.Fatal("different source keyset reused a stale confirmation token")
+	}
+	restored, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: restorePreview.ReconciliationEvidence.ConfirmationToken,
+	}, restore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, restored, 0, 1, 2, 0, 0)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"private-product-alpha": {price: 100},
+		"private-product-beta":  {price: 200},
+		"private-product-gamma": {price: 350},
+	}, true)
+
+	encoded, err := json.Marshal(preview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"private-product-alpha", "private-product-beta", "private-product-gamma", path} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("operator evidence exposed destination detail %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestSQLiteSoftDeleteTokenBindsSourceValuesAndTargetMarkerState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete-exact-plan.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "A", "final_price": int64(100)},
+		{"product_code": "B", "final_price": int64(200)},
+	}
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code",
+	}, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := []map[string]interface{}{{"product_code": "B", "final_price": int64(200)}}
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := preview.ReconciliationEvidence.ConfirmationToken
+
+	changedSource := []map[string]interface{}{{"product_code": "B", "final_price": int64(201)}}
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: token,
+	}, changedSource)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("same-key source-value change mutated the destination schema")
+	}
+
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: token,
+	}, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	markerPreview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE products SET "patris_export_deleted" = 0 WHERE product_code = 'A'`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: markerPreview.ReconciliationEvidence.ConfirmationToken,
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"A": {price: 100},
+		"B": {price: 200},
+	}, true)
+}
+
+func TestSQLiteSoftDeleteBlocksEmptyAndChangedPartialSources(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete-guards.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "A", "final_price": int64(100)},
+		{"product_code": "B", "final_price": int64(200)},
+		{"product_code": "C", "final_price": int64(300)},
+	}
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{Table: "products", KeyField: "product_code"}, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyPreview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("empty-source preview should return evidence: %v", err)
+	}
+	assertSQLResultCounts(t, emptyPreview, 0, 0, 0, 3, 0)
+	assertSoftDeleteEvidence(t, emptyPreview.ReconciliationEvidence, 0, 3, 3, 3, 0, 0)
+	if emptyPreview.ReconciliationEvidence.ApplyAllowed || emptyPreview.ReconciliationEvidence.ConfirmationToken != "" ||
+		emptyPreview.ReconciliationEvidence.GuardCode != ReconciliationGuardEmptySource {
+		t.Fatalf("empty source was not fail-closed: %+v", emptyPreview.ReconciliationEvidence)
+	}
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: "sha256:empty-must-never-apply",
+	}, nil)
+	assertReconciliationGuard(t, err, ReconciliationGuardEmptySource)
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("empty-source apply attempt evolved the schema")
+	}
+
+	partial := initial[1:]
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, partial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldToken := preview.ReconciliationEvidence.ConfirmationToken
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code",
+	}, []map[string]interface{}{{"product_code": "D", "final_price": int64(400)}}); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: oldToken,
+	}, partial)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+	if blocked.ReconciliationEvidence == nil || blocked.ReconciliationEvidence.TargetRows != 4 || blocked.ReconciliationEvidence.MissingRows != 2 {
+		t.Fatalf("changed-target guard evidence = %+v", blocked.ReconciliationEvidence)
+	}
+	if sqliteColumnExists(t, path, "products", SoftDeleteColumn) {
+		t.Fatal("stale partial-source confirmation evolved the schema")
+	}
+	refreshed, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, partial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.ReconciliationEvidence.ConfirmationToken == oldToken || !refreshed.ReconciliationEvidence.PartialSourceRisk {
+		t.Fatalf("changed destination did not require a new risky-plan confirmation: %+v", refreshed.ReconciliationEvidence)
+	}
+}
+
+func TestSQLiteSoftDeletePreviewCanSafelyAuthorizeNewDestination(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "new-soft-delete.sqlite")
+	snapshot := []map[string]interface{}{{"product_code": "001", "final_price": int64(100)}}
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, preview, 1, 0, 0, 0, 0)
+	assertSoftDeleteEvidence(t, preview.ReconciliationEvidence, 1, 0, 0, 0, 0, 0)
+	if sqlitePathExists(path) {
+		t.Fatal("new-destination preview created the SQLite file")
+	}
+	applied, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: preview.ReconciliationEvidence.ConfirmationToken,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, applied, 1, 0, 0, 0, 0)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{"001": {price: 100}}, true)
+}
+
+func TestSQLiteSoftDeletePreservesProtectedRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete-protected.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "A", "final_price": int64(100)},
+		{"product_code": "B", "final_price": int64(200)},
+		{"product_code": "C", "final_price": int64(300)},
+	}
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{Table: "products", KeyField: "product_code"}, initial); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := []map[string]interface{}{{"product_code": "B", "final_price": int64(200)}}
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ProtectedKeys: []string{"A"}, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, preview, 0, 0, 1, 1, 0)
+	assertSoftDeleteEvidence(t, preview.ReconciliationEvidence, 1, 3, 1, 1, 0, 0)
+	if preview.ReconciliationEvidence.ProtectedRows != 1 {
+		t.Fatalf("protected evidence = %+v", preview.ReconciliationEvidence)
+	}
+	applied, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ProtectedKeys: []string{"A"}, ReconciliationToken: preview.ReconciliationEvidence.ConfirmationToken,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSQLResultCounts(t, applied, 0, 0, 1, 1, 0)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"A": {price: 100},
+		"B": {price: 200},
+		"C": {price: 300, deleted: true},
+	}, true)
+}
+
+func TestMySQLSoftDeleteStagesKeysInBatchesAndNeverHardDeletes(t *testing.T) {
+	state := &schemaDriverState{}
+	db := sql.OpenDB(schemaConnector{state: state})
+	defer db.Close()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := softDeleteRowsAbsentFromSnapshot(
+		context.Background(), tx, "mysql", "products", "product_code", []string{"001", "002", "003"}, 2,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("soft-delete affected count = %d, want fake-driver result 1", count)
+	}
+	joined := strings.Join(state.execs, "\n")
+	if !strings.Contains(joined, "UPDATE `products` SET `patris_export_deleted` = ?") ||
+		strings.Contains(joined, "DELETE FROM `products`") {
+		t.Fatalf("MySQL soft-delete statement was unsafe:\n%s", joined)
+	}
+	staged := 0
+	for _, execution := range state.prepared {
+		if strings.HasPrefix(execution.query, "INSERT INTO `patris_snapshot_keys`") {
+			staged += len(execution.args)
+		}
+	}
+	if staged != 3 {
+		t.Fatalf("staged snapshot keys = %d, want 3: %#v", staged, state.prepared)
+	}
+	if columnType("sqlite", SoftDeleteColumn, "product_code", nil) != "INTEGER" ||
+		columnType("mysql", SoftDeleteColumn, "product_code", nil) != "TINYINT(1)" {
+		t.Fatal("soft-delete metadata did not use portable boolean column types")
+	}
+}
+
+func TestSQLiteSoftDeleteFailureRollsBackAndCanRetryExactPlan(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete-retry.sqlite")
+	initial := []map[string]interface{}{
+		{"product_code": "A", "final_price": int64(100)},
+		{"product_code": "B", "final_price": int64(200)},
+	}
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{Table: "products", KeyField: "product_code"}, initial); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`ALTER TABLE products ADD COLUMN "patris_export_deleted" INTEGER NOT NULL DEFAULT 0`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER fail_soft_delete BEFORE UPDATE OF "patris_export_deleted" ON products
+		WHEN NEW.product_code = 'A' AND NEW."patris_export_deleted" = 1
+		BEGIN SELECT RAISE(ABORT, 'injected soft-delete failure'); END`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := []map[string]interface{}{{"product_code": "B", "final_price": int64(250)}}
+	preview, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := preview.ReconciliationEvidence.ConfirmationToken
+	failed, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: token,
+	}, snapshot)
+	if err == nil {
+		t.Fatal("injected soft-delete failure unexpectedly committed")
+	}
+	assertSQLResultCounts(t, failed, 0, 0, 0, 0, 1)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"A": {price: 100},
+		"B": {price: 200},
+	}, true)
+
+	db, err = sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DROP TRIGGER fail_soft_delete`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	retried, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: token,
+	}, snapshot)
+	if err != nil {
+		t.Fatalf("retry after rollback: %v", err)
+	}
+	assertSQLResultCounts(t, retried, 0, 1, 0, 1, 0)
+	assertSQLiteSoftDeleteRows(t, path, map[string]softDeleteRow{
+		"A": {price: 100, deleted: true},
+		"B": {price: 250},
+	}, true)
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing,
+		ReconciliationToken: token,
+	}, snapshot)
+	assertReconciliationGuard(t, err, ReconciliationGuardPreviewMismatch)
+}
+
+func TestSoftDeleteRejectsReservedAndInvalidMetadataWithoutExposingValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "soft-delete-metadata.sqlite")
+	if _, err := SyncSQLite(context.Background(), path, SQLOptions{Table: "products", KeyField: "product_code"}, []map[string]interface{}{{
+		"product_code": "A", "final_price": int64(100),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, []map[string]interface{}{{"product_code": "A", SoftDeleteColumn: true}})
+	assertReconciliationGuard(t, err, ReconciliationGuardReservedField)
+	for _, alias := range []string{"patris-export-deleted", " patris export deleted ", "_PATRIS_EXPORT_DELETED_"} {
+		_, err = SyncSQLite(context.Background(), path, SQLOptions{
+			Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+		}, []map[string]interface{}{{"product_code": "A", alias: true}})
+		assertReconciliationGuard(t, err, ReconciliationGuardReservedField)
+	}
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "patris-export-deleted", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, []map[string]interface{}{{"patris-export-deleted": "A"}})
+	assertReconciliationGuard(t, err, ReconciliationGuardReservedField)
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const privateValue = "private-invalid-tombstone-value"
+	if _, err := db.Exec(`ALTER TABLE products ADD COLUMN "patris_export_deleted" TEXT`); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE products SET "patris_export_deleted" = ?`, privateValue); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = SyncSQLite(context.Background(), path, SQLOptions{
+		Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+	}, []map[string]interface{}{{"product_code": "A", "final_price": int64(100)}})
+	assertReconciliationGuard(t, err, ReconciliationGuardInvalidTombstone)
+	if strings.Contains(err.Error(), privateValue) {
+		t.Fatalf("invalid metadata error exposed its stored value: %v", err)
+	}
+
+	for name, definition := range map[string]string{
+		"nullable":     `INTEGER DEFAULT 0`,
+		"true_default": `INTEGER NOT NULL DEFAULT 1`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalidPath := filepath.Join(t.TempDir(), name+".sqlite")
+			if _, err := SyncSQLite(context.Background(), invalidPath, SQLOptions{
+				Table: "products", KeyField: "product_code",
+			}, []map[string]interface{}{{"product_code": "A", "final_price": int64(100)}}); err != nil {
+				t.Fatal(err)
+			}
+			invalidDB, err := sql.Open("sqlite3", invalidPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := invalidDB.Exec(`ALTER TABLE products ADD COLUMN "patris_export_deleted" ` + definition); err != nil {
+				invalidDB.Close()
+				t.Fatal(err)
+			}
+			if err := invalidDB.Close(); err != nil {
+				t.Fatal(err)
+			}
+			_, err = SyncSQLite(context.Background(), invalidPath, SQLOptions{
+				Table: "products", KeyField: "product_code", Reconciliation: SoftDeleteMissing, DryRun: true,
+			}, []map[string]interface{}{{"product_code": "A", "final_price": int64(100)}})
+			assertReconciliationGuard(t, err, ReconciliationGuardInvalidTombstone)
+		})
+	}
+}
+
+type softDeleteRow struct {
+	price   int64
+	deleted bool
+}
+
+func assertSoftDeleteEvidence(t *testing.T, evidence *SQLReconciliationEvidence, source, target, missing, wouldDelete, alreadyDeleted, wouldRestore int) {
+	t.Helper()
+	if evidence == nil || evidence.SourceRows != source || evidence.TargetRows != target || evidence.MissingRows != missing ||
+		evidence.WouldSoftDelete != wouldDelete || evidence.AlreadySoftDeleted != alreadyDeleted || evidence.WouldRestore != wouldRestore {
+		t.Fatalf("soft-delete evidence = %+v, want source=%d target=%d missing=%d would_delete=%d already_deleted=%d restore=%d",
+			evidence, source, target, missing, wouldDelete, alreadyDeleted, wouldRestore)
+	}
+}
+
+func assertReconciliationGuard(t *testing.T, err error, expected ReconciliationGuardCode) {
+	t.Helper()
+	var guard *ReconciliationGuardError
+	if !errors.As(err, &guard) || guard.Code != expected {
+		t.Fatalf("reconciliation error = %#v, want guard %q", err, expected)
+	}
+}
+
+func sqliteColumnExists(t *testing.T, path, table, column string) bool {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count > 0
+}
+
+func sqlitePathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func assertSQLiteSoftDeleteRows(t *testing.T, path string, expected map[string]softDeleteRow, markerExists bool) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	query := `SELECT product_code, final_price FROM products ORDER BY product_code`
+	if markerExists {
+		query = `SELECT product_code, final_price, "patris_export_deleted" FROM products ORDER BY product_code`
+	}
+	rows, err := db.Query(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	seen := map[string]bool{}
+	for rows.Next() {
+		var code string
+		var price int64
+		var deleted bool
+		if markerExists {
+			err = rows.Scan(&code, &price, &deleted)
+		} else {
+			err = rows.Scan(&code, &price)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, exists := expected[code]
+		if !exists || want.price != price || want.deleted != deleted {
+			t.Fatalf("row %q = price:%d deleted:%t, expected=%+v exists=%t", code, price, deleted, want, exists)
+		}
+		seen[code] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != len(expected) {
+		t.Fatalf("rows seen=%v, want=%v", seen, expected)
+	}
+}

--- a/pkg/recordsink/sql_diagnostic.go
+++ b/pkg/recordsink/sql_diagnostic.go
@@ -40,6 +40,7 @@ const (
 	SQLFailureTransient            SQLFailureCode = "transient_database_error"
 	SQLFailureUnavailable          SQLFailureCode = "database_unavailable"
 	SQLFailureSchema               SQLFailureCode = "schema_incompatible"
+	SQLFailureReconciliation       SQLFailureCode = "reconciliation_blocked"
 	SQLFailureUnknown              SQLFailureCode = "unknown_database_error"
 )
 
@@ -47,10 +48,11 @@ const (
 // available to errors.Is/errors.As for in-process control flow, but is never
 // part of JSON or Error output.
 type SQLFailure struct {
-	Code      SQLFailureCode  `json:"code"`
-	Stage     SQLFailureStage `json:"stage"`
-	Retryable bool            `json:"retryable"`
-	Message   string          `json:"message"`
+	Code      SQLFailureCode          `json:"code"`
+	Stage     SQLFailureStage         `json:"stage"`
+	Retryable bool                    `json:"retryable"`
+	Message   string                  `json:"message"`
+	Reason    ReconciliationGuardCode `json:"reason,omitempty"`
 
 	cause error
 }
@@ -59,7 +61,11 @@ func (failure *SQLFailure) Error() string {
 	if failure == nil {
 		return ""
 	}
-	return fmt.Sprintf("SQL %s failed: %s (code=%s, retryable=%t)", failure.Stage, failure.Message, failure.Code, failure.Retryable)
+	reason := ""
+	if failure.Reason != "" {
+		reason = fmt.Sprintf(", reason=%s", failure.Reason)
+	}
+	return fmt.Sprintf("SQL %s failed: %s (code=%s%s, retryable=%t)", failure.Stage, failure.Message, failure.Code, reason, failure.Retryable)
 }
 
 func (failure *SQLFailure) Unwrap() error {
@@ -82,13 +88,18 @@ func ClassifySQLError(stage SQLFailureStage, err error) *SQLFailure {
 
 	stage = normalizedSQLFailureStage(stage)
 	code := classifySQLFailureCode(stage, err)
-	return &SQLFailure{
+	failure := &SQLFailure{
 		Code:      code,
 		Stage:     stage,
 		Retryable: sqlFailureRetryable(code),
 		Message:   sqlFailureMessage(code),
 		cause:     err,
 	}
+	var guardError *ReconciliationGuardError
+	if errors.As(err, &guardError) {
+		failure.Reason = normalizedReconciliationGuardCode(guardError.Code)
+	}
+	return failure
 }
 
 func normalizedSQLFailureStage(stage SQLFailureStage) SQLFailureStage {
@@ -101,6 +112,10 @@ func normalizedSQLFailureStage(stage SQLFailureStage) SQLFailureStage {
 }
 
 func classifySQLFailureCode(stage SQLFailureStage, err error) SQLFailureCode {
+	var guardError *ReconciliationGuardError
+	if errors.As(err, &guardError) {
+		return SQLFailureReconciliation
+	}
 	switch {
 	case errors.Is(err, context.Canceled):
 		return SQLFailureCancelled
@@ -193,6 +208,8 @@ func sqlFailureMessage(code SQLFailureCode) string {
 		return "The SQL target is temporarily unavailable."
 	case SQLFailureSchema:
 		return "The SQL target schema is incompatible."
+	case SQLFailureReconciliation:
+		return "The SQL reconciliation safety guard blocked the operation."
 	default:
 		return "The SQL target operation failed."
 	}

--- a/pkg/recordsink/sql_diagnostic_test.go
+++ b/pkg/recordsink/sql_diagnostic_test.go
@@ -34,6 +34,7 @@ func TestClassifySQLErrorUsesStableRetryCategories(t *testing.T) {
 		{name: "network timeout", stage: SQLStageConnect, err: &net.DNSError{IsTimeout: true}, code: SQLFailureTimeout, retryable: true},
 		{name: "network unavailable", stage: SQLStageConnect, err: &net.DNSError{IsTemporary: true}, code: SQLFailureUnavailable, retryable: true},
 		{name: "certificate hostname", stage: SQLStageConnect, err: x509.HostnameError{Certificate: &x509.Certificate{}, Host: "private.internal"}, code: SQLFailureTLSVerification},
+		{name: "reconciliation guard", stage: SQLStageSync, err: &ReconciliationGuardError{Code: ReconciliationGuardPreviewMismatch}, code: SQLFailureReconciliation},
 		{name: "configuration", stage: SQLStageConfiguration, err: errors.New("raw config details"), code: SQLFailureInvalidConfiguration},
 		{name: "schema", stage: SQLStageSchema, err: errors.New("raw schema details"), code: SQLFailureSchema},
 		{name: "unknown", stage: SQLStageSync, err: errors.New("raw unknown details"), code: SQLFailureUnknown},
@@ -79,5 +80,31 @@ func TestClassifySQLErrorPreservesAnExistingSafeFailure(t *testing.T) {
 	classified := ClassifySQLError(SQLStageSync, fmt.Errorf("outer: %w", original))
 	if classified != original {
 		t.Fatalf("existing safe failure was reclassified: got=%p want=%p", classified, original)
+	}
+}
+
+func TestReconciliationFailureIncludesOnlyStableGuardReason(t *testing.T) {
+	failure := ClassifySQLError(SQLStageSync, fmt.Errorf("private plan details: %w", &ReconciliationGuardError{Code: ReconciliationGuardPreviewMismatch}))
+	if failure.Code != SQLFailureReconciliation || failure.Reason != ReconciliationGuardPreviewMismatch || failure.Retryable {
+		t.Fatalf("reconciliation classification = %+v", failure)
+	}
+	encoded, err := json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outward := failure.Error() + string(encoded)
+	if strings.Contains(outward, "private plan details") || !strings.Contains(outward, string(ReconciliationGuardPreviewMismatch)) {
+		t.Fatalf("reconciliation diagnostic was unsafe or unclear: %s", outward)
+	}
+
+	const privateReason = ReconciliationGuardCode("private-runtime-detail")
+	failure = ClassifySQLError(SQLStageSync, &ReconciliationGuardError{Code: privateReason})
+	encoded, err = json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outward = failure.Error() + string(encoded)
+	if strings.Contains(outward, string(privateReason)) || failure.Reason != ReconciliationGuardUnknown {
+		t.Fatalf("unrecognized guard reason escaped the stable outward vocabulary: %s", outward)
 	}
 }

--- a/pkg/recordsink/sql_matrix_integration_test.go
+++ b/pkg/recordsink/sql_matrix_integration_test.go
@@ -25,7 +25,7 @@ func TestSQLTargetMatrixParitySchemaEvolutionAndRollback(t *testing.T) {
 		t.Skip("set PATRIS_EXPORT_TEST_MYSQL_DSN to run the disposable MySQL/MariaDB compatibility proof")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	mysqlDB, err := sql.Open("mysql", dsn)
@@ -125,6 +125,88 @@ func TestSQLTargetMatrixParitySchemaEvolutionAndRollback(t *testing.T) {
 	assertMatrixUserColumn(t, ctx, mysqlDB, "mysql", table, "0001")
 	assertMatrixUserColumn(t, ctx, sqliteDB, "sqlite", table, "0001")
 
+	softDeleteSnapshot := []map[string]interface{}{
+		{"product_code": "0002", "name": "Beta", "final_price": int64(200), "warehouse_stock": int64(3)},
+	}
+	mysqlSoftDelete := options
+	mysqlSoftDelete.Reconciliation = SoftDeleteMissing
+	mysqlSoftDelete.DryRun = true
+	mysqlPreview, err := SyncSQLWithResult(ctx, mysqlSoftDelete, softDeleteSnapshot)
+	if err != nil {
+		t.Fatal("preview MySQL/MariaDB soft delete:", err)
+	}
+	assertSQLResultCounts(t, mysqlPreview, 0, 0, 1, 1, 0)
+
+	sqliteSoftDelete := SQLOptions{
+		Table: table, KeyField: "product_code", Batch: 1,
+		Reconciliation: SoftDeleteMissing, DryRun: true,
+	}
+	sqlitePreview, err := SyncSQLite(ctx, sqlitePath, sqliteSoftDelete, softDeleteSnapshot)
+	if err != nil {
+		t.Fatal("preview SQLite soft delete:", err)
+	}
+	assertSQLResultCounts(t, sqlitePreview, 0, 0, 1, 1, 0)
+	if mysqlPreview.ReconciliationEvidence == nil || sqlitePreview.ReconciliationEvidence == nil ||
+		mysqlPreview.ReconciliationEvidence.ConfirmationToken == "" ||
+		mysqlPreview.ReconciliationEvidence.ConfirmationToken != sqlitePreview.ReconciliationEvidence.ConfirmationToken {
+		t.Fatalf("soft-delete preview parity mismatch: mysql=%+v sqlite=%+v",
+			mysqlPreview.ReconciliationEvidence, sqlitePreview.ReconciliationEvidence)
+	}
+
+	mysqlSoftDelete.DryRun = false
+	mysqlSoftDelete.ReconciliationToken = mysqlPreview.ReconciliationEvidence.ConfirmationToken
+	mysqlResult, err = SyncSQLWithResult(ctx, mysqlSoftDelete, softDeleteSnapshot)
+	if err != nil {
+		t.Fatal("apply MySQL/MariaDB soft delete:", err)
+	}
+	assertSQLResultCounts(t, mysqlResult, 0, 0, 1, 1, 0)
+
+	sqliteSoftDelete.DryRun = false
+	sqliteSoftDelete.ReconciliationToken = sqlitePreview.ReconciliationEvidence.ConfirmationToken
+	sqliteResult, err = SyncSQLite(ctx, sqlitePath, sqliteSoftDelete, softDeleteSnapshot)
+	if err != nil {
+		t.Fatal("apply SQLite soft delete:", err)
+	}
+	assertSQLResultCounts(t, sqliteResult, 0, 0, 1, 1, 0)
+	assertMatrixSoftDeleteParity(t, ctx, mysqlDB, sqliteDB, table, map[string]bool{
+		"0001": true,
+		"0002": false,
+	})
+
+	mysqlSoftDelete.DryRun = true
+	mysqlSoftDelete.ReconciliationToken = ""
+	mysqlRestorePreview, err := SyncSQLWithResult(ctx, mysqlSoftDelete, evolved)
+	if err != nil {
+		t.Fatal("preview MySQL/MariaDB soft-delete restore:", err)
+	}
+	assertSQLResultCounts(t, mysqlRestorePreview, 0, 1, 1, 0, 0)
+	sqliteSoftDelete.DryRun = true
+	sqliteSoftDelete.ReconciliationToken = ""
+	sqliteRestorePreview, err := SyncSQLite(ctx, sqlitePath, sqliteSoftDelete, evolved)
+	if err != nil {
+		t.Fatal("preview SQLite soft-delete restore:", err)
+	}
+	assertSQLResultCounts(t, sqliteRestorePreview, 0, 1, 1, 0, 0)
+
+	mysqlSoftDelete.DryRun = false
+	mysqlSoftDelete.ReconciliationToken = mysqlRestorePreview.ReconciliationEvidence.ConfirmationToken
+	mysqlResult, err = SyncSQLWithResult(ctx, mysqlSoftDelete, evolved)
+	if err != nil {
+		t.Fatal("restore MySQL/MariaDB soft-deleted row:", err)
+	}
+	assertSQLResultCounts(t, mysqlResult, 0, 1, 1, 0, 0)
+	sqliteSoftDelete.DryRun = false
+	sqliteSoftDelete.ReconciliationToken = sqliteRestorePreview.ReconciliationEvidence.ConfirmationToken
+	sqliteResult, err = SyncSQLite(ctx, sqlitePath, sqliteSoftDelete, evolved)
+	if err != nil {
+		t.Fatal("restore SQLite soft-deleted row:", err)
+	}
+	assertSQLResultCounts(t, sqliteResult, 0, 1, 1, 0, 0)
+	assertMatrixSoftDeleteParity(t, ctx, mysqlDB, sqliteDB, table, map[string]bool{
+		"0001": false,
+		"0002": false,
+	})
+
 	failing := []map[string]interface{}{
 		{"product_code": "0001", "name": "Alpha", "final_price": int64(999), "warehouse_stock": int64(7), "rollback_guard": "accepted"},
 		{"product_code": "0003", "name": "Gamma", "final_price": int64(300), "warehouse_stock": int64(1), "rollback_guard": "reject"},
@@ -142,6 +224,45 @@ func TestSQLTargetMatrixParitySchemaEvolutionAndRollback(t *testing.T) {
 	if got := readMatrixProducts(t, ctx, sqliteDB, "sqlite", table); !reflect.DeepEqual(got, sqliteProducts) {
 		t.Fatalf("SQLite batch failure did not roll back: got=%+v want=%+v", got, sqliteProducts)
 	}
+}
+
+func assertMatrixSoftDeleteParity(
+	t *testing.T,
+	ctx context.Context,
+	mysqlDB, sqliteDB *sql.DB,
+	table string,
+	expected map[string]bool,
+) {
+	t.Helper()
+	mysqlState := readMatrixSoftDeleteState(t, ctx, mysqlDB, "mysql", table)
+	sqliteState := readMatrixSoftDeleteState(t, ctx, sqliteDB, "sqlite", table)
+	if !reflect.DeepEqual(mysqlState, sqliteState) || !reflect.DeepEqual(mysqlState, expected) {
+		t.Fatalf("soft-delete state parity mismatch: mysql=%v sqlite=%v want=%v", mysqlState, sqliteState, expected)
+	}
+}
+
+func readMatrixSoftDeleteState(t *testing.T, ctx context.Context, db *sql.DB, driver, table string) map[string]bool {
+	t.Helper()
+	query := "SELECT `product_code`, `patris_export_deleted` FROM " + quoteIdent(driver, table) + " ORDER BY `product_code`"
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		t.Fatal("read matrix soft-delete state:", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]bool)
+	for rows.Next() {
+		var code string
+		var deleted bool
+		if err := rows.Scan(&code, &deleted); err != nil {
+			t.Fatal("scan matrix soft-delete state:", err)
+		}
+		result[code] = deleted
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal("iterate matrix soft-delete state:", err)
+	}
+	return result
 }
 
 func readMatrixProducts(t *testing.T, ctx context.Context, db *sql.DB, driver, table string) []matrixProduct {


### PR DESCRIPTION
## What changed

- adds `soft_delete_missing` as an explicit SQL reconciliation mode while preserving `upsert_only` as the safe default
- manages a reserved, additive `patris_export_deleted` boolean tombstone and restores returning rows
- requires a non-mutating dry-run preview followed by the exact `sha256:` confirmation token for apply
- binds the confirmation digest to deterministic prepared source fields and typed values, source/protected keys, and every destination key plus tombstone state
- blocks empty sources, stale previews, same-key source changes, target-state changes, reserved identifier aliases, and incompatible pre-existing tombstone schemas before mutation
- returns allowlisted, secret-safe reconciliation evidence and typed guard diagnostics without exposing keys, source values, connection material, or supplied tokens
- extends the disposable MySQL 8.4/MariaDB 11.4/SQLite parity matrix to cover soft deletion and restoration
- documents preview/apply, rollback retry, fresh-preview idempotency, and operator safeguards

## Why

Issue #6 requires an explicit soft-delete snapshot policy. The existing sink supported safe-default upserts and opt-in hard deletion, but had no reversible missing-row state and no exact preview/apply guard. A keyset-only token would also permit same-key data or tombstone-state drift, so this implementation binds the complete prepared source plan and target tombstone state.

## Validation

- full Windows guarded dynamic-pxlib Go suite: `go test -count=1 ./...`
- full guarded dynamic-pxlib vet: `go vet ./...`
- race checks: `go test -race -count=1 ./pkg/recordsink ./pkg/appconfig ./cmd/patris-export`
- focused reconciliation and matrix compilation tests
- clean frontend install and high-severity dependency audit: 0 vulnerabilities
- frontend tests: 52/52; production build passed
- delivery adapter tests: 13/13
- JavaScript host adapter tests: 29/29; syntax checks passed
- `git diff --check` and exact commit hygiene passed

The pull-request SQL compatibility workflow is the authoritative disposable MySQL 8.4/MariaDB 11.4 runtime gate. No production database was touched and no local live executable was rebuilt or promoted in this focused slice.

Refs #6