### PR TITLE
Complete secure SQL target operations backend

### DIFF
--- a/docs/SQL-TARGET-OPERATIONS-API.md
+++ b/docs/SQL-TARGET-OPERATIONS-API.md
@@ -1,0 +1,227 @@
+# SQL target operations API
+
+The SQL target operations API exposes bounded, explicit operator actions while
+keeping the MySQL/MariaDB DSN, custom-CA path, TLS server name, server version,
+and raw driver errors inside the Patris process. It reuses the same
+`recordpipe` canonical projection and `recordsink` transaction path as CLI and
+watch exports.
+
+The API never accepts connection details from the browser. Configure those
+values through protected server configuration or environment variables as
+described in [Export, transform, and send](examples/export-transform-send.md).
+
+## Authorization
+
+An operator first creates a short-lived in-memory session:
+
+```http
+POST /api/sql-target/session
+Origin: http://127.0.0.1:18080
+```
+
+When both the request peer and the exact origin hostname are loopback
+(`localhost`, `127.0.0.1`, or `::1`), the application can bootstrap the session
+without another credential. This exception does not apply merely because a
+reverse proxy connects to Patris over loopback.
+
+For every non-loopback origin:
+
+- HTTPS is mandatory.
+- Set a dedicated, random value of 32 to 512 characters in
+  `PATRIS_EXPORT_SQL_OPERATOR_TOKEN`.
+- Send that value once in `X-Patris-SQL-Operator-Token` when creating the
+  session.
+
+The edge-upload token, delivery credentials, and other Patris credentials
+cannot authorize SQL operations. Never put the SQL operator token in a URL,
+application config, browser storage, repository, or log.
+
+Patris itself serves HTTP. When HTTPS terminates at a reverse proxy, preserve
+the public `Host` or send singular `X-Forwarded-Host` and
+`X-Forwarded-Proto: https` headers. Patris accepts these forwarding headers only
+from a loopback proxy peer; an internet client cannot use them to impersonate a
+secure origin.
+
+A successful session response sets an `HttpOnly`, `SameSite=Strict` cookie
+scoped to `/api/sql-target` and returns:
+
+```json
+{
+  "authenticated": true,
+  "csrf_token": "opaque-short-lived-value",
+  "expires_at": "2026-07-24T12:10:00Z"
+}
+```
+
+The session expires after ten minutes and is bound to the exact scheme, host,
+and effective port used during bootstrap. Every following request must carry
+that cookie and exactly one `X-Patris-CSRF-Token` header. Session creation and
+all protected POST operations also require exactly one matching `Origin`
+header. Same-origin browsers do not consistently emit `Origin` on GET, so a
+protected GET may instead supply the browser-generated
+`Sec-Fetch-Site: same-origin` plus a `Referer` whose scheme, host, and effective
+port match the session origin. Cross-site, missing, duplicated, or mismatched
+evidence is rejected. Authentication failures use one generic response and do
+not reveal which credential check failed.
+
+Revoke the session when the operator locks or leaves the SQL controls:
+
+```http
+DELETE /api/sql-target/session
+Origin: http://127.0.0.1:18080
+X-Patris-CSRF-Token: opaque-short-lived-value
+```
+
+This deletes the hashed in-memory session and expires the browser cookie. A
+successful response is `{"authenticated":false}`.
+
+## Operations
+
+All responses use `Cache-Control: no-store`. Connection tests, previews, and
+manual syncs share one server-side operation permit so they cannot overlap.
+`busy` remains readable while an operation is running.
+
+### Status
+
+```http
+GET /api/sql-target/status
+X-Patris-CSRF-Token: opaque-short-lived-value
+```
+
+```json
+{
+  "configured": true,
+  "driver": "mysql",
+  "table_configured": true,
+  "batch_size": 250,
+  "reconciliation": "upsert_only",
+  "connect_timeout_ms": 10000,
+  "verified_tls_configured": true,
+  "busy": false,
+  "last_result_available": false
+}
+```
+
+The booleans report configuration presence only. They do not return the table,
+host, database, CA path, or certificate server name.
+
+### Non-mutating connection test
+
+```http
+POST /api/sql-target/test
+X-Patris-CSRF-Token: opaque-short-lived-value
+```
+
+The bounded probe performs a ping, a server-vendor query, and a best-effort TLS
+state query. It does not create a table or change data.
+
+### Dry-run preview
+
+```http
+POST /api/sql-target/preview
+X-Patris-CSRF-Token: opaque-short-lived-value
+```
+
+The preview reads the current source through `Server.RecordResult`, preserving
+the active transform, canonical contract, field mapping, key, and protected
+quarantine Codes. It calls the shared SQL sink with `dry_run=true`; no schema or
+row mutation is committed.
+
+For `soft_delete_missing`, a successful, apply-allowed preview adds bounded
+reconciliation evidence:
+
+```json
+{
+  "source_rows": 1002,
+  "protected_rows": 3,
+  "target_rows": 1005,
+  "missing_rows": 3,
+  "would_soft_delete": 3,
+  "already_soft_deleted": 0,
+  "would_restore": 0,
+  "partial_source_risk": true,
+  "confirmation_required": true,
+  "apply_allowed": true,
+  "confirmation_token": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+```
+
+The token is an aggregate exact-plan digest. It never contains source values,
+destination keys, or connection material. Keep it only in application memory,
+discard it on any config or status change and after every apply attempt, and
+request a new preview before retrying. An empty or safety-blocked source does
+not receive a token.
+
+### Explicit manual sync
+
+```http
+POST /api/sql-target/sync
+Content-Type: application/json
+X-Patris-CSRF-Token: opaque-short-lived-value
+
+{"confirm":"manual_sync"}
+```
+
+For `soft_delete_missing`, include the exact token issued by the immediately
+preceding preview:
+
+```json
+{
+  "confirm": "manual_sync",
+  "reconciliation_token": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+```
+
+The body is limited to 4 KiB. Unknown fields, additional JSON values, a missing
+content type, any other confirmation string, whitespace-padded tokens, uppercase
+hex, and malformed or oversized tokens fail before the sink runs. The shared
+sink re-computes the exact plan; a source-value, target-key, or tombstone-state
+change returns `409 reconciliation_blocked` with reason `preview_mismatch`.
+
+`upsert_only` does not accept a reconciliation token. Browser-triggered
+`delete_missing` apply returns `422 hard_delete_unavailable`: the existing hard
+delete mode has no exact-plan token contract and remains available only through
+an explicitly protected server-side operator workflow. Its non-mutating preview
+remains available.
+
+### Last in-process result
+
+```http
+GET /api/sql-target/last-result
+X-Patris-CSRF-Token: opaque-short-lived-value
+```
+
+Before any operation it returns `{"available":false}`. Otherwise it returns the
+last diagnostic held in memory. A process restart clears it.
+
+Successful diagnostics contain the operation name, timestamps, optional source
+record count, and either a probe or the shared SQL result:
+
+```json
+{
+  "success": true,
+  "diagnostic": {
+    "operation": "preview",
+    "status": "succeeded",
+    "started_at": "2026-07-24T12:00:00Z",
+    "finished_at": "2026-07-24T12:00:01Z",
+    "record_count": 1002,
+    "result": {
+      "inserted": 3,
+      "updated": 8,
+      "unchanged": 991,
+      "deleted": 0,
+      "failed": 0,
+      "elapsed_ms": 734,
+      "dry_run": true,
+      "reconciliation": "upsert_only"
+    }
+  }
+}
+```
+
+Failures return a stable code, stage, retryable flag, generic message, and an
+allowlisted reconciliation reason when applicable. Reconciliation evidence is
+copied and normalized at the HTTP boundary; unknown guard codes and malformed
+tokens are never forwarded. Failed or unconfirmed transactions report no
+inserted, updated, unchanged, or deleted successes.

--- a/docs/SQL-TARGET-OPERATIONS-API.md
+++ b/docs/SQL-TARGET-OPERATIONS-API.md
@@ -19,10 +19,12 @@ POST /api/sql-target/session
 Origin: http://127.0.0.1:18080
 ```
 
-When both the request peer and the exact origin hostname are loopback
-(`localhost`, `127.0.0.1`, or `::1`), the application can bootstrap the session
-without another credential. This exception does not apply merely because a
-reverse proxy connects to Patris over loopback.
+When the request peer and exact origin hostname are loopback (`localhost`,
+`127.0.0.1`, or `::1`), the application can bootstrap without another
+credential only if `PATRIS_EXPORT_SQL_OPERATOR_TOKEN` is unset and the request
+contains no recognized proxy-forwarding marker. If the operator token is
+configured, direct-loopback callers must send it too. The tokenless exception
+never applies merely because a reverse proxy connects to Patris over loopback.
 
 For every non-loopback origin:
 
@@ -40,7 +42,10 @@ Patris itself serves HTTP. When HTTPS terminates at a reverse proxy, preserve
 the public `Host` or send singular `X-Forwarded-Host` and
 `X-Forwarded-Proto: https` headers. Patris accepts these forwarding headers only
 from a loopback proxy peer; an internet client cannot use them to impersonate a
-secure origin.
+secure origin. The proxy must preserve at least one recognized forwarding
+marker and must require the dedicated operator token. Do not expose this API
+through a proxy that strips all of `Forwarded`, `Via`, `X-Forwarded-*`, and
+`X-Real-IP`: such a request is indistinguishable from a direct local client.
 
 A successful session response sets an `HttpOnly`, `SameSite=Strict` cookie
 scoped to `/api/sql-target` and returns:
@@ -79,7 +84,11 @@ successful response is `{"authenticated":false}`.
 
 All responses use `Cache-Control: no-store`. Connection tests, previews, and
 manual syncs share one server-side operation permit so they cannot overlap.
-`busy` remains readable while an operation is running.
+`busy` remains readable while an operation is running. For bounded API calls,
+the MySQL connector defaults or caps its connect, read, and write deadlines to
+the remaining request deadline. This also bounds driver-level transaction
+commit/rollback I/O that does not otherwise observe a Go context; unbounded
+CLI/watch callers retain their configured DSN behavior.
 
 ### Status
 
@@ -102,8 +111,15 @@ X-Patris-CSRF-Token: opaque-short-lived-value
 }
 ```
 
-The booleans report configuration presence only. They do not return the table,
-host, database, CA path, or certificate server name.
+The booleans report safe configuration readiness only. They do not return the
+table, host, database, CA path, or certificate server name.
+`table_configured=true` requires an explicit `convert.table` or
+`export.mysql_table`; the SQLite table and inferred source names do not count.
+The explicit table must already be in its normalized SQL form: 1 to 64 ASCII
+characters, starting with a letter, ending with a letter or number, and
+containing only letters, numbers, and underscores. An invalid name is never
+silently rewritten and preview/sync returns `422 target_table_invalid` before
+source or sink work.
 
 ### Non-mutating connection test
 
@@ -122,10 +138,36 @@ POST /api/sql-target/preview
 X-Patris-CSRF-Token: opaque-short-lived-value
 ```
 
-The preview reads the current source through `Server.RecordResult`, preserving
-the active transform, canonical contract, field mapping, key, and protected
-quarantine Codes. It calls the shared SQL sink with `dry_run=true`; no schema or
-row mutation is committed.
+The preview reads the current source through `Server.RecordResultContext`,
+preserving the active transform, canonical contract, field mapping, key, and
+protected quarantine Codes. The same operation permit covers source preparation
+and the sink, preventing an overlapping probe or sync from observing a stale
+snapshot. Built-in downloads, temporary copies, JSON reads, projection, and
+native record iteration cooperate with the request deadline. Temporary refreshes
+are staged and atomically published so cancellation cannot replace a stable copy
+with partial data. A single pxlib native call remains the smallest
+non-interruptible unit. The preview calls the shared SQL sink with
+`dry_run=true`; no schema or row mutation is committed.
+
+Every successful, apply-eligible preview returns a random one-time authorization
+inside the direct diagnostic:
+
+```json
+{
+  "preview_grant": "43-character-unpadded-base64url-value",
+  "preview_grant_expires_at": "2026-07-24T12:02:00Z"
+}
+```
+
+The grant expires after at most two minutes and never extends the operator
+session. It is held only as a hash in process memory and is bound to the exact
+operator session, protected target configuration (including DSN, TLS, table,
+mode, and batch), source configuration, and typed source projection. A new
+preview replaces the previous grant. Every apply attempt consumes it before
+validation, source, or sink outcomes, so retries, config/source changes, expiry,
+and replay all require a fresh preview. Values with different SQL material
+types, such as integer versus float or bytes versus text, receive different
+source fingerprints.
 
 For `soft_delete_missing`, a successful, apply-allowed preview adds bounded
 reconciliation evidence:
@@ -159,7 +201,10 @@ POST /api/sql-target/sync
 Content-Type: application/json
 X-Patris-CSRF-Token: opaque-short-lived-value
 
-{"confirm":"manual_sync"}
+{
+  "confirm": "manual_sync",
+  "preview_grant": "43-character-unpadded-base64url-value"
+}
 ```
 
 For `soft_delete_missing`, include the exact token issued by the immediately
@@ -168,21 +213,27 @@ preceding preview:
 ```json
 {
   "confirm": "manual_sync",
+  "preview_grant": "43-character-unpadded-base64url-value",
   "reconciliation_token": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }
 ```
 
-The body is limited to 4 KiB. Unknown fields, additional JSON values, a missing
-content type, any other confirmation string, whitespace-padded tokens, uppercase
-hex, and malformed or oversized tokens fail before the sink runs. The shared
-sink re-computes the exact plan; a source-value, target-key, or tombstone-state
-change returns `409 reconciliation_blocked` with reason `preview_mismatch`.
+The body is limited to 4 KiB and is parsed before taking the global SQL
+operation permit, so a slow or partial request body cannot block probes or
+previews. Unknown fields, additional JSON values, a missing content type, any
+other confirmation string, malformed grants, whitespace-padded tokens,
+uppercase hex, and malformed or oversized tokens fail before the sink runs.
+Missing, stale, mismatched, expired, or replayed grants return a generic
+`409 reconciliation_blocked` diagnostic with reason `preview_required`. The
+shared sink then re-computes the soft-delete exact plan as an independent
+second defense; a target-key or tombstone-state change returns
+`409 reconciliation_blocked` with reason `preview_mismatch`.
 
-`upsert_only` does not accept a reconciliation token. Browser-triggered
-`delete_missing` apply returns `422 hard_delete_unavailable`: the existing hard
-delete mode has no exact-plan token contract and remains available only through
-an explicitly protected server-side operator workflow. Its non-mutating preview
-remains available.
+`upsert_only` requires the one-time preview grant but does not accept a
+reconciliation token. Browser-triggered `delete_missing` apply returns
+`422 hard_delete_unavailable`: the existing hard-delete mode has no exact-plan
+token contract and remains available only through an explicitly protected
+server-side operator workflow. Its non-mutating preview remains available.
 
 ### Last in-process result
 
@@ -192,7 +243,11 @@ X-Patris-CSRF-Token: opaque-short-lived-value
 ```
 
 Before any operation it returns `{"available":false}`. Otherwise it returns the
-last diagnostic held in memory. A process restart clears it.
+last diagnostic held in memory. A process restart clears it. Preview
+grants, grant expiry, and reconciliation confirmation tokens are returned only
+by the direct preview response; cached diagnostics strip them, set
+`apply_allowed=false`, and use `guard_code=preview_required`, so an apply always
+requires a fresh preview.
 
 Successful diagnostics contain the operation name, timestamps, optional source
 record count, and either a probe or the shared SQL result:

--- a/docs/examples/export-transform-send.md
+++ b/docs/examples/export-transform-send.md
@@ -199,8 +199,11 @@ outcome and must be reconciled before retrying.
 The shared `recordsink.ProbeSQLTarget` operation is non-mutating: it performs a
 bounded ping plus `SELECT VERSION()` and a best-effort session TLS-status read.
 Its result contains only connection state, driver/vendor, a bounded printable
-version, TLS state, and elapsed time. It is the backend primitive for the
-authenticated connection-test UI follow-up.
+version, TLS state, and elapsed time. The authenticated HTTP boundary omits the
+version along with all protected target details. See
+[SQL target operations API](../SQL-TARGET-OPERATIONS-API.md) for its short-lived
+operator session, redacted status, connection test, dry-run preview, explicit
+manual sync, and last-result contract.
 
 Watch mode uses this same `recordpipe` -> `recordsink` route for its initial
 write and every debounced update; there is no separate live SQL implementation:

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -636,7 +636,30 @@ func isEmptyConfigValue(value interface{}) bool {
 	}
 }
 
-func (m *Manager) Watch(onChange func(Config)) (*fsnotify.Watcher, error) {
+const configWatchDebounce = 120 * time.Millisecond
+
+// ConfigWatcher owns both fsnotify and the debounce callback lifecycle. Close
+// joins the watcher goroutine, so no callback can outlive the server that
+// registered it.
+type ConfigWatcher struct {
+	watcher  *fsnotify.Watcher
+	done     chan struct{}
+	close    sync.Once
+	closeErr error
+}
+
+func (watcher *ConfigWatcher) Close() error {
+	if watcher == nil {
+		return nil
+	}
+	watcher.close.Do(func() {
+		watcher.closeErr = watcher.watcher.Close()
+		<-watcher.done
+	})
+	return watcher.closeErr
+}
+
+func (m *Manager) Watch(onChange func(Config)) (*ConfigWatcher, error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -650,8 +673,16 @@ func (m *Manager) Watch(onChange func(Config)) (*fsnotify.Watcher, error) {
 		w.Close()
 		return nil, err
 	}
+	watcher := &ConfigWatcher{watcher: w, done: make(chan struct{})}
 	go func() {
+		defer close(watcher.done)
 		var timer *time.Timer
+		var timerChannel <-chan time.Time
+		defer func() {
+			if timer != nil {
+				timer.Stop()
+			}
+		}()
 		for {
 			select {
 			case event, ok := <-w.Events:
@@ -665,13 +696,22 @@ func (m *Manager) Watch(onChange func(Config)) (*fsnotify.Watcher, error) {
 					continue
 				}
 				if timer != nil {
-					timer.Stop()
-				}
-				timer = time.AfterFunc(120*time.Millisecond, func() {
-					if err := m.Reload(); err == nil && onChange != nil {
-						onChange(m.Get())
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
 					}
-				})
+					timer.Reset(configWatchDebounce)
+				} else {
+					timer = time.NewTimer(configWatchDebounce)
+				}
+				timerChannel = timer.C
+			case <-timerChannel:
+				timerChannel = nil
+				if err := m.Reload(); err == nil && onChange != nil {
+					onChange(m.Get())
+				}
 			case _, ok := <-w.Errors:
 				if !ok {
 					return
@@ -679,7 +719,7 @@ func (m *Manager) Watch(onChange func(Config)) (*fsnotify.Watcher, error) {
 			}
 		}
 	}()
-	return w, nil
+	return watcher, nil
 }
 
 func (c Config) Addr() string {

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
 )
@@ -52,6 +54,52 @@ func TestLoadFilesLayersJSONYAMLTOML(t *testing.T) {
 	}
 	if mgr.Path() != tomlPath {
 		t.Fatalf("write path = %q, want %q", mgr.Path(), tomlPath)
+	}
+}
+
+func TestConfigWatcherCloseJoinsInFlightCallback(t *testing.T) {
+	manager, err := Load(filepath.Join(t.TempDir(), "watch.json"))
+	if err != nil {
+		t.Fatalf("load watched config: %v", err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	watcher, err := manager.Watch(func(Config) {
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+	})
+	if err != nil {
+		t.Fatalf("watch config: %v", err)
+	}
+	if err := manager.Update(func(cfg *Config) { cfg.Server.Port++ }); err != nil {
+		t.Fatalf("update watched config: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		_ = watcher.Close()
+		t.Fatal("watch callback did not start")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- watcher.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("watcher Close returned before callback exited: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close watcher: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher Close did not join callback")
+	}
+	if err := watcher.Close(); err != nil {
+		t.Fatalf("idempotent watcher Close: %v", err)
 	}
 }
 

--- a/pkg/canonical/context_test.go
+++ b/pkg/canonical/context_test.go
@@ -1,0 +1,76 @@
+package canonical
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
+)
+
+type cancellingPricingProvider struct {
+	cancel context.CancelFunc
+	once   sync.Once
+	calls  atomic.Int32
+}
+
+func (provider *cancellingPricingProvider) Resolve(ctx context.Context, _ string) pricingcatalog.Resolution {
+	provider.calls.Add(1)
+	provider.once.Do(provider.cancel)
+	select {
+	case <-ctx.Done():
+	default:
+	}
+	return pricingcatalog.Resolution{}
+}
+
+func TestTransformContextCancelsWorkerDispatchAndJoinsWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &cancellingPricingProvider{cancel: cancel}
+	cfg := DefaultConfig()
+	cfg.Pricing.Mode = pricingcatalog.ModeDigitalogic
+	cfg.Pricing.Digitalogic.BaseURL = "https://pricing.invalid"
+	cfg.Pricing.Digitalogic.MaxConcurrency = 4
+	rows := make([]map[string]interface{}, 128)
+	for index := range rows {
+		rows[index] = map[string]interface{}{
+			"Code":   fmt.Sprintf("%09d", 100000000+index),
+			"Name":   "Product",
+			"Serial": fmt.Sprintf("SKU-%d", index),
+		}
+	}
+
+	productRows, envelope, err := TransformContext(ctx, rows, "kala.db", cfg, provider, time.Unix(1, 0))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("TransformContext error=%v, want context.Canceled", err)
+	}
+	if productRows != nil || envelope != nil {
+		t.Fatalf("cancelled transform returned partial output: rows=%d envelope=%v", len(productRows), envelope != nil)
+	}
+	if calls := provider.calls.Load(); calls < 1 || calls > int32(cfg.Pricing.Digitalogic.MaxConcurrency) {
+		t.Fatalf("provider calls=%d, want bounded active workers only", calls)
+	}
+}
+
+func TestTransformContextRejectsPreCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rows, envelope, err := TransformContext(
+		ctx,
+		[]map[string]interface{}{{"Code": "100000001", "Name": "Product"}},
+		"kala.db",
+		DefaultConfig(),
+		pricingcatalog.NewProvider(pricingcatalog.Config{Mode: pricingcatalog.ModeNone}),
+		time.Unix(1, 0),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("TransformContext error=%v, want context.Canceled", err)
+	}
+	if rows != nil || envelope != nil {
+		t.Fatalf("pre-cancelled transform returned output: rows=%#v envelope=%#v", rows, envelope)
+	}
+}

--- a/pkg/canonical/contract.go
+++ b/pkg/canonical/contract.go
@@ -1,6 +1,7 @@
 package canonical
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -125,32 +126,79 @@ func rejectUnknownJSONFields(raw map[string]json.RawMessage, kind string, allowe
 }
 
 func NewEnvelope(rows []Product, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) *Envelope {
-	return newEnvelope(rows, nil, nil, source, sourceID, generatedAt, quarantinedCodes...)
+	envelope, _ := newEnvelopeContext(context.Background(), rows, nil, nil, source, sourceID, generatedAt, quarantinedCodes...)
+	return envelope
 }
 
 func NewEnvelopeWithCategories(rows []Product, categories []Category, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) *Envelope {
-	return newEnvelope(rows, categories, nil, source, sourceID, generatedAt, quarantinedCodes...)
+	envelope, _ := newEnvelopeContext(context.Background(), rows, categories, nil, source, sourceID, generatedAt, quarantinedCodes...)
+	return envelope
 }
 
 func NewCatalogEnvelope(rows []Product, categories []Category, excludedCodes []string, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) *Envelope {
-	return newEnvelope(rows, categories, excludedCodes, source, sourceID, generatedAt, quarantinedCodes...)
+	envelope, _ := NewCatalogEnvelopeContext(context.Background(), rows, categories, excludedCodes, source, sourceID, generatedAt, quarantinedCodes...)
+	return envelope
 }
 
-func newEnvelope(rows []Product, categories []Category, excludedCodes []string, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) *Envelope {
+// NewCatalogEnvelopeContext builds a deterministic snapshot while allowing
+// request cancellation to interrupt cloning, sorting, revision hashing, and
+// event identity materialization.
+func NewCatalogEnvelopeContext(ctx context.Context, rows []Product, categories []Category, excludedCodes []string, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) (*Envelope, error) {
+	return newEnvelopeContext(ctx, rows, categories, excludedCodes, source, sourceID, generatedAt, quarantinedCodes...)
+}
+
+func newEnvelopeContext(ctx context.Context, rows []Product, categories []Category, excludedCodes []string, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) (*Envelope, error) {
+	envelope, err := newEnvelopeBaseContext(ctx, rows, categories, excludedCodes, source, sourceID, generatedAt, quarantinedCodes...)
+	if err != nil {
+		return nil, err
+	}
+	envelope.EventID, err = eventIDContext(ctx, envelope)
+	if err != nil {
+		return nil, err
+	}
+	return envelope, nil
+}
+
+func newEnvelopeBaseContext(ctx context.Context, rows []Product, categories []Category, excludedCodes []string, source, sourceID string, generatedAt time.Time, quarantinedCodes ...string) (*Envelope, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if generatedAt.IsZero() {
 		generatedAt = time.Now()
 	}
-	products := cloneProducts(rows)
-	sort.SliceStable(products, func(i, j int) bool {
-		return products[i].ProductCode < products[j].ProductCode
-	})
-	categories = cloneCategories(categories)
-	sort.SliceStable(categories, func(i, j int) bool {
-		return categories[i].CategoryCode < categories[j].CategoryCode
-	})
-	quarantinedCodes = normalizedWarnings(quarantinedCodes)
-	excludedCodes = normalizedWarnings(excludedCodes)
-	revision := sourceRevision(products, categories, excludedCodes, quarantinedCodes)
+	products, err := cloneProductsContext(ctx, rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := stableSortContext(ctx, products, func(left, right Product) bool {
+		return left.ProductCode < right.ProductCode
+	}); err != nil {
+		return nil, err
+	}
+	categories, err = cloneCategoriesContext(ctx, categories)
+	if err != nil {
+		return nil, err
+	}
+	if err := stableSortContext(ctx, categories, func(left, right Category) bool {
+		return left.CategoryCode < right.CategoryCode
+	}); err != nil {
+		return nil, err
+	}
+	quarantinedCodes, err = normalizedWarningsContext(ctx, quarantinedCodes)
+	if err != nil {
+		return nil, err
+	}
+	excludedCodes, err = normalizedWarningsContext(ctx, excludedCodes)
+	if err != nil {
+		return nil, err
+	}
+	revision, err := sourceRevisionContext(ctx, products, categories, excludedCodes, quarantinedCodes)
+	if err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(sourceID) == "" {
 		sourceID = sourceBaseName(source)
 	}
@@ -168,10 +216,12 @@ func newEnvelope(rows []Product, categories []Category, excludedCodes []string, 
 		Warnings:         normalizedWarnings(nil),
 	}
 	for _, code := range quarantinedCodes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		envelope.Warnings = append(envelope.Warnings, "duplicate_product_code:"+code)
 	}
-	envelope.EventID = eventID(envelope)
-	return envelope
+	return envelope, nil
 }
 
 func ChangeEnvelope(snapshot *Envelope, changes *recorddiff.ChangeSet) *Envelope {
@@ -238,54 +288,207 @@ func ChangeEnvelope(snapshot *Envelope, changes *recorddiff.ChangeSet) *Envelope
 }
 
 func sourceRevision(products []Product, categories []Category, excludedCodes, quarantinedCodes []string) string {
+	revision, _ := sourceRevisionContext(context.Background(), products, categories, excludedCodes, quarantinedCodes)
+	return revision
+}
+
+func sourceRevisionContext(ctx context.Context, products []Product, categories []Category, excludedCodes, quarantinedCodes []string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	material := make([]string, 0, len(products)+len(categories)+len(excludedCodes))
 	for _, product := range products {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		material = append(material, product.ProductCode+"="+product.RecordHash)
 	}
 	for _, category := range categories {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		material = append(material, "category:"+category.CategoryCode+"="+category.RecordHash)
 	}
 	for _, code := range excludedCodes {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		material = append(material, "excluded="+code)
 	}
-	sort.Strings(material)
+	if err := stableSortContext(ctx, material, func(left, right string) bool { return left < right }); err != nil {
+		return "", err
+	}
 	for _, code := range quarantinedCodes {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		material = append(material, "quarantined="+code)
 	}
-	return hashBytes([]byte(strings.Join(material, "\n")))
+	digest := sha256.New()
+	for index, value := range material {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		if index > 0 {
+			_, _ = digest.Write([]byte{'\n'})
+		}
+		_, _ = digest.Write([]byte(value))
+	}
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 func eventID(envelope *Envelope) string {
-	type identity struct {
-		Schema           string      `json:"schema"`
-		EventType        string      `json:"event_type"`
-		LocalCurrency    string      `json:"local_currency,omitempty"`
-		FormulaID        string      `json:"formula_id,omitempty"`
-		Source           Source      `json:"source"`
-		GeneratedAt      string      `json:"generated_at"`
-		Products         []string    `json:"products"`
-		Categories       []string    `json:"categories"`
-		ExcludedCodes    []string    `json:"excluded_codes"`
-		DeletedCodes     []Tombstone `json:"deleted_codes,omitempty"`
-		QuarantinedCodes []string    `json:"quarantined_codes"`
+	value, _ := eventIDContext(context.Background(), envelope)
+	return value
+}
+
+func eventIDContext(ctx context.Context, envelope *Envelope) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
 	}
 	hashes := make([]string, 0, len(envelope.Products))
 	for _, product := range envelope.Products {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		hashes = append(hashes, product.ProductCode+"="+product.RecordHash)
 	}
-	sort.Strings(hashes)
+	if err := stableSortContext(ctx, hashes, func(left, right string) bool { return left < right }); err != nil {
+		return "", err
+	}
 	categoryHashes := make([]string, 0, len(envelope.Categories))
 	for _, category := range envelope.Categories {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		categoryHashes = append(categoryHashes, category.CategoryCode+"="+category.RecordHash)
 	}
-	sort.Strings(categoryHashes)
-	material, _ := json.Marshal(identity{
-		Schema: envelope.Schema, EventType: envelope.EventType,
-		LocalCurrency: envelope.LocalCurrency, FormulaID: envelope.FormulaID,
-		Source: envelope.Source, GeneratedAt: envelope.GeneratedAt, Products: hashes, Categories: categoryHashes, ExcludedCodes: envelope.ExcludedCodes,
-		DeletedCodes: envelope.DeletedCodes, QuarantinedCodes: envelope.QuarantinedCodes,
-	})
-	return hashBytes(material)
+	if err := stableSortContext(ctx, categoryHashes, func(left, right string) bool { return left < right }); err != nil {
+		return "", err
+	}
+
+	digest := sha256.New()
+	write := func(value string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		_, _ = digest.Write([]byte(value))
+		return nil
+	}
+	writeJSONString := func(value string) error {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		return write(string(encoded))
+	}
+	writeStringField := func(prefix, value string) error {
+		if err := write(prefix); err != nil {
+			return err
+		}
+		return writeJSONString(value)
+	}
+	writeStringArray := func(prefix string, values []string) error {
+		if err := write(prefix); err != nil {
+			return err
+		}
+		if values == nil {
+			return write("null")
+		}
+		if err := write("["); err != nil {
+			return err
+		}
+		for index, value := range values {
+			if index > 0 {
+				if err := write(","); err != nil {
+					return err
+				}
+			}
+			if err := writeJSONString(value); err != nil {
+				return err
+			}
+		}
+		return write("]")
+	}
+
+	if err := writeStringField(`{"schema":`, envelope.Schema); err != nil {
+		return "", err
+	}
+	if err := writeStringField(`,"event_type":`, envelope.EventType); err != nil {
+		return "", err
+	}
+	if envelope.LocalCurrency != "" {
+		if err := writeStringField(`,"local_currency":`, envelope.LocalCurrency); err != nil {
+			return "", err
+		}
+	}
+	if envelope.FormulaID != "" {
+		if err := writeStringField(`,"formula_id":`, envelope.FormulaID); err != nil {
+			return "", err
+		}
+	}
+	if err := write(`,"source":{"id":`); err != nil {
+		return "", err
+	}
+	if err := writeJSONString(envelope.Source.ID); err != nil {
+		return "", err
+	}
+	if err := writeStringField(`,"dataset":`, envelope.Source.Dataset); err != nil {
+		return "", err
+	}
+	if err := writeStringField(`,"revision":`, envelope.Source.Revision); err != nil {
+		return "", err
+	}
+	if err := writeStringField(`},"generated_at":`, envelope.GeneratedAt); err != nil {
+		return "", err
+	}
+	if err := writeStringArray(`,"products":`, hashes); err != nil {
+		return "", err
+	}
+	if err := writeStringArray(`,"categories":`, categoryHashes); err != nil {
+		return "", err
+	}
+	if err := writeStringArray(`,"excluded_codes":`, envelope.ExcludedCodes); err != nil {
+		return "", err
+	}
+	if len(envelope.DeletedCodes) > 0 {
+		if err := write(`,"deleted_codes":[`); err != nil {
+			return "", err
+		}
+		for index, tombstone := range envelope.DeletedCodes {
+			if index > 0 {
+				if err := write(","); err != nil {
+					return "", err
+				}
+			}
+			if err := write(`{"product_code":`); err != nil {
+				return "", err
+			}
+			if err := writeJSONString(tombstone.ProductCode); err != nil {
+				return "", err
+			}
+			if tombstone.Deleted {
+				if err := write(`,"deleted":true}`); err != nil {
+					return "", err
+				}
+			} else if err := write(`,"deleted":false}`); err != nil {
+				return "", err
+			}
+		}
+		if err := write("]"); err != nil {
+			return "", err
+		}
+	}
+	if err := writeStringArray(`,"quarantined_codes":`, envelope.QuarantinedCodes); err != nil {
+		return "", err
+	}
+	if err := write("}"); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 func hashBytes(material []byte) string {
@@ -320,47 +523,169 @@ func cloneEnvelope(value *Envelope) *Envelope {
 }
 
 func cloneCategories(values []Category) []Category {
+	result, _ := cloneCategoriesContext(context.Background(), values)
+	return result
+}
+
+func cloneCategoriesContext(ctx context.Context, values []Category) ([]Category, error) {
 	result := make([]Category, 0, len(values))
 	for _, value := range values {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		copy := value
 		copy.fieldPresence = make(map[string]fieldPresence, len(value.fieldPresence))
 		for key, state := range value.fieldPresence {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			copy.fieldPresence[key] = state
 		}
 		if value.Warnings != nil {
-			copy.Warnings = append(make([]string, 0, len(value.Warnings)), value.Warnings...)
+			copy.Warnings = make([]string, 0, len(value.Warnings))
+			for _, warning := range value.Warnings {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				copy.Warnings = append(copy.Warnings, warning)
+			}
 		}
 		result = append(result, copy)
 	}
-	return result
+	return result, nil
 }
 
 func cloneProducts(values []Product) []Product {
-	result := make([]Product, 0, len(values))
-	for _, value := range values {
-		result = append(result, cloneProduct(value))
-	}
+	result, _ := cloneProductsContext(context.Background(), values)
 	return result
 }
 
+func cloneProductsContext(ctx context.Context, values []Product) ([]Product, error) {
+	result := make([]Product, 0, len(values))
+	for _, value := range values {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		copy, err := cloneProductContext(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, copy)
+	}
+	return result, nil
+}
+
 func cloneProduct(value Product) Product {
+	copy, _ := cloneProductContext(context.Background(), value)
+	return copy
+}
+
+func cloneProductContext(ctx context.Context, value Product) (Product, error) {
 	copy := value
 	copy.WarehouseStock = make(map[string]float64, len(value.WarehouseStock))
 	for key, stock := range value.WarehouseStock {
+		if err := ctx.Err(); err != nil {
+			return Product{}, err
+		}
 		copy.WarehouseStock[key] = stock
 	}
 	copy.fieldPresence = make(map[string]fieldPresence, len(value.fieldPresence))
 	for key, state := range value.fieldPresence {
+		if err := ctx.Err(); err != nil {
+			return Product{}, err
+		}
 		copy.fieldPresence[key] = state
 	}
 	copy.warehouseNulls = make(map[string]bool, len(value.warehouseNulls))
 	for key, isNull := range value.warehouseNulls {
+		if err := ctx.Err(); err != nil {
+			return Product{}, err
+		}
 		copy.warehouseNulls[key] = isNull
 	}
 	if value.Warnings != nil {
-		copy.Warnings = append(make([]string, 0, len(value.Warnings)), value.Warnings...)
+		copy.Warnings = make([]string, 0, len(value.Warnings))
+		for _, warning := range value.Warnings {
+			if err := ctx.Err(); err != nil {
+				return Product{}, err
+			}
+			copy.Warnings = append(copy.Warnings, warning)
+		}
 	}
-	return copy
+	return copy, nil
+}
+
+// stableSortContext is an iterative stable merge sort with cancellation checks
+// inside both merge and copy passes. The standard sort helpers cannot abort an
+// in-progress O(N log N) catalog sort after a request is cancelled.
+func stableSortContext[T any](ctx context.Context, values []T, less func(left, right T) bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(values) < 2 {
+		return nil
+	}
+
+	buffer := make([]T, len(values))
+	source := values
+	target := buffer
+	for width := 1; width < len(values); {
+		for start := 0; start < len(values); start += 2 * width {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			middle := min(start+width, len(values))
+			end := min(start+2*width, len(values))
+			left, right, output := start, middle, start
+			for left < middle && right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if less(source[right], source[left]) {
+					target[output] = source[right]
+					right++
+				} else {
+					target[output] = source[left]
+					left++
+				}
+				output++
+			}
+			for left < middle {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				target[output] = source[left]
+				left++
+				output++
+			}
+			for right < end {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				target[output] = source[right]
+				right++
+				output++
+			}
+		}
+		source, target = target, source
+		if width > len(values)/2 {
+			width = len(values)
+		} else {
+			width *= 2
+		}
+	}
+	if len(source) > 0 && &source[0] != &values[0] {
+		for index := range source {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			values[index] = source[index]
+		}
+	}
+	return ctx.Err()
 }
 
 func copyRows(rows []map[string]interface{}) []map[string]interface{} {

--- a/pkg/canonical/contract_context_test.go
+++ b/pkg/canonical/contract_context_test.go
@@ -1,0 +1,187 @@
+package canonical
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type cancelAfterChecksContext struct {
+	context.Context
+	limit int32
+	calls atomic.Int32
+	done  chan struct{}
+	once  sync.Once
+}
+
+func newCancelAfterChecksContext(limit int32) *cancelAfterChecksContext {
+	return &cancelAfterChecksContext{
+		Context: context.Background(),
+		limit:   limit,
+		done:    make(chan struct{}),
+	}
+}
+
+func (ctx *cancelAfterChecksContext) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	if ctx.calls.Add(1) >= ctx.limit {
+		ctx.once.Do(func() { close(ctx.done) })
+		return context.Canceled
+	}
+	select {
+	case <-ctx.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func TestSourceRevisionContextMatchesLegacyMaterial(t *testing.T) {
+	products := []Product{
+		{ProductCode: "200", RecordHash: "hash-2"},
+		{ProductCode: "100", RecordHash: "hash-1"},
+	}
+	categories := []Category{
+		{CategoryCode: "20", RecordHash: "category-2"},
+		{CategoryCode: "10", RecordHash: "category-1"},
+	}
+	excluded := []string{"999", "111"}
+	quarantined := []string{"700", "800"}
+
+	material := []string{
+		"200=hash-2",
+		"100=hash-1",
+		"category:20=category-2",
+		"category:10=category-1",
+		"excluded=999",
+		"excluded=111",
+	}
+	sort.Strings(material)
+	material = append(material, "quarantined=700", "quarantined=800")
+	want := hashBytes([]byte(strings.Join(material, "\n")))
+
+	got, err := sourceRevisionContext(context.Background(), products, categories, excluded, quarantined)
+	if err != nil {
+		t.Fatalf("sourceRevisionContext error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("source revision=%q, want %q", got, want)
+	}
+}
+
+func TestSourceRevisionContextCancelsDuringMaterialization(t *testing.T) {
+	products := make([]Product, 64)
+	for index := range products {
+		products[index] = Product{
+			ProductCode: fmt.Sprintf("%04d", index),
+			RecordHash:  fmt.Sprintf("hash-%04d", index),
+		}
+	}
+	ctx := newCancelAfterChecksContext(12)
+	revision, err := sourceRevisionContext(ctx, products, nil, nil, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sourceRevisionContext error=%v, want context.Canceled", err)
+	}
+	if revision != "" {
+		t.Fatalf("cancelled source revision=%q, want empty", revision)
+	}
+}
+
+func TestEventIDContextMatchesLegacyJSONIdentity(t *testing.T) {
+	envelope := &Envelope{
+		Schema:        `patris.<sync>`,
+		EventType:     "snapshot",
+		LocalCurrency: "IRT",
+		FormulaID:     "landed&price",
+		Source: Source{
+			ID:       `source-"one"`,
+			Dataset:  "kala.db",
+			Revision: "sha256:revision",
+		},
+		GeneratedAt: "2026-07-24T00:00:00Z",
+		Products: []Product{
+			{ProductCode: "200", RecordHash: "hash-2"},
+			{ProductCode: "100", RecordHash: "hash-1"},
+		},
+		Categories: []Category{
+			{CategoryCode: "20", RecordHash: "category-2"},
+			{CategoryCode: "10", RecordHash: "category-1"},
+		},
+		ExcludedCodes:    []string{"999", "111"},
+		DeletedCodes:     []Tombstone{{ProductCode: "300", Deleted: true}, {ProductCode: "400", Deleted: false}},
+		QuarantinedCodes: nil,
+	}
+	productHashes := []string{"200=hash-2", "100=hash-1"}
+	categoryHashes := []string{"20=category-2", "10=category-1"}
+	sort.Strings(productHashes)
+	sort.Strings(categoryHashes)
+	legacyIdentity := struct {
+		Schema           string      `json:"schema"`
+		EventType        string      `json:"event_type"`
+		LocalCurrency    string      `json:"local_currency,omitempty"`
+		FormulaID        string      `json:"formula_id,omitempty"`
+		Source           Source      `json:"source"`
+		GeneratedAt      string      `json:"generated_at"`
+		Products         []string    `json:"products"`
+		Categories       []string    `json:"categories"`
+		ExcludedCodes    []string    `json:"excluded_codes"`
+		DeletedCodes     []Tombstone `json:"deleted_codes,omitempty"`
+		QuarantinedCodes []string    `json:"quarantined_codes"`
+	}{
+		Schema: envelope.Schema, EventType: envelope.EventType,
+		LocalCurrency: envelope.LocalCurrency, FormulaID: envelope.FormulaID,
+		Source: envelope.Source, GeneratedAt: envelope.GeneratedAt,
+		Products: productHashes, Categories: categoryHashes,
+		ExcludedCodes: envelope.ExcludedCodes, DeletedCodes: envelope.DeletedCodes,
+		QuarantinedCodes: envelope.QuarantinedCodes,
+	}
+	material, err := json.Marshal(legacyIdentity)
+	if err != nil {
+		t.Fatalf("marshal legacy identity: %v", err)
+	}
+	want := hashBytes(material)
+
+	got, err := eventIDContext(context.Background(), envelope)
+	if err != nil {
+		t.Fatalf("eventIDContext error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("event ID=%q, want %q; legacy=%s", got, want, material)
+	}
+}
+
+func TestEventIDContextCancelsDuringIdentityStreaming(t *testing.T) {
+	excluded := make([]string, 128)
+	for index := range excluded {
+		excluded[index] = fmt.Sprintf("excluded-%04d", index)
+	}
+	envelope := &Envelope{
+		Schema:           ContractName,
+		EventType:        "snapshot",
+		Source:           Source{ID: "source", Dataset: "kala.db", Revision: "sha256:revision"},
+		GeneratedAt:      "2026-07-24T00:00:00Z",
+		Products:         []Product{},
+		Categories:       []Category{},
+		ExcludedCodes:    excluded,
+		QuarantinedCodes: []string{},
+	}
+	// Empty product/category lists keep the pre-stream check count bounded; the
+	// cancellation threshold is reached while excluded_codes is being emitted.
+	ctx := newCancelAfterChecksContext(40)
+	value, err := eventIDContext(ctx, envelope)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("eventIDContext error=%v, want context.Canceled", err)
+	}
+	if value != "" {
+		t.Fatalf("cancelled event ID=%q, want empty", value)
+	}
+}

--- a/pkg/canonical/kala.go
+++ b/pkg/canonical/kala.go
@@ -99,6 +99,21 @@ type Category struct {
 }
 
 func Transform(ctx context.Context, rows []map[string]interface{}, source string, cfg Config, provider pricingcatalog.Provider, generatedAt time.Time) ([]map[string]interface{}, *Envelope) {
+	products, envelope, _ := TransformContext(ctx, rows, source, cfg, provider, generatedAt)
+	return products, envelope
+}
+
+// TransformContext builds the canonical snapshot while cooperatively honoring
+// cancellation throughout classification, category construction, pricing
+// dispatch, hashing, and row materialization. Transform remains the compatible
+// wrapper for existing unbounded callers.
+func TransformContext(ctx context.Context, rows []map[string]interface{}, source string, cfg Config, provider pricingcatalog.Provider, generatedAt time.Time) ([]map[string]interface{}, *Envelope, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	integrationActive := pricingcatalog.Configured(cfg.Pricing)
 	if provider == nil {
 		provider = pricingcatalog.NewProvider(cfg.Pricing)
@@ -106,28 +121,49 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 	products := make([]Product, 0, len(rows))
 	codeCounts := make(map[string]int, len(rows))
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		if code := codeString(firstValue(row, "product_code", "code", "Code")); code != "" {
 			codeCounts[code]++
 		}
 	}
 	duplicateCodes := make([]string, 0)
 	for code, count := range codeCounts {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		if count > 1 {
 			duplicateCodes = append(duplicateCodes, code)
 		}
 	}
 	sort.Strings(duplicateCodes)
-	categoryCodes, excludedCodes, ambiguousCodes := classifyKalaRows(rows, codeCounts)
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	categoryCodes, excludedCodes, ambiguousCodes, err := classifyKalaRowsContext(ctx, rows, codeCounts)
+	if err != nil {
+		return nil, nil, err
+	}
 	quarantined := normalizedWarnings(append(append([]string{}, duplicateCodes...), ambiguousCodes...))
-	categories := parseKalaCategories(rows, codeCounts, categoryCodes)
+	categories, err := parseKalaCategoriesContext(ctx, rows, codeCounts, categoryCodes)
+	if err != nil {
+		return nil, nil, err
+	}
 	categoryByCode := make(map[string]Category, len(categories))
 	for _, category := range categories {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		categoryByCode[category.CategoryCode] = category
 	}
 	quarantineSet := stringSet(quarantined)
 	excludedSet := stringSet(excludedCodes)
 	eligible := make([]int, 0, len(rows))
 	for index, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		code := codeString(firstValue(row, "product_code", "code", "Code"))
 		if code != "" && codeCounts[code] == 1 && !categoryCodes[code] && !quarantineSet[code] && !excludedSet[code] {
 			eligible = append(eligible, index)
@@ -136,9 +172,15 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 	if prefetcher, ok := provider.(pricingcatalog.Prefetcher); ok && len(eligible) > 0 {
 		codes := make([]string, 0, len(eligible))
 		for _, index := range eligible {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			codes = append(codes, codeString(firstValue(rows[index], "product_code", "code", "Code")))
 		}
 		provider = prefetcher.Prefetch(ctx, codes)
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 	}
 	parsedProducts := make([]Product, len(rows))
 	workers := 1
@@ -151,7 +193,13 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 	}
 	if workers <= 1 {
 		for _, index := range eligible {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			parsedProducts[index] = parseKalaProduct(ctx, rows[index], provider, integrationActive)
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 		}
 	} else {
 		jobs := make(chan int)
@@ -160,74 +208,139 @@ func Transform(ctx context.Context, rows []map[string]interface{}, source string
 		for worker := 0; worker < workers; worker++ {
 			go func() {
 				defer wait.Done()
-				for index := range jobs {
-					parsedProducts[index] = parseKalaProduct(ctx, rows[index], provider, integrationActive)
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case index, ok := <-jobs:
+						if !ok {
+							return
+						}
+						product := parseKalaProduct(ctx, rows[index], provider, integrationActive)
+						if ctx.Err() != nil {
+							return
+						}
+						parsedProducts[index] = product
+					}
 				}
 			}()
 		}
+	dispatch:
 		for _, index := range eligible {
-			jobs <- index
+			select {
+			case <-ctx.Done():
+				break dispatch
+			case jobs <- index:
+			}
 		}
 		close(jobs)
 		wait.Wait()
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 	}
 	for _, product := range parsedProducts {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		if product.ProductCode == "" {
 			continue
 		}
 		if codeCounts[product.ProductCode] > 1 {
 			continue
 		}
-		product.CategoryCode = longestCategoryPrefix(product.ProductCode, categoryByCode)
+		product.CategoryCode, err = longestCategoryPrefixContext(ctx, product.ProductCode, categoryByCode)
+		if err != nil {
+			return nil, nil, err
+		}
 		product.RecordHash = recordHash(product)
 		products = append(products, product)
 	}
 	sort.SliceStable(products, func(i, j int) bool {
 		return products[i].ProductCode < products[j].ProductCode
 	})
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	envelope := NewCatalogEnvelope(products, categories, excludedCodes, source, cfg.SourceID, generatedAt, quarantined...)
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if !integrationActive {
 		envelope.LocalCurrency = ""
 		envelope.FormulaID = ""
 	}
 	envelope.Warnings = nil
 	for _, code := range duplicateCodes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		envelope.Warnings = append(envelope.Warnings, "duplicate_product_code:"+code)
 	}
 	for _, code := range ambiguousCodes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		envelope.Warnings = append(envelope.Warnings, "ambiguous_catalog_record:"+code)
 	}
 	envelope.Warnings = normalizedWarnings(envelope.Warnings)
 	envelope.EventID = eventID(envelope)
-	return ProductsToRows(products), envelope
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	productRows, err := ProductsToRowsContext(ctx, products)
+	if err != nil {
+		return nil, nil, err
+	}
+	return productRows, envelope, nil
 }
 
 // classifyKalaRows applies the verified Patris hierarchy to the complete
 // snapshot. It deliberately fails closed for ambiguous numeric rows: category
 // headers and accounting/service entries must never become Woo products.
 func classifyKalaRows(rows []map[string]interface{}, codeCounts map[string]int) (map[string]bool, []string, []string) {
+	categories, excluded, quarantined, _ := classifyKalaRowsContext(context.Background(), rows, codeCounts)
+	return categories, excluded, quarantined
+}
+
+func classifyKalaRowsContext(ctx context.Context, rows []map[string]interface{}, codeCounts map[string]int) (map[string]bool, []string, []string, error) {
 	codes := make([]string, 0, len(codeCounts))
 	rowByCode := make(map[string]map[string]interface{}, len(rows))
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
 		code := codeString(firstValue(row, "product_code", "code", "Code"))
 		if code != "" && codeCounts[code] == 1 {
 			rowByCode[code] = row
 		}
 	}
 	for code := range codeCounts {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
 		codes = append(codes, code)
 	}
 	sort.Strings(codes)
+	if err := ctx.Err(); err != nil {
+		return nil, nil, nil, err
+	}
 
 	categories := make(map[string]bool)
 	excluded := make(map[string]bool)
 	quarantined := make(map[string]bool)
 	hasDescendant := make(map[string]bool)
 	for _, code := range codes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
 		if codeCounts[code] != 1 || len(code) != 6 || !asciiDigits(code) {
 			continue
 		}
 		for _, candidate := range codes {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, nil, err
+			}
 			if codeCounts[candidate] == 1 && len(candidate) == 9 && strings.HasPrefix(candidate, code) {
 				hasDescendant[code] = true
 				break
@@ -236,6 +349,9 @@ func classifyKalaRows(rows []map[string]interface{}, codeCounts map[string]int) 
 	}
 
 	for _, code := range codes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
 		if codeCounts[code] != 1 || !asciiDigits(code) {
 			continue
 		}
@@ -276,6 +392,9 @@ func classifyKalaRows(rows []map[string]interface{}, codeCounts map[string]int) 
 	// Do not require parents to be present here: filtered/partial extracts are a
 	// supported input, and their valid leaf products must remain exportable.
 	for _, code := range codes {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
 		if codeCounts[code] != 1 || !asciiDigits(code) || categories[code] || excluded[code] || quarantined[code] {
 			continue
 		}
@@ -284,7 +403,10 @@ func classifyKalaRows(rows []map[string]interface{}, codeCounts map[string]int) 
 		}
 	}
 
-	return categories, sortedSet(excluded), sortedSet(quarantined)
+	if err := ctx.Err(); err != nil {
+		return nil, nil, nil, err
+	}
+	return categories, sortedSet(excluded), sortedSet(quarantined), nil
 }
 
 func asciiDigits(value string) bool {
@@ -319,8 +441,16 @@ func sortedSet(values map[string]bool) []string {
 }
 
 func parseKalaCategories(rows []map[string]interface{}, codeCounts map[string]int, categoryCodes map[string]bool) []Category {
+	categories, _ := parseKalaCategoriesContext(context.Background(), rows, codeCounts, categoryCodes)
+	return categories
+}
+
+func parseKalaCategoriesContext(ctx context.Context, rows []map[string]interface{}, codeCounts map[string]int, categoryCodes map[string]bool) ([]Category, error) {
 	byCode := make(map[string]Category, len(categoryCodes))
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		code := codeString(firstValue(row, "product_code", "code", "Code"))
 		if code == "" || codeCounts[code] != 1 || !categoryCodes[code] {
 			continue
@@ -337,6 +467,9 @@ func parseKalaCategories(rows []map[string]interface{}, codeCounts map[string]in
 
 	codes := make([]string, 0, len(byCode))
 	for code := range byCode {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		codes = append(codes, code)
 	}
 	sort.SliceStable(codes, func(i, j int) bool {
@@ -345,12 +478,25 @@ func parseKalaCategories(rows []map[string]interface{}, codeCounts map[string]in
 		}
 		return codes[i] < codes[j]
 	})
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	for _, code := range codes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		category := byCode[code]
-		category.ParentCode = longestCategoryPrefix(code, byCode)
+		parent, err := longestCategoryPrefixContext(ctx, code, byCode)
+		if err != nil {
+			return nil, err
+		}
+		category.ParentCode = parent
 		category.Depth = 1
 		for parent := category.ParentCode; parent != ""; {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			category.Depth++
 			ancestor, exists := byCode[parent]
 			if !exists || ancestor.ParentCode == parent {
@@ -364,17 +510,31 @@ func parseKalaCategories(rows []map[string]interface{}, codeCounts map[string]in
 
 	categories := make([]Category, 0, len(codes))
 	for _, code := range codes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		categories = append(categories, byCode[code])
 	}
 	sort.SliceStable(categories, func(i, j int) bool {
 		return categories[i].CategoryCode < categories[j].CategoryCode
 	})
-	return categories
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return categories, nil
 }
 
 func longestCategoryPrefix(code string, categories map[string]Category) string {
+	parent, _ := longestCategoryPrefixContext(context.Background(), code, categories)
+	return parent
+}
+
+func longestCategoryPrefixContext(ctx context.Context, code string, categories map[string]Category) (string, error) {
 	parent := ""
 	for candidate := range categories {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		if len(candidate) >= len(code) || len(candidate) <= len(parent) {
 			continue
 		}
@@ -382,7 +542,7 @@ func longestCategoryPrefix(code string, categories map[string]Category) string {
 			parent = candidate
 		}
 	}
-	return parent
+	return parent, nil
 }
 
 func categoryHasStrongProductSignals(row map[string]interface{}) bool {
@@ -436,6 +596,9 @@ func emptyCategoryHeader(code string, row map[string]interface{}) bool {
 }
 
 func parseKalaProduct(ctx context.Context, row map[string]interface{}, provider pricingcatalog.Provider, integrationActive bool) Product {
+	if ctx != nil && ctx.Err() != nil {
+		return Product{}
+	}
 	warnings := naming.Merge(row[naming.InternalWarningsField], naming.Warnings(row))
 	code := codeString(firstValue(row, "product_code", "code", "Code"))
 	foreignPrice := extractForeignPrice(row, &warnings)
@@ -443,6 +606,9 @@ func parseKalaProduct(ctx context.Context, row map[string]interface{}, provider 
 	resolution := pricingcatalog.Resolution{}
 	if integrationActive {
 		resolution = provider.Resolve(ctx, code)
+		if ctx != nil && ctx.Err() != nil {
+			return Product{}
+		}
 		warnings = append(warnings, resolution.Warnings...)
 	}
 	warehouseStock, warehouseNulls := warehouseStock(row)
@@ -702,11 +868,27 @@ func recordHash(product Product) string {
 }
 
 func ProductsToRows(products []Product) []map[string]interface{} {
+	rows, _ := ProductsToRowsContext(context.Background(), products)
+	return rows
+}
+
+// ProductsToRowsContext materializes canonical row maps with cooperative
+// cancellation between products.
+func ProductsToRowsContext(ctx context.Context, products []Product) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	rows := make([]map[string]interface{}, 0, len(products))
 	for _, product := range products {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		rows = append(rows, product.Map())
 	}
-	return rows
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (category Category) Map() map[string]interface{} {

--- a/pkg/canonical/kala.go
+++ b/pkg/canonical/kala.go
@@ -262,8 +262,8 @@ func TransformContext(ctx context.Context, rows []map[string]interface{}, source
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
-	envelope := NewCatalogEnvelope(products, categories, excludedCodes, source, cfg.SourceID, generatedAt, quarantined...)
-	if err := ctx.Err(); err != nil {
+	envelope, err := newEnvelopeBaseContext(ctx, products, categories, excludedCodes, source, cfg.SourceID, generatedAt, quarantined...)
+	if err != nil {
 		return nil, nil, err
 	}
 	if !integrationActive {
@@ -283,9 +283,12 @@ func TransformContext(ctx context.Context, rows []map[string]interface{}, source
 		}
 		envelope.Warnings = append(envelope.Warnings, "ambiguous_catalog_record:"+code)
 	}
-	envelope.Warnings = normalizedWarnings(envelope.Warnings)
-	envelope.EventID = eventID(envelope)
-	if err := ctx.Err(); err != nil {
+	envelope.Warnings, err = normalizedWarningsContext(ctx, envelope.Warnings)
+	if err != nil {
+		return nil, nil, err
+	}
+	envelope.EventID, err = eventIDContext(ctx, envelope)
+	if err != nil {
 		return nil, nil, err
 	}
 	productRows, err := ProductsToRowsContext(ctx, products)
@@ -1536,8 +1539,19 @@ func formatOptionalTime(value time.Time) string {
 func floatPointer(value float64) *float64 { return &value }
 
 func normalizedWarnings(values []string) []string {
+	result, _ := normalizedWarningsContext(context.Background(), values)
+	return result
+}
+
+func normalizedWarningsContext(ctx context.Context, values []string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	set := map[string]struct{}{}
 	for _, value := range values {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		value = strings.TrimSpace(value)
 		if value != "" {
 			set[value] = struct{}{}
@@ -1545,10 +1559,15 @@ func normalizedWarnings(values []string) []string {
 	}
 	result := make([]string, 0, len(set))
 	for value := range set {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		result = append(result, value)
 	}
-	sort.Strings(result)
-	return result
+	if err := stableSortContext(ctx, result, func(left, right string) bool { return left < right }); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func hasAny(values []string, expected ...string) bool {

--- a/pkg/converter/exporter.go
+++ b/pkg/converter/exporter.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -137,11 +138,31 @@ func (e *Exporter) ExportToCSVWriter(records []paradox.Record, fields []paradox.
 // and order. Dataset profiles use it before Code-keyed shaping so duplicate
 // identifiers remain observable and can be quarantined safely.
 func (e *Exporter) ConvertRecords(records []paradox.Record) []paradox.Record {
+	converted, _ := e.ConvertRecordsContext(context.Background(), records)
+	return converted
+}
+
+// ConvertRecordsContext converts records while cooperatively honoring caller
+// cancellation between records and fields. The background wrapper above keeps
+// the established exporter API unchanged for unbounded CLI/file workflows.
+func (e *Exporter) ConvertRecordsContext(ctx context.Context, records []paradox.Record) ([]paradox.Record, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	converted := make([]paradox.Record, len(records))
 
 	for i, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		convertedRecord := make(paradox.Record)
 		for key, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			// Sort fields are internal Paradox indexes. Discard them before
 			// even inspecting/converting values to avoid needless work.
 			if IsSortField(key) {
@@ -161,7 +182,7 @@ func (e *Exporter) ConvertRecords(records []paradox.Record) []paradox.Record {
 		converted[i] = convertedRecord
 	}
 
-	return converted
+	return converted, nil
 }
 
 // ExportRecordsToString exports records to a JSON string
@@ -232,9 +253,25 @@ func (e *Exporter) TransformRecordsMap(records []map[string]interface{}) map[str
 // - Combine ANBAR fields into an array (sorted by number)
 // This method is used by both the file exporter and the web server to ensure consistent output.
 func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interface{} {
+	result, _ := e.TransformRecordsContext(context.Background(), records)
+	return result
+}
+
+// TransformRecordsContext shapes records while cooperatively honoring caller
+// cancellation between records, fields, and ANBAR materialization.
+func (e *Exporter) TransformRecordsContext(ctx context.Context, records []paradox.Record) (map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	result := make(map[string]interface{})
 
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		// Extract Code as the key
 		codeKey := ""
 		if code, ok := record["Code"]; ok {
@@ -250,6 +287,9 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 		maxAnbarIndex := 0
 
 		for key, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			// Skip Sort fields
 			if IsSortField(key) {
 				continue
@@ -283,6 +323,9 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 			// Build array with correct ordering (1-indexed fields -> 0-indexed array)
 			anbarValues := make([]interface{}, maxAnbarIndex)
 			for i := 1; i <= maxAnbarIndex; i++ {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 				if val, ok := anbarFields[i]; ok {
 					anbarValues[i-1] = val
 				} else {
@@ -295,7 +338,7 @@ func (e *Exporter) TransformRecords(records []paradox.Record) map[string]interfa
 		result[codeKey] = optimized
 	}
 
-	return result
+	return result, nil
 }
 
 func exportFields(fields []paradox.Field) []paradox.Field {

--- a/pkg/converter/transform_test.go
+++ b/pkg/converter/transform_test.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -261,5 +263,44 @@ func TestTransformRecordsSplitsMultilineDescriptions(t *testing.T) {
 	}
 	if want := []string{"one", "", "three"}; !reflect.DeepEqual(record["Sharh2"], want) {
 		t.Fatalf("Sharh2 = %#v, want %#v", record["Sharh2"], want)
+	}
+}
+
+func TestConvertRecordsContextStopsDuringConversion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	exp := NewExporter(func(value string) string {
+		calls++
+		if calls == 5 {
+			cancel()
+		}
+		return value
+	})
+	records := make([]paradox.Record, 100)
+	for index := range records {
+		records[index] = paradox.Record{"Code": "value"}
+	}
+
+	converted, err := exp.ConvertRecordsContext(ctx, records)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ConvertRecordsContext error=%v, want context.Canceled", err)
+	}
+	if converted != nil {
+		t.Fatalf("cancelled conversion returned partial records: %#v", converted)
+	}
+	if calls != 5 {
+		t.Fatalf("converter calls=%d, want prompt stop at cancellation", calls)
+	}
+}
+
+func TestTransformRecordsContextRejectsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	transformed, err := NewExporter(nil).TransformRecordsContext(ctx, []paradox.Record{{"Code": "100"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("TransformRecordsContext error=%v, want context.Canceled", err)
+	}
+	if transformed != nil {
+		t.Fatalf("cancelled transform returned a partial payload: %#v", transformed)
 	}
 }

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -1,8 +1,11 @@
 package datasource
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,6 +26,13 @@ type DataSource interface {
 	GetPath() string
 	// Close closes the data source
 	Close() error
+}
+
+// ContextDataSource cooperatively stops source preparation when a caller's
+// bounded operation is cancelled. DataSource remains backward compatible for
+// external implementations; the built-in sources implement both interfaces.
+type ContextDataSource interface {
+	GetRawRecordsContext(context.Context) ([]map[string]interface{}, error)
 }
 
 // ParadoxDataSource represents a Paradox database file
@@ -98,10 +108,23 @@ func (p *ParadoxDataSource) GetRecords() ([]map[string]interface{}, error) {
 // GetRawRecords implements DataSource for ParadoxDataSource without applying
 // encoding conversion, ANBAR compaction, Code-keying, or custom mapping.
 func (p *ParadoxDataSource) GetRawRecords() ([]map[string]interface{}, error) {
+	return p.GetRawRecordsContext(context.Background())
+}
+
+// GetRawRecordsContext implements cooperative cancellation for Paradox source
+// preparation. Individual native pxlib calls cannot be interrupted, but
+// cancellation is checked around each record/field call.
+func (p *ParadoxDataSource) GetRawRecordsContext(ctx context.Context) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	pathToOpen := p.path
 	cleanup := func() {}
 	if filecopy.IsURL(p.path) {
-		tempFileInfo, err := filecopy.DownloadToTemp(p.path)
+		tempFileInfo, err := filecopy.DownloadToTempContext(ctx, p.path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download database to temp: %w", err)
 		}
@@ -110,7 +133,7 @@ func (p *ParadoxDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 			filecopy.CleanupTemp(tempFileInfo.TempPath)
 		}
 	} else if p.useTempFile {
-		tempFileInfo, err := filecopy.CopyToTemp(p.path)
+		tempFileInfo, err := filecopy.CopyToTempContext(ctx, p.path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to copy database to temp: %w", err)
 		}
@@ -121,19 +144,27 @@ func (p *ParadoxDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 	}
 	defer cleanup()
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	db, err := paradox.Open(pathToOpen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 	defer db.Close()
 
-	records, err := db.GetRecords()
+	records, err := db.GetRecordsContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read records: %w", err)
 	}
 
 	result := make([]map[string]interface{}, 0, len(records))
-	for _, record := range records {
+	for index, record := range records {
+		if index%128 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		row := make(map[string]interface{}, len(record))
 		for key, value := range record {
 			row[key] = value
@@ -141,6 +172,9 @@ func (p *ParadoxDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 		result = append(result, row)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -161,10 +195,22 @@ func (j *JSONDataSource) GetRecords() ([]map[string]interface{}, error) {
 
 // GetRawRecords implements DataSource for JSONDataSource.
 func (j *JSONDataSource) GetRawRecords() ([]map[string]interface{}, error) {
+	return j.GetRawRecordsContext(context.Background())
+}
+
+// GetRawRecordsContext implements cooperative cancellation for JSON download,
+// file reading, parsing boundaries, and row materialization.
+func (j *JSONDataSource) GetRawRecordsContext(ctx context.Context) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	pathToRead := j.path
 	cleanup := func() {}
 	if filecopy.IsURL(j.path) {
-		tempFileInfo, err := filecopy.DownloadToTemp(j.path)
+		tempFileInfo, err := filecopy.DownloadToTempContext(ctx, j.path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download JSON to temp: %w", err)
 		}
@@ -175,16 +221,22 @@ func (j *JSONDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 	}
 	defer cleanup()
 
-	data, err := os.ReadFile(pathToRead)
+	data, err := readFileContext(ctx, pathToRead)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read JSON file: %w", err)
 	}
 
 	var rows []map[string]interface{}
 	if err := json.Unmarshal(data, &rows); err == nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
 		return rows, nil
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	var result map[string]interface{}
 	if err := json.Unmarshal(data, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
@@ -193,7 +245,14 @@ func (j *JSONDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 	// The JSON file should match the transformed format with Code as keys
 	// Extract records from the map
 	records := make([]map[string]interface{}, 0, len(result))
+	index := 0
 	for code, value := range result {
+		if index%128 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		index++
 		if recordMap, ok := value.(map[string]interface{}); ok {
 			row := make(map[string]interface{}, len(recordMap)+1)
 			if _, hasCode := recordMap["Code"]; !hasCode {
@@ -206,7 +265,41 @@ func (j *JSONDataSource) GetRawRecords() ([]map[string]interface{}, error) {
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return records, nil
+}
+
+func readFileContext(ctx context.Context, path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var buffer bytes.Buffer
+	chunk := make([]byte, 64*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		read, readErr := file.Read(chunk)
+		if read > 0 {
+			if _, err := buffer.Write(chunk[:read]); err != nil {
+				return nil, err
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				return buffer.Bytes(), nil
+			}
+			return nil, readErr
+		}
+	}
 }
 
 // GetPath implements DataSource for JSONDataSource

--- a/pkg/datasource/datasource_test.go
+++ b/pkg/datasource/datasource_test.go
@@ -1,0 +1,36 @@
+package datasource
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuiltInSourcesImplementContextDataSource(t *testing.T) {
+	var _ ContextDataSource = (*JSONDataSource)(nil)
+	var _ ContextDataSource = (*ParadoxDataSource)(nil)
+}
+
+func TestJSONDataSourceHonorsPreCancelledContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "products.json")
+	if err := os.WriteFile(path, []byte(`[{"Code":"001"}]`), 0o600); err != nil {
+		t.Fatalf("write JSON source: %v", err)
+	}
+	source := &JSONDataSource{path: path}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := source.GetRawRecordsContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled JSON source error=%v, want context.Canceled", err)
+	}
+}
+
+func TestParadoxDataSourceHonorsPreCancelledContextBeforeNativeOpen(t *testing.T) {
+	source := &ParadoxDataSource{path: filepath.Join(t.TempDir(), "missing.db")}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := source.GetRawRecordsContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled Paradox source error=%v, want context.Canceled", err)
+	}
+}

--- a/pkg/filecopy/filecopy.go
+++ b/pkg/filecopy/filecopy.go
@@ -1,6 +1,7 @@
 package filecopy
 
 import (
+	"context"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -164,6 +165,19 @@ func CalculateHash(filePath string) (string, error) {
 // in a single pass for efficiency. Returns information about the copied file.
 // The source file is opened in read-only mode (os.Open uses O_RDONLY by default).
 func CopyToTemp(sourcePath string) (*FileInfo, error) {
+	return CopyToTempContext(context.Background(), sourcePath)
+}
+
+// CopyToTempContext is CopyToTemp with cooperative cancellation between
+// bounded copy chunks. A single operating-system file read may still complete
+// before cancellation is observed.
+func CopyToTempContext(ctx context.Context, sourcePath string) (*FileInfo, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// Get file info
 	sourceInfo, err := os.Stat(sourcePath)
 	if err != nil {
@@ -197,17 +211,22 @@ func CopyToTemp(sourcePath string) (*FileInfo, error) {
 	tempFileName := fmt.Sprintf("%s.%08x", baseName, pathHash)
 	tempPath := filepath.Join(tempDir, tempFileName)
 
-	// Open/create destination file
-	dest, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	// Write a unique sibling and publish it only after the complete copy is
+	// durable. Cancellation or failure must never truncate the last stable
+	// snapshot that another reader may still be using.
+	dest, err := os.CreateTemp(tempDir, "."+baseName+".partial-*")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
+		return nil, fmt.Errorf("failed to create staging temp file: %w", err)
 	}
-
-	// Ensure destination is closed properly, handling any write errors
-	var closeErr error
+	stagingPath := dest.Name()
+	closed := false
+	committed := false
 	defer func() {
-		if cerr := dest.Close(); cerr != nil && closeErr == nil {
-			closeErr = cerr
+		if !closed {
+			_ = dest.Close()
+		}
+		if !committed {
+			_ = os.Remove(stagingPath)
 		}
 	}()
 
@@ -215,12 +234,18 @@ func CopyToTemp(sourcePath string) (*FileInfo, error) {
 	hash := crc32.NewIEEE()
 	buffer := make([]byte, ChunkSize)
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		n, readErr := source.Read(buffer)
 		if readErr != nil && readErr != io.EOF {
 			return nil, fmt.Errorf("failed to read from source: %w", readErr)
 		}
 		if n == 0 {
 			break
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 
 		// Update hash
@@ -230,21 +255,33 @@ func CopyToTemp(sourcePath string) (*FileInfo, error) {
 
 		// Write to destination
 		if _, err := dest.Write(buffer[:n]); err != nil {
-			closeErr = err
 			return nil, fmt.Errorf("failed to write to temp file: %w", err)
 		}
 	}
 
-	// Check for deferred close errors
-	if closeErr != nil {
-		return nil, fmt.Errorf("failed to close temp file: %w", closeErr)
+	if err := dest.Sync(); err != nil {
+		return nil, fmt.Errorf("failed to sync temp file: %w", err)
 	}
+	if err := dest.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temp file: %w", err)
+	}
+	closed = true
 
 	// Preserve modification time
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	modTime := sourceInfo.ModTime()
-	if err := os.Chtimes(tempPath, time.Now(), modTime); err != nil {
+	if err := os.Chtimes(stagingPath, time.Now(), modTime); err != nil {
 		return nil, fmt.Errorf("failed to set modification time: %w", err)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := replaceFileAtomic(stagingPath, tempPath); err != nil {
+		return nil, fmt.Errorf("failed to publish temp file: %w", err)
+	}
+	committed = true
 
 	return &FileInfo{
 		SourcePath: sourcePath,
@@ -281,6 +318,18 @@ func IsURL(path string) bool {
 // directory. The temp filename is stable for the URL so polling and repeated
 // reads reuse the same location while still refreshing the content.
 func DownloadToTemp(sourceURL string) (*FileInfo, error) {
+	return DownloadToTempContext(context.Background(), sourceURL)
+}
+
+// DownloadToTempContext is DownloadToTemp with caller cancellation propagated
+// through the HTTP request and response-body copy.
+func DownloadToTempContext(ctx context.Context, sourceURL string) (*FileInfo, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	u, err := url.Parse(strings.TrimSpace(sourceURL))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
@@ -296,7 +345,7 @@ func DownloadToTemp(sourceURL string) (*FileInfo, error) {
 
 	urlHash := crc32.ChecksumIEEE([]byte(sourceURL))
 
-	req, err := http.NewRequest(http.MethodGet, sourceURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -318,35 +367,54 @@ func DownloadToTemp(sourceURL string) (*FileInfo, error) {
 	}
 	tempPath := filepath.Join(tempDir, fmt.Sprintf("%s.%08x", baseName, urlHash))
 
-	dest, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	dest, err := os.CreateTemp(tempDir, "."+baseName+".partial-*")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
+		return nil, fmt.Errorf("failed to create staging temp file: %w", err)
 	}
-
-	var closeErr error
+	stagingPath := dest.Name()
+	closed := false
+	committed := false
 	defer func() {
-		if cerr := dest.Close(); cerr != nil && closeErr == nil {
-			closeErr = cerr
+		if !closed {
+			_ = dest.Close()
+		}
+		if !committed {
+			_ = os.Remove(stagingPath)
 		}
 	}()
 
 	hash := crc32.NewIEEE()
 	written, err := io.CopyBuffer(io.MultiWriter(dest, hash), resp.Body, make([]byte, ChunkSize))
 	if err != nil {
-		closeErr = err
 		return nil, fmt.Errorf("failed to write downloaded file: %w", err)
 	}
-	if closeErr != nil {
-		return nil, fmt.Errorf("failed to close temp file: %w", closeErr)
+	if err := dest.Sync(); err != nil {
+		return nil, fmt.Errorf("failed to sync downloaded file: %w", err)
+	}
+	if err := dest.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close downloaded file: %w", err)
+	}
+	closed = true
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	modTime := time.Now()
 	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
 		if parsed, err := http.ParseTime(lastModified); err == nil {
 			modTime = parsed
-			_ = os.Chtimes(tempPath, time.Now(), modTime)
 		}
 	}
+	if err := os.Chtimes(stagingPath, time.Now(), modTime); err != nil {
+		return nil, fmt.Errorf("failed to set downloaded file modification time: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := replaceFileAtomic(stagingPath, tempPath); err != nil {
+		return nil, fmt.Errorf("failed to publish downloaded file: %w", err)
+	}
+	committed = true
 
 	return &FileInfo{
 		SourcePath: sourceURL,

--- a/pkg/filecopy/filecopy_test.go
+++ b/pkg/filecopy/filecopy_test.go
@@ -1,11 +1,14 @@
 package filecopy
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -340,5 +343,81 @@ func TestDownloadToTemp(t *testing.T) {
 	}
 	if string(got) != string(content) {
 		t.Fatalf("downloaded content mismatch: %q", got)
+	}
+}
+
+func TestDownloadToTempContextCancelsWithoutPartialFile(t *testing.T) {
+	tempRoot := t.TempDir()
+	SetTempDir(tempRoot)
+	defer SetTempDir("")
+
+	requestStarted := make(chan struct{})
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if calls.Add(1) == 1 {
+			_, _ = response.Write([]byte("last-known-good"))
+			return
+		}
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write([]byte("partial-replacement"))
+		if flusher, ok := response.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(requestStarted)
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	stable, err := DownloadToTemp(server.URL + "/delayed.db")
+	if err != nil {
+		t.Fatalf("create last-known-good download: %v", err)
+	}
+	defer CleanupTemp(stable.TempPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := DownloadToTempContext(ctx, server.URL+"/delayed.db")
+		done <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("delayed download did not start")
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("cancelled download error=%v, want context deadline", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled download did not return promptly")
+	}
+	content, err := os.ReadFile(stable.TempPath)
+	if err != nil {
+		t.Fatalf("read stable download after cancellation: %v", err)
+	}
+	if string(content) != "last-known-good" {
+		t.Fatalf("cancelled replacement changed stable download: %q", content)
+	}
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		t.Fatalf("read temp root: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(stable.TempPath) {
+		t.Fatalf("cancelled download left partial files: %#v", entries)
+	}
+}
+
+func TestCopyToTempContextRejectsPreCancelledRequest(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.db")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := CopyToTempContext(ctx, source); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled copy error=%v, want context.Canceled", err)
 	}
 }

--- a/pkg/filecopy/replace_unix.go
+++ b/pkg/filecopy/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package filecopy
+
+import "os"
+
+func replaceFileAtomic(source, destination string) error {
+	return os.Rename(source, destination)
+}

--- a/pkg/filecopy/replace_windows.go
+++ b/pkg/filecopy/replace_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package filecopy
+
+import "golang.org/x/sys/windows"
+
+func replaceFileAtomic(source, destination string) error {
+	sourceUTF16, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	destinationUTF16, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		sourceUTF16,
+		destinationUTF16,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/pkg/paradox/native.go
+++ b/pkg/paradox/native.go
@@ -1,6 +1,7 @@
 package paradox
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -198,16 +199,33 @@ func (db *Database) GetFields() ([]Field, error) {
 
 // GetRecords returns all records from the database.
 func (db *Database) GetRecords() ([]Record, error) {
+	return db.GetRecordsContext(context.Background())
+}
+
+// GetRecordsContext returns all records while checking cancellation between
+// native calls and decoded fields. A single pxlib call is not interruptible,
+// but it is the smallest unbounded unit and no background goroutine survives a
+// cancelled request.
+func (db *Database) GetRecordsContext(ctx context.Context) ([]Record, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 	defer runtime.KeepAlive(db)
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if db.pxdoc == nil {
 		return nil, fmt.Errorf("database is not open")
 	}
 
 	numRecords, err := nonNegativeNativeCount("record", db.lib.pxGetNumRecords(db.pxdoc))
 	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	numFields, err := nativeFieldCount(db.lib.pxGetNumFields(db.pxdoc))
@@ -217,9 +235,15 @@ func (db *Database) GetRecords() ([]Record, error) {
 	records := make([]Record, 0, numRecords)
 
 	for i := 0; i < numRecords; i++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		valuesPtr := db.lib.pxRetrieveRecord(db.pxdoc, int32(i))
 		if valuesPtr == nil {
 			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 
 		values, err := nativeRecordValues(valuesPtr, numFields)
@@ -229,6 +253,9 @@ func (db *Database) GetRecords() ([]Record, error) {
 		record := make(Record)
 
 		for j := 0; j < numFields; j++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			fieldMeta := db.lib.pxGetField(db.pxdoc, int32(j))
 			if values[j] == nil {
 				continue
@@ -255,6 +282,9 @@ func (db *Database) GetRecords() ([]Record, error) {
 		records = append(records, record)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return records, nil
 }
 

--- a/pkg/recordmap/mapping.go
+++ b/pkg/recordmap/mapping.go
@@ -1,6 +1,7 @@
 package recordmap
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -135,16 +136,35 @@ func Effective(cfg Config, source string) Config {
 }
 
 func Apply(records []map[string]interface{}, cfg Config, source string) []map[string]interface{} {
+	out, _ := ApplyContext(context.Background(), records, cfg, source)
+	return out
+}
+
+// ApplyContext applies mapping rules while checking cancellation between
+// records, fields, and defaults. Existing unbounded callers retain Apply.
+func ApplyContext(ctx context.Context, records []map[string]interface{}, cfg Config, source string) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	effective := Effective(cfg, source)
 	if !effective.Enabled {
-		return CopyRows(records)
+		return CopyRowsContext(ctx, records)
 	}
 	include := stringSet(effective.Include)
 	drop := stringSet(effective.Drop)
 	out := make([]map[string]interface{}, 0, len(records))
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		next := map[string]interface{}{}
 		for key, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if len(include) > 0 && !include[key] {
 				continue
 			}
@@ -152,8 +172,14 @@ func Apply(records []map[string]interface{}, cfg Config, source string) []map[st
 				continue
 			}
 			value = mapValue(value, effective.Values[key])
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if rule, ok := effective.Numeric[key]; ok {
 				value = applyNumeric(value, rule)
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 			}
 			dest := key
 			if renamed := strings.TrimSpace(effective.Fields[key]); renamed != "" {
@@ -162,13 +188,19 @@ func Apply(records []map[string]interface{}, cfg Config, source string) []map[st
 			next[dest] = value
 		}
 		for key, value := range effective.Defaults {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if _, exists := next[key]; !exists {
 				next[key] = value
 			}
 		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		out = append(out, next)
 	}
-	return out
+	return out, nil
 }
 
 func KeyField(cfg Config, source string) string {
@@ -180,17 +212,38 @@ func KeyField(cfg Config, source string) string {
 }
 
 func Keyed(records []map[string]interface{}, keyField string, omitKey bool) map[string]interface{} {
+	result, _ := KeyedContext(context.Background(), records, keyField, omitKey)
+	return result
+}
+
+// KeyedContext builds a keyed payload while honoring caller cancellation.
+func KeyedContext(ctx context.Context, records []map[string]interface{}, keyField string, omitKey bool) (map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if strings.TrimSpace(keyField) == "" {
 		keyField = "Code"
 	}
 	result := make(map[string]interface{}, len(records))
 	for index, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := strings.TrimSpace(fmt.Sprintf("%v", record[keyField]))
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if key == "" || key == "<nil>" {
 			key = fmt.Sprintf("row-%d", index+1)
 		}
 		value := map[string]interface{}{}
 		for field, fieldValue := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if omitKey && field == keyField {
 				continue
 			}
@@ -198,19 +251,37 @@ func Keyed(records []map[string]interface{}, keyField string, omitKey bool) map[
 		}
 		result[key] = value
 	}
-	return result
+	return result, nil
 }
 
 func CopyRows(records []map[string]interface{}) []map[string]interface{} {
+	out, _ := CopyRowsContext(context.Background(), records)
+	return out
+}
+
+// CopyRowsContext copies row maps while honoring caller cancellation.
+func CopyRowsContext(ctx context.Context, records []map[string]interface{}) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	out := make([]map[string]interface{}, 0, len(records))
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		next := make(map[string]interface{}, len(record))
 		for key, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			next[key] = value
 		}
 		out = append(out, next)
 	}
-	return out
+	return out, nil
 }
 
 func Fields(records []map[string]interface{}, keyField string) []string {

--- a/pkg/recordmap/mapping_context_test.go
+++ b/pkg/recordmap/mapping_context_test.go
@@ -1,0 +1,51 @@
+package recordmap
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type cancellingStringer struct {
+	cancel context.CancelFunc
+}
+
+func (value cancellingStringer) String() string {
+	value.cancel()
+	return "cancel-now"
+}
+
+func TestApplyContextStopsWhenMappingCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rows := []map[string]interface{}{{
+		"Code":  "100",
+		"Value": cancellingStringer{cancel: cancel},
+	}}
+	cfg := Config{
+		Enabled: true,
+		Values: map[string]ValueMap{
+			"Value": {"cancel-now": "mapped"},
+		},
+	}
+
+	mapped, err := ApplyContext(ctx, rows, cfg, "products")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ApplyContext error=%v, want context.Canceled", err)
+	}
+	if mapped != nil {
+		t.Fatalf("cancelled mapping returned partial rows: %#v", mapped)
+	}
+}
+
+func TestKeyedAndCopyRowsContextRejectCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rows := []map[string]interface{}{{"Code": "100"}}
+
+	if keyed, err := KeyedContext(ctx, rows, "Code", true); !errors.Is(err, context.Canceled) || keyed != nil {
+		t.Fatalf("KeyedContext result=%#v error=%v, want nil/context.Canceled", keyed, err)
+	}
+	if copied, err := CopyRowsContext(ctx, rows); !errors.Is(err, context.Canceled) || copied != nil {
+		t.Fatalf("CopyRowsContext result=%#v error=%v, want nil/context.Canceled", copied, err)
+	}
+}

--- a/pkg/recordpipe/pipeline.go
+++ b/pkg/recordpipe/pipeline.go
@@ -37,8 +37,17 @@ func Build(rawRows []map[string]interface{}, source string, options Options) Res
 }
 
 func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source string, options Options) Result {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ctx.Err() != nil {
+		return Result{}
+	}
 	if options.Raw {
-		rows := copyRowsWithoutSortFields(rawRows)
+		rows, err := copyRowsWithoutSortFieldsContext(ctx, rawRows)
+		if err != nil {
+			return Result{}
+		}
 		return Result{
 			Rows:     rows,
 			Payload:  rows,
@@ -47,17 +56,33 @@ func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source 
 		}
 	}
 
-	records := mapsToParadox(rawRows)
+	records, err := mapsToParadoxContext(ctx, rawRows)
+	if err != nil {
+		return Result{}
+	}
 	exp := converter.NewExporter(converter.Patris2Fa)
 	if _, ok := canonical.ProfileFor(source, options.Canonical); ok {
-		rows := paradoxToRows(exp.ConvertRecords(records))
+		converted, err := exp.ConvertRecordsContext(ctx, records)
+		if err != nil {
+			return Result{}
+		}
+		rows, err := paradoxToRowsContext(ctx, converted)
+		if err != nil {
+			return Result{}
+		}
 		for index, row := range rows {
+			if ctx.Err() != nil {
+				return Result{}
+			}
 			warnings := naming.Merge(nil, append(naming.Warnings(rawRows[index]), naming.Warnings(row)...))
 			if len(warnings) > 0 {
 				row[naming.InternalWarningsField] = warnings
 			}
 		}
-		rows, contract := canonical.Transform(ctx, rows, source, options.Canonical, options.CatalogProvider, options.GeneratedAt)
+		rows, contract, err := canonical.TransformContext(ctx, rows, source, options.Canonical, options.CatalogProvider, options.GeneratedAt)
+		if err != nil {
+			return Result{}
+		}
 		return Result{
 			Rows:     rows,
 			Payload:  contract,
@@ -66,30 +91,57 @@ func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source 
 			Contract: contract,
 		}
 	}
-	converted := exp.ConvertRecords(records)
+	converted, err := exp.ConvertRecordsContext(ctx, records)
+	if err != nil {
+		return Result{}
+	}
 	namingWarningsByCode := make(map[string][]string, len(converted))
 	for index, record := range converted {
+		if ctx.Err() != nil {
+			return Result{}
+		}
 		code := fmt.Sprint(record["Code"])
 		convertedRow := make(map[string]interface{}, len(record))
 		for field, value := range record {
+			if ctx.Err() != nil {
+				return Result{}
+			}
 			convertedRow[field] = value
 		}
 		namingWarningsByCode[code] = naming.Merge(namingWarningsByCode[code], append(naming.Warnings(rawRows[index]), naming.Warnings(convertedRow)...))
 	}
-	keyed := exp.TransformRecords(converted)
-	rows := rowsFromKeyed(keyed, "Code")
+	keyed, err := exp.TransformRecordsContext(ctx, converted)
+	if err != nil {
+		return Result{}
+	}
+	rows, err := rowsFromKeyedContext(ctx, keyed, "Code")
+	if err != nil {
+		return Result{}
+	}
 	namingWarnings := make([][]string, len(rows))
 	for index, row := range rows {
+		if ctx.Err() != nil {
+			return Result{}
+		}
 		namingWarnings[index] = naming.Merge(namingWarningsByCode[fmt.Sprint(row["Code"])], naming.Warnings(row))
 	}
-	rows = recordmap.Apply(rows, options.Mapping, source)
+	rows, err = recordmap.ApplyContext(ctx, rows, options.Mapping, source)
+	if err != nil {
+		return Result{}
+	}
 	for index, warnings := range namingWarnings {
+		if ctx.Err() != nil {
+			return Result{}
+		}
 		if len(warnings) > 0 {
 			rows[index]["warnings"] = naming.Merge(rows[index]["warnings"], warnings)
 		}
 	}
 	keyField := recordmap.KeyField(options.Mapping, source)
-	payload := recordmap.Keyed(rows, keyField, true)
+	payload, err := recordmap.KeyedContext(ctx, rows, keyField, true)
+	if err != nil {
+		return Result{}
+	}
 	return Result{
 		Rows:     rows,
 		Payload:  payload,
@@ -99,29 +151,51 @@ func BuildContext(ctx context.Context, rawRows []map[string]interface{}, source 
 }
 
 func copyRowsWithoutSortFields(records []map[string]interface{}) []map[string]interface{} {
+	rows, _ := copyRowsWithoutSortFieldsContext(context.Background(), records)
+	return rows
+}
+
+func copyRowsWithoutSortFieldsContext(ctx context.Context, records []map[string]interface{}) ([]map[string]interface{}, error) {
 	rows := make([]map[string]interface{}, 0, len(records))
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		row := make(map[string]interface{}, len(record))
 		for field, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if !converter.IsSortField(field) {
 				row[field] = value
 			}
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
 }
 
 func paradoxToRows(records []paradox.Record) []map[string]interface{} {
+	rows, _ := paradoxToRowsContext(context.Background(), records)
+	return rows
+}
+
+func paradoxToRowsContext(ctx context.Context, records []paradox.Record) ([]map[string]interface{}, error) {
 	rows := make([]map[string]interface{}, 0, len(records))
 	for _, record := range records {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		row := make(map[string]interface{}, len(record))
 		for key, value := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			row[key] = value
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
 }
 
 func (result Result) SyncEnvelope(changes *recorddiff.ChangeSet) *canonical.Envelope {
@@ -184,23 +258,42 @@ func SourceTableName(source string) string {
 }
 
 func mapsToParadox(rows []map[string]interface{}) []paradox.Record {
+	records, _ := mapsToParadoxContext(context.Background(), rows)
+	return records
+}
+
+func mapsToParadoxContext(ctx context.Context, rows []map[string]interface{}) ([]paradox.Record, error) {
 	records := make([]paradox.Record, 0, len(rows))
 	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		record := paradox.Record{}
 		for key, value := range row {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			record[key] = value
 		}
 		records = append(records, record)
 	}
-	return records
+	return records, nil
 }
 
 func rowsFromKeyed(keyed map[string]interface{}, keyField string) []map[string]interface{} {
+	rows, _ := rowsFromKeyedContext(context.Background(), keyed, keyField)
+	return rows
+}
+
+func rowsFromKeyedContext(ctx context.Context, keyed map[string]interface{}, keyField string) ([]map[string]interface{}, error) {
 	if keyField == "" {
 		keyField = "Code"
 	}
 	rows := make([]map[string]interface{}, 0, len(keyed))
 	for key, value := range keyed {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		record, ok := value.(map[string]interface{})
 		if !ok {
 			continue
@@ -208,11 +301,14 @@ func rowsFromKeyed(keyed map[string]interface{}, keyField string) []map[string]i
 		row := make(map[string]interface{}, len(record)+1)
 		row[keyField] = key
 		for field, fieldValue := range record {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			row[field] = fieldValue
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
 }
 
 func sanitizeIdentifier(value string) string {

--- a/pkg/recordpipe/pipeline_test.go
+++ b/pkg/recordpipe/pipeline_test.go
@@ -1,7 +1,9 @@
 package recordpipe
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -17,6 +19,15 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 )
+
+type cancellingMappedValue struct {
+	cancel context.CancelFunc
+}
+
+func (value cancellingMappedValue) String() string {
+	value.cancel()
+	return "cancel-now"
+}
 
 func TestBuildRawSkipsTransformAndMapping(t *testing.T) {
 	rows := []map[string]interface{}{{"Code": "100", "Name": "Raw", "ANBAR1": 2, "Sort": "ignored", "SortCode": "ignored too"}}
@@ -46,6 +57,40 @@ func TestBuildRawSkipsTransformAndMapping(t *testing.T) {
 	}
 	if _, exists := result.Rows[0]["warnings"]; exists {
 		t.Fatal("raw mode must not add derived naming warnings")
+	}
+}
+
+func TestBuildContextStopsDuringNonCanonicalMapping(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	result := BuildContext(ctx, []map[string]interface{}{{
+		"Code":  "100",
+		"Name":  "Product",
+		"Value": cancellingMappedValue{cancel: cancel},
+	}}, "products.db", Options{
+		Mapping: recordmap.Config{
+			Enabled: true,
+			Values: map[string]recordmap.ValueMap{
+				"Value": {"cancel-now": "mapped"},
+			},
+		},
+	})
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("context error=%v, want context.Canceled", ctx.Err())
+	}
+	if result.Rows != nil || result.Payload != nil || result.Contract != nil || result.KeyField != "" {
+		t.Fatalf("cancelled BuildContext returned partial output: %#v", result)
+	}
+}
+
+func TestBuildContextRejectsPreCancelledRawProjection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := BuildContext(ctx, []map[string]interface{}{{"Code": "100"}}, "products.db", Options{Raw: true})
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("context error=%v, want context.Canceled", ctx.Err())
+	}
+	if result.Rows != nil || result.Payload != nil {
+		t.Fatalf("pre-cancelled raw projection returned output: %#v", result)
 	}
 }
 

--- a/pkg/recordsink/mysql_target.go
+++ b/pkg/recordsink/mysql_target.go
@@ -79,7 +79,7 @@ func ProbeSQLTarget(ctx context.Context, options SQLOptions) (SQLProbeResult, er
 
 	connectCtx, cancel := sqlConnectContext(ctx, options.ConnectTimeout)
 	defer cancel()
-	db, err := openSQLTarget(options)
+	db, err := openSQLTarget(connectCtx, options)
 	if err != nil {
 		result.ElapsedMS = time.Since(started).Milliseconds()
 		return result, err
@@ -138,7 +138,7 @@ func ProbeSQLDB(ctx context.Context, db *sql.DB, driverName string) (result SQLP
 	return result, nil
 }
 
-func openSQLTarget(options SQLOptions) (*sql.DB, error) {
+func openSQLTarget(ctx context.Context, options SQLOptions) (*sql.DB, error) {
 	driverName := normalizedSQLDriver(options.Driver)
 	if strings.TrimSpace(options.DSN) == "" {
 		return nil, ClassifySQLError(SQLStageConfiguration, errors.New("SQL DSN is required"))
@@ -151,7 +151,7 @@ func openSQLTarget(options SQLOptions) (*sql.DB, error) {
 		return db, nil
 	}
 
-	config, err := mysqlConnectorConfig(options)
+	config, err := mysqlConnectorConfig(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,12 @@ func openSQLTarget(options SQLOptions) (*sql.DB, error) {
 	return sql.OpenDB(connector), nil
 }
 
-func mysqlConnectorConfig(options SQLOptions) (*mysql.Config, error) {
+func mysqlConnectorConfig(ctx context.Context, options SQLOptions) (*mysql.Config, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, ClassifySQLError(SQLStageConnect, err)
+		}
+	}
 	config, err := mysql.ParseDSN(options.DSN)
 	if err != nil {
 		return nil, ClassifySQLError(SQLStageConfiguration, err)
@@ -174,20 +179,46 @@ func mysqlConnectorConfig(options SQLOptions) (*mysql.Config, error) {
 	tlsOptions := options.MySQLTLS
 	tlsOptions.CAFile = strings.TrimSpace(tlsOptions.CAFile)
 	tlsOptions.ServerName = strings.TrimSpace(tlsOptions.ServerName)
-	if tlsOptions.CAFile == "" && tlsOptions.ServerName == "" {
-		return config, nil
+	if tlsOptions.CAFile != "" || tlsOptions.ServerName != "" {
+		tlsConfig, err := verifiedMySQLTLSConfig(tlsOptions)
+		if err != nil {
+			return nil, ClassifySQLError(SQLStageTLS, err)
+		}
+		// A protected CA/server-name setting always selects verified TLS and
+		// disables any plaintext fallback or insecure mode present in the DSN.
+		config.TLSConfig = ""
+		config.TLS = tlsConfig
+		config.AllowFallbackToPlaintext = false
 	}
 
-	tlsConfig, err := verifiedMySQLTLSConfig(tlsOptions)
-	if err != nil {
-		return nil, ClassifySQLError(SQLStageTLS, err)
+	if remaining, bounded := contextDeadlineRemaining(ctx); bounded {
+		if remaining <= 0 {
+			return nil, ClassifySQLError(SQLStageConnect, context.DeadlineExceeded)
+		}
+		config.Timeout = capSQLDriverTimeout(config.Timeout, remaining)
+		config.ReadTimeout = capSQLDriverTimeout(config.ReadTimeout, remaining)
+		config.WriteTimeout = capSQLDriverTimeout(config.WriteTimeout, remaining)
 	}
-	// A protected CA/server-name setting always selects verified TLS and
-	// disables any plaintext fallback or insecure mode present in the DSN.
-	config.TLSConfig = ""
-	config.TLS = tlsConfig
-	config.AllowFallbackToPlaintext = false
 	return config, nil
+}
+
+func contextDeadlineRemaining(ctx context.Context) (time.Duration, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	deadline, bounded := ctx.Deadline()
+	if !bounded {
+		return 0, false
+	}
+	remaining := time.Until(deadline)
+	return remaining, true
+}
+
+func capSQLDriverTimeout(configured, remaining time.Duration) time.Duration {
+	if configured <= 0 || configured > remaining {
+		return remaining
+	}
+	return configured
 }
 
 func verifiedMySQLTLSConfig(options MySQLTLSOptions) (*tls.Config, error) {

--- a/pkg/recordsink/mysql_target_test.go
+++ b/pkg/recordsink/mysql_target_test.go
@@ -32,7 +32,7 @@ func TestMySQLConnectorConfigUsesVerifiedCustomCAAndBoundedTimeout(t *testing.T)
 			ServerName: "mysql.service.internal",
 		},
 	}
-	config, err := mysqlConnectorConfig(options)
+	config, err := mysqlConnectorConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestMySQLConnectorConfigUsesVerifiedCustomCAAndBoundedTimeout(t *testing.T)
 }
 
 func TestMySQLConnectorConfigRespectsExplicitDSNTimeoutWithoutCustomTLS(t *testing.T) {
-	config, err := mysqlConnectorConfig(SQLOptions{
+	config, err := mysqlConnectorConfig(context.Background(), SQLOptions{
 		DSN:            "user:password@tcp(localhost:3306)/shop?timeout=3s&tls=true",
 		ConnectTimeout: 20 * time.Second,
 	})
@@ -66,13 +66,75 @@ func TestMySQLConnectorConfigRespectsExplicitDSNTimeoutWithoutCustomTLS(t *testi
 	}
 }
 
+func TestMySQLConnectorConfigCapsEveryDriverDeadlineToContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	config, err := mysqlConnectorConfig(ctx, SQLOptions{
+		DSN: "user:password@tcp(localhost:3306)/shop?timeout=30s&readTimeout=40s&writeTimeout=50s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, timeout := range map[string]time.Duration{
+		"connect": config.Timeout,
+		"read":    config.ReadTimeout,
+		"write":   config.WriteTimeout,
+	} {
+		if timeout <= 0 || timeout > 2*time.Second {
+			t.Fatalf("%s timeout=%s, want positive context-bounded value", name, timeout)
+		}
+	}
+
+	unset, err := mysqlConnectorConfig(ctx, SQLOptions{
+		DSN:            "user:password@tcp(localhost:3306)/shop",
+		ConnectTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unset.ReadTimeout <= 0 || unset.WriteTimeout <= 0 ||
+		unset.ReadTimeout > 2*time.Second || unset.WriteTimeout > 2*time.Second ||
+		unset.Timeout > 2*time.Second {
+		t.Fatalf("unset/long driver deadlines were not bounded: timeout=%s read=%s write=%s", unset.Timeout, unset.ReadTimeout, unset.WriteTimeout)
+	}
+
+	short, err := mysqlConnectorConfig(ctx, SQLOptions{
+		DSN: "user:password@tcp(localhost:3306)/shop?timeout=20ms&readTimeout=30ms&writeTimeout=40ms",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if short.Timeout != 20*time.Millisecond || short.ReadTimeout != 30*time.Millisecond || short.WriteTimeout != 40*time.Millisecond {
+		t.Fatalf("short explicit deadlines were lengthened: timeout=%s read=%s write=%s", short.Timeout, short.ReadTimeout, short.WriteTimeout)
+	}
+}
+
+func TestMySQLConnectorConfigPreservesUnboundedCLIIOTimings(t *testing.T) {
+	config, err := mysqlConnectorConfig(context.Background(), SQLOptions{
+		DSN:            "user:password@tcp(localhost:3306)/shop?timeout=7s&readTimeout=8s&writeTimeout=9s",
+		ConnectTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Timeout != 7*time.Second || config.ReadTimeout != 8*time.Second || config.WriteTimeout != 9*time.Second {
+		t.Fatalf("background caller deadlines changed: timeout=%s read=%s write=%s", config.Timeout, config.ReadTimeout, config.WriteTimeout)
+	}
+
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := mysqlConnectorConfig(expired, SQLOptions{DSN: "user:password@tcp(localhost:3306)/shop"}); err == nil {
+		t.Fatal("expired connector context unexpectedly succeeded")
+	}
+}
+
 func TestCustomCAFailuresReturnOnlySafeTypedDiagnostics(t *testing.T) {
 	privatePath := filepath.Join(t.TempDir(), "private-customer-ca-name.pem")
 	if err := os.WriteFile(privatePath, []byte("not a certificate; private contents"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	const dsn = "private_user:private_password@tcp(private-db.internal:3306)/private_schema"
-	db, err := openSQLTarget(SQLOptions{DSN: dsn, MySQLTLS: MySQLTLSOptions{CAFile: privatePath}})
+	db, err := openSQLTarget(context.Background(), SQLOptions{DSN: dsn, MySQLTLS: MySQLTLSOptions{CAFile: privatePath}})
 	if db != nil {
 		db.Close()
 		t.Fatal("invalid custom CA unexpectedly opened a target")

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -216,6 +216,9 @@ func SyncSnapshotSQL(ctx context.Context, db *sql.DB, driver, table, keyField st
 // evolution remains additive and is performed before it. Soft-delete apply
 // requires the digest returned by an exact dry-run preview.
 func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[string]interface{}) (result SQLResult, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	started := time.Now()
 	result.DryRun = options.DryRun
 	result.Reconciliation, err = normalizeReconciliation(options.Reconciliation)
@@ -235,6 +238,9 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	if err != nil {
 		return result, err
 	}
+	if err = ctx.Err(); err != nil {
+		return result, err
+	}
 
 	driver := strings.ToLower(strings.TrimSpace(options.Driver))
 	if driver == "" {
@@ -250,7 +256,10 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 		return result, err
 	}
 
-	fields := recordmap.Fields(rows, options.KeyField)
+	fields, err := sqlFieldsContext(ctx, rows, options.KeyField)
+	if err != nil {
+		return result, err
+	}
 	keyField := strings.TrimSpace(options.KeyField)
 	if keyField == "" {
 		if len(fields) > 0 {
@@ -260,19 +269,22 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 		}
 	}
 	if result.Reconciliation == SoftDeleteMissing {
-		rows, err = prepareSoftDeleteRows(rows, keyField)
+		rows, err = prepareSoftDeleteRowsContext(ctx, rows, keyField)
 		if err != nil {
 			return result, err
 		}
-		fields = recordmap.Fields(rows, keyField)
+		fields, err = sqlFieldsContext(ctx, rows, keyField)
+		if err != nil {
+			return result, err
+		}
 	}
-	keys, err := snapshotKeys(rows, keyField, nil)
+	keys, err := snapshotKeysContext(ctx, rows, keyField, nil)
 	if err != nil {
 		return result, err
 	}
 	keepKeys := keys
 	if result.Reconciliation != UpsertOnly {
-		keepKeys, err = appendProtectedKeys(keys, options.ProtectedKeys)
+		keepKeys, err = appendProtectedKeysContext(ctx, keys, options.ProtectedKeys)
 		if err != nil {
 			return result, err
 		}
@@ -495,12 +507,28 @@ func effectiveBatchSize(driver string, requested, fieldCount int) int {
 }
 
 func appendProtectedKeys(keys, protected []string) ([]string, error) {
+	return appendProtectedKeysContext(context.Background(), keys, protected)
+}
+
+func appendProtectedKeysContext(ctx context.Context, keys, protected []string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	seen := make(map[string]struct{}, len(keys)+len(protected))
 	result := append([]string(nil), keys...)
 	for _, key := range result {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		seen[key] = struct{}{}
 	}
 	for index, value := range protected {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := strings.TrimSpace(value)
 		if key == "" {
 			return nil, fmt.Errorf("protected snapshot key %d is empty", index)
@@ -511,7 +539,7 @@ func appendProtectedKeys(keys, protected []string) ([]string, error) {
 		seen[key] = struct{}{}
 		result = append(result, key)
 	}
-	return result, nil
+	return result, ctx.Err()
 }
 
 type sqlCounts struct {
@@ -781,14 +809,33 @@ func mergeSnapshotOptions(values []SnapshotOptions) SnapshotOptions {
 }
 
 func snapshotKeys(rows []map[string]interface{}, keyField string, protected []string) ([]string, error) {
+	return snapshotKeysContext(context.Background(), rows, keyField, protected)
+}
+
+func snapshotKeysContext(ctx context.Context, rows []map[string]interface{}, keyField string, protected []string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	seen := make(map[string]struct{}, len(rows)+len(protected))
 	keys := make([]string, 0, len(rows)+len(protected))
 	for index, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		value, exists := row[keyField]
-		if !exists || value == nil || strings.TrimSpace(cell(value)) == "" {
+		if !exists || value == nil {
 			return nil, fmt.Errorf("snapshot row %d is missing key field %q", index, keyField)
 		}
 		key := cell(value)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("snapshot row %d is missing key field %q", index, keyField)
+		}
 		if _, exists := seen[key]; exists {
 			return nil, fmt.Errorf("snapshot contains duplicate %s %q", keyField, key)
 		}
@@ -796,6 +843,9 @@ func snapshotKeys(rows []map[string]interface{}, keyField string, protected []st
 		keys = append(keys, key)
 	}
 	for index, value := range protected {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := strings.TrimSpace(value)
 		if key == "" {
 			return nil, fmt.Errorf("protected snapshot key %d is empty", index)
@@ -806,7 +856,7 @@ func snapshotKeys(rows []map[string]interface{}, keyField string, protected []st
 		seen[key] = struct{}{}
 		keys = append(keys, key)
 	}
-	return keys, nil
+	return keys, ctx.Err()
 }
 
 func deleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string, requestedBatch int) (int, error) {

--- a/pkg/recordsink/sink.go
+++ b/pkg/recordsink/sink.go
@@ -165,7 +165,7 @@ func SyncSQLWithResult(ctx context.Context, options SQLOptions, rows []map[strin
 		ctx = context.Background()
 	}
 	connectCtx, cancel := sqlConnectContext(ctx, options.ConnectTimeout)
-	db, err := openSQLTarget(options)
+	db, err := openSQLTarget(ctx, options)
 	if err != nil {
 		cancel()
 		return SQLResult{}, err
@@ -240,7 +240,7 @@ func SyncSQLDB(ctx context.Context, db *sql.DB, options SQLOptions, rows []map[s
 	if driver == "" {
 		driver = "mysql"
 	}
-	table := sanitizeIdentifier(options.Table)
+	table := NormalizeSQLIdentifier(options.Table)
 	if table == "" {
 		table = "patris_export"
 	}
@@ -1110,7 +1110,7 @@ func sqlValue(value interface{}) interface{} {
 }
 
 func quoteIdent(driver, ident string) string {
-	ident = sanitizeIdentifier(ident)
+	ident = NormalizeSQLIdentifier(ident)
 	if ident == "" {
 		ident = "field"
 	}
@@ -1121,7 +1121,10 @@ func quoteIdent(driver, ident string) string {
 	return quote + strings.ReplaceAll(ident, quote, quote+quote) + quote
 }
 
-func sanitizeIdentifier(value string) string {
+// NormalizeSQLIdentifier returns the identifier spelling used by SQL sinks.
+// Callers that must not silently redirect a configured identifier should also
+// require the returned value to exactly match the trimmed input.
+func NormalizeSQLIdentifier(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return ""

--- a/pkg/recordsink/soft_delete.go
+++ b/pkg/recordsink/soft_delete.go
@@ -9,11 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"sort"
 	"strings"
 	"time"
-
-	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 )
 
 // SoftDeleteColumn is reserved for recordsink-managed tombstone state. Source
@@ -78,13 +75,29 @@ type sqlQueryer interface {
 }
 
 func prepareSoftDeleteRows(rows []map[string]interface{}, keyField string) ([]map[string]interface{}, error) {
+	return prepareSoftDeleteRowsContext(context.Background(), rows, keyField)
+}
+
+func prepareSoftDeleteRowsContext(ctx context.Context, rows []map[string]interface{}, keyField string) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if isSoftDeleteIdentifier(keyField) {
 		return nil, &ReconciliationGuardError{Code: ReconciliationGuardReservedField}
 	}
 	prepared := make([]map[string]interface{}, len(rows))
 	for index, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		copyRow := make(map[string]interface{}, len(row)+1)
 		for field, value := range row {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			if isSoftDeleteIdentifier(field) {
 				return nil, &ReconciliationGuardError{Code: ReconciliationGuardReservedField}
 			}
@@ -92,6 +105,9 @@ func prepareSoftDeleteRows(rows []map[string]interface{}, keyField string) ([]ma
 		}
 		copyRow[SoftDeleteColumn] = false
 		prepared[index] = copyRow
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	return prepared, nil
 }
@@ -104,6 +120,12 @@ func buildSoftDeleteEvidence(
 	sourceRows []map[string]interface{},
 	sourceKeys, keepKeys []string,
 ) (SQLReconciliationEvidence, string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return SQLReconciliationEvidence{}, "", err
+	}
 	evidence := SQLReconciliationEvidence{
 		SourceRows:           len(sourceKeys),
 		ProtectedRows:        len(keepKeys) - len(sourceKeys),
@@ -111,7 +133,10 @@ func buildSoftDeleteEvidence(
 		ApplyAllowed:         len(sourceKeys) > 0,
 	}
 	if !tableExists {
-		token := softDeleteConfirmationToken(table, keyField, sourceRows, sourceKeys, keepKeys, nil)
+		token, err := softDeleteConfirmationTokenContext(ctx, table, keyField, sourceRows, sourceKeys, keepKeys, nil)
+		if err != nil {
+			return evidence, "", err
+		}
 		return evidence, token, nil
 	}
 	if markerExists {
@@ -120,8 +145,14 @@ func buildSoftDeleteEvidence(
 		}
 	}
 
-	sourceSet := stringSet(sourceKeys)
-	keepSet := stringSet(keepKeys)
+	sourceSet, err := stringSetContext(ctx, sourceKeys)
+	if err != nil {
+		return evidence, "", err
+	}
+	keepSet, err := stringSetContext(ctx, keepKeys)
+	if err != nil {
+		return evidence, "", err
+	}
 	fields := quoteIdent(driver, keyField)
 	if markerExists {
 		fields += ", " + quoteIdent(driver, SoftDeleteColumn)
@@ -135,6 +166,9 @@ func buildSoftDeleteEvidence(
 
 	targetStates := make([]softDeleteTargetState, 0)
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return evidence, "", err
+		}
 		var keyValue interface{}
 		var markerValue interface{}
 		if markerExists {
@@ -146,6 +180,9 @@ func buildSoftDeleteEvidence(
 			return evidence, "", err
 		}
 		key := databaseKey(keyValue)
+		if err := ctx.Err(); err != nil {
+			return evidence, "", err
+		}
 		if strings.TrimSpace(key) == "" {
 			return evidence, "", errors.New("soft-delete target contains an empty key")
 		}
@@ -170,9 +207,15 @@ func buildSoftDeleteEvidence(
 	if err := rows.Err(); err != nil {
 		return evidence, "", err
 	}
+	if err := ctx.Err(); err != nil {
+		return evidence, "", err
+	}
 	evidence.TargetRows = len(targetStates)
 	evidence.PartialSourceRisk = evidence.MissingRows > 0
-	token := softDeleteConfirmationToken(table, keyField, sourceRows, sourceKeys, keepKeys, targetStates)
+	token, err := softDeleteConfirmationTokenContext(ctx, table, keyField, sourceRows, sourceKeys, keepKeys, targetStates)
+	if err != nil {
+		return evidence, "", err
+	}
 	return evidence, token, nil
 }
 
@@ -322,15 +365,57 @@ func softDeleteConfirmationToken(
 	sourceKeys, keepKeys []string,
 	targetStates []softDeleteTargetState,
 ) string {
+	token, _ := softDeleteConfirmationTokenContext(
+		context.Background(),
+		table,
+		keyField,
+		sourceRows,
+		sourceKeys,
+		keepKeys,
+		targetStates,
+	)
+	return token
+}
+
+func softDeleteConfirmationTokenContext(
+	ctx context.Context,
+	table, keyField string,
+	sourceRows []map[string]interface{},
+	sourceKeys, keepKeys []string,
+	targetStates []softDeleteTargetState,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	digest := sha256.New()
-	writeDigestPart(digest, "patris-soft-delete-v2")
-	writeDigestPart(digest, strings.ToLower(strings.TrimSpace(table)))
-	writeDigestPart(digest, strings.ToLower(strings.TrimSpace(keyField)))
-	writeSourceRowsDigest(digest, sourceRows, keyField)
-	writeDigestList(digest, sourceKeys)
-	writeDigestList(digest, keepKeys)
-	writeTargetStatesDigest(digest, targetStates)
-	return SoftDeleteConfirmationTokenPrefix + hex.EncodeToString(digest.Sum(nil))
+	for _, value := range []string{
+		"patris-soft-delete-v2",
+		strings.ToLower(strings.TrimSpace(table)),
+		strings.ToLower(strings.TrimSpace(keyField)),
+	} {
+		if err := writeDigestStringContext(ctx, digest, value); err != nil {
+			return "", err
+		}
+	}
+	if err := writeSourceRowsDigestContext(ctx, digest, sourceRows, keyField); err != nil {
+		return "", err
+	}
+	if err := writeDigestListContext(ctx, digest, sourceKeys); err != nil {
+		return "", err
+	}
+	if err := writeDigestListContext(ctx, digest, keepKeys); err != nil {
+		return "", err
+	}
+	if err := writeTargetStatesDigestContext(ctx, digest, targetStates); err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return SoftDeleteConfirmationTokenPrefix + hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 // SQLSourceFingerprint returns a deterministic, typed digest of the exact
@@ -338,39 +423,82 @@ func softDeleteConfirmationToken(
 // distinguishes values that JSON alone collapses, such as int64 from float64,
 // []byte from string, and time.Time from its formatted text.
 func SQLSourceFingerprint(rows []map[string]interface{}, keyField string, protectedKeys []string) [sha256.Size]byte {
-	digest := sha256.New()
-	writeDigestPart(digest, "patris-sql-source-v1")
-	writeDigestPart(digest, strings.TrimSpace(keyField))
-	writeSourceRowsDigest(digest, rows, keyField)
-	writeDigestList(digest, protectedKeys)
-	var fingerprint [sha256.Size]byte
-	copy(fingerprint[:], digest.Sum(nil))
+	fingerprint, _ := SQLSourceFingerprintContext(context.Background(), rows, keyField, protectedKeys)
 	return fingerprint
 }
 
+// SQLSourceFingerprintContext is SQLSourceFingerprint with cooperative
+// cancellation throughout field collection, stable ordering, typed value
+// hashing, and protected-key hashing.
+func SQLSourceFingerprintContext(
+	ctx context.Context,
+	rows []map[string]interface{},
+	keyField string,
+	protectedKeys []string,
+) ([sha256.Size]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	digest := sha256.New()
+	if err := writeDigestStringContext(ctx, digest, "patris-sql-source-v1"); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	if err := writeDigestStringContext(ctx, digest, strings.TrimSpace(keyField)); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	if err := writeSourceRowsDigestContext(ctx, digest, rows, keyField); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	if err := writeDigestListContext(ctx, digest, protectedKeys); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	var fingerprint [sha256.Size]byte
+	copy(fingerprint[:], digest.Sum(nil))
+	return fingerprint, nil
+}
+
 func writeSourceRowsDigest(digest hash.Hash, rows []map[string]interface{}, keyField string) {
-	fields := recordmap.Fields(rows, keyField)
+	_ = writeSourceRowsDigestContext(context.Background(), digest, rows, keyField)
+}
+
+func writeSourceRowsDigestContext(ctx context.Context, digest hash.Hash, rows []map[string]interface{}, keyField string) error {
+	fields, err := sqlFieldsContext(ctx, rows, keyField)
+	if err != nil {
+		return err
+	}
 	writeDigestCount(digest, len(fields))
 	for _, field := range fields {
-		writeDigestPart(digest, field)
+		if err := writeDigestStringContext(ctx, digest, field); err != nil {
+			return err
+		}
 	}
 
-	ordered := append([]map[string]interface{}(nil), rows...)
-	sort.SliceStable(ordered, func(left, right int) bool {
-		return databaseKey(ordered[left][keyField]) < databaseKey(ordered[right][keyField])
-	})
+	ordered, err := stableDigestRowsContext(ctx, rows, keyField)
+	if err != nil {
+		return err
+	}
 	writeDigestCount(digest, len(ordered))
 	for _, row := range ordered {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for _, field := range fields {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			value, exists := row[field]
 			if !exists {
 				value = nil
 			}
-			typeName, text := softDeleteDigestValue(value)
-			writeDigestPart(digest, typeName)
-			writeDigestPart(digest, text)
+			if err := writeSoftDeleteDigestValueContext(ctx, digest, value); err != nil {
+				return err
+			}
 		}
 	}
+	return ctx.Err()
 }
 
 func softDeleteDigestValue(value interface{}) (string, string) {
@@ -384,28 +512,60 @@ func softDeleteDigestValue(value interface{}) (string, string) {
 }
 
 func writeTargetStatesDigest(digest hash.Hash, states []softDeleteTargetState) {
+	_ = writeTargetStatesDigestContext(context.Background(), digest, states)
+}
+
+func writeTargetStatesDigestContext(ctx context.Context, digest hash.Hash, states []softDeleteTargetState) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ordered := append([]softDeleteTargetState(nil), states...)
-	sort.Slice(ordered, func(left, right int) bool {
-		return ordered[left].Key < ordered[right].Key
-	})
+	if err := stableSortTargetStatesContext(ctx, ordered); err != nil {
+		return err
+	}
 	writeDigestCount(digest, len(ordered))
 	for _, state := range ordered {
-		writeDigestPart(digest, state.Key)
+		if err := writeDigestStringContext(ctx, digest, state.Key); err != nil {
+			return err
+		}
 		if state.Deleted {
-			writeDigestPart(digest, "1")
+			if err := writeDigestStringContext(ctx, digest, "1"); err != nil {
+				return err
+			}
 		} else {
-			writeDigestPart(digest, "0")
+			if err := writeDigestStringContext(ctx, digest, "0"); err != nil {
+				return err
+			}
 		}
 	}
+	return ctx.Err()
 }
 
 func writeDigestList(digest hash.Hash, values []string) {
+	_ = writeDigestListContext(context.Background(), digest, values)
+}
+
+func writeDigestListContext(ctx context.Context, digest hash.Hash, values []string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ordered := append([]string(nil), values...)
-	sort.Strings(ordered)
+	if err := stableSortStringsContext(ctx, ordered); err != nil {
+		return err
+	}
 	writeDigestCount(digest, len(ordered))
 	for _, value := range ordered {
-		writeDigestPart(digest, value)
+		if err := writeDigestStringContext(ctx, digest, value); err != nil {
+			return err
+		}
 	}
+	return ctx.Err()
 }
 
 func writeDigestCount(digest hash.Hash, count int) {
@@ -415,18 +575,270 @@ func writeDigestCount(digest hash.Hash, count int) {
 }
 
 func writeDigestPart(digest hash.Hash, value string) {
+	_ = writeDigestStringContext(context.Background(), digest, value)
+}
+
+const sqlDigestChunkSize = 64 * 1024
+
+func writeDigestStringContext(ctx context.Context, digest hash.Hash, value string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	var length [8]byte
 	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
 	_, _ = digest.Write(length[:])
-	_, _ = digest.Write([]byte(value))
+	for start := 0; start < len(value); start += sqlDigestChunkSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := start + sqlDigestChunkSize
+		if end > len(value) {
+			end = len(value)
+		}
+		_, _ = digest.Write([]byte(value[start:end]))
+	}
+	return ctx.Err()
+}
+
+func writeDigestBytesContext(ctx context.Context, digest hash.Hash, value []byte) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = digest.Write(length[:])
+	for start := 0; start < len(value); start += sqlDigestChunkSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := start + sqlDigestChunkSize
+		if end > len(value) {
+			end = len(value)
+		}
+		_, _ = digest.Write(value[start:end])
+	}
+	return ctx.Err()
+}
+
+func sqlFieldsContext(ctx context.Context, rows []map[string]interface{}, keyField string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	fields := []string{}
+	if keyField != "" {
+		seen[keyField] = true
+		fields = append(fields, keyField)
+	}
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for field := range row {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if !seen[field] {
+				seen[field] = true
+				fields = append(fields, field)
+			}
+		}
+	}
+	if len(fields) <= 1 {
+		return fields, ctx.Err()
+	}
+	sortStart := 0
+	if keyField != "" && fields[0] == keyField {
+		sortStart = 1
+	}
+	if err := stableSortStringsContext(ctx, fields[sortStart:]); err != nil {
+		return nil, err
+	}
+	return fields, ctx.Err()
+}
+
+type sqlDigestRow struct {
+	row map[string]interface{}
+	key string
+}
+
+func stableDigestRowsContext(ctx context.Context, rows []map[string]interface{}, keyField string) ([]map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	ordered := make([]sqlDigestRow, len(rows))
+	for index, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		key := databaseKey(row[keyField])
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		ordered[index] = sqlDigestRow{row: row, key: key}
+	}
+	if err := stableSortDigestRowsContext(ctx, ordered); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	result := make([]map[string]interface{}, len(ordered))
+	for index, entry := range ordered {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		result[index] = entry.row
+	}
+	return result, ctx.Err()
+}
+
+func stableSortStringsContext(ctx context.Context, values []string) error {
+	return stableSortContext(ctx, values, func(left, right string) bool {
+		return left < right
+	})
+}
+
+func stableSortDigestRowsContext(ctx context.Context, values []sqlDigestRow) error {
+	return stableSortContext(ctx, values, func(left, right sqlDigestRow) bool {
+		return left.key < right.key
+	})
+}
+
+func stableSortTargetStatesContext(ctx context.Context, values []softDeleteTargetState) error {
+	return stableSortContext(ctx, values, func(left, right softDeleteTargetState) bool {
+		return left.Key < right.Key
+	})
+}
+
+func stableSortContext[T any](ctx context.Context, values []T, less func(T, T) bool) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if len(values) <= 1 {
+		return nil
+	}
+	scratch := make([]T, len(values))
+	var sortRange func(int, int) error
+	sortRange = func(low, high int) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if high-low <= 1 {
+			return nil
+		}
+		middle := low + (high-low)/2
+		if err := sortRange(low, middle); err != nil {
+			return err
+		}
+		if err := sortRange(middle, high); err != nil {
+			return err
+		}
+		left, right := low, middle
+		for output := low; output < high; output++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			switch {
+			case left >= middle:
+				scratch[output] = values[right]
+				right++
+			case right >= high:
+				scratch[output] = values[left]
+				left++
+			case !less(values[right], values[left]):
+				scratch[output] = values[left]
+				left++
+			default:
+				scratch[output] = values[right]
+				right++
+			}
+		}
+		for index := low; index < high; index++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			values[index] = scratch[index]
+		}
+		return nil
+	}
+	if err := sortRange(0, len(values)); err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+func writeSoftDeleteDigestValueContext(ctx context.Context, digest hash.Hash, value interface{}) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	typeName := "nil"
+	if value != nil {
+		if _, ok := value.(time.Time); ok {
+			typeName = "time.Time"
+		} else {
+			typeName = fmt.Sprintf("%T", value)
+		}
+	}
+	if err := writeDigestStringContext(ctx, digest, typeName); err != nil {
+		return err
+	}
+	switch typed := value.(type) {
+	case nil:
+		return writeDigestStringContext(ctx, digest, "")
+	case time.Time:
+		return writeDigestStringContext(ctx, digest, typed.Format(time.RFC3339Nano))
+	case []byte:
+		return writeDigestBytesContext(ctx, digest, typed)
+	case string:
+		return writeDigestStringContext(ctx, digest, typed)
+	default:
+		text := databaseText(value)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return writeDigestStringContext(ctx, digest, text)
+	}
 }
 
 func stringSet(values []string) map[string]struct{} {
+	result, _ := stringSetContext(context.Background(), values)
+	return result
+}
+
+func stringSetContext(ctx context.Context, values []string) (map[string]struct{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	result := make(map[string]struct{}, len(values))
 	for _, value := range values {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		result[value] = struct{}{}
 	}
-	return result
+	return result, ctx.Err()
 }
 
 func softDeleteRowsAbsentFromSnapshot(ctx context.Context, tx *sql.Tx, driver, table, keyField string, keys []string, requestedBatch int) (int, error) {

--- a/pkg/recordsink/soft_delete.go
+++ b/pkg/recordsink/soft_delete.go
@@ -278,7 +278,7 @@ func validateSoftDeleteColumn(ctx context.Context, queryer sqlQueryer, driver, t
 }
 
 func isSoftDeleteIdentifier(value string) bool {
-	return strings.EqualFold(sanitizeIdentifier(value), SoftDeleteColumn)
+	return strings.EqualFold(NormalizeSQLIdentifier(value), SoftDeleteColumn)
 }
 
 func softDeleteDefaultIsFalse(value interface{}) bool {
@@ -331,6 +331,21 @@ func softDeleteConfirmationToken(
 	writeDigestList(digest, keepKeys)
 	writeTargetStatesDigest(digest, targetStates)
 	return SoftDeleteConfirmationTokenPrefix + hex.EncodeToString(digest.Sum(nil))
+}
+
+// SQLSourceFingerprint returns a deterministic, typed digest of the exact
+// source rows and protected-key inputs supplied to a SQL sync. It deliberately
+// distinguishes values that JSON alone collapses, such as int64 from float64,
+// []byte from string, and time.Time from its formatted text.
+func SQLSourceFingerprint(rows []map[string]interface{}, keyField string, protectedKeys []string) [sha256.Size]byte {
+	digest := sha256.New()
+	writeDigestPart(digest, "patris-sql-source-v1")
+	writeDigestPart(digest, strings.TrimSpace(keyField))
+	writeSourceRowsDigest(digest, rows, keyField)
+	writeDigestList(digest, protectedKeys)
+	var fingerprint [sha256.Size]byte
+	copy(fingerprint[:], digest.Sum(nil))
+	return fingerprint
 }
 
 func writeSourceRowsDigest(digest hash.Hash, rows []map[string]interface{}, keyField string) {

--- a/pkg/recordsink/soft_delete_test.go
+++ b/pkg/recordsink/soft_delete_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSQLiteSoftDeleteRequiresExactPreviewAndFreshNoOpRetry(t *testing.T) {
@@ -572,6 +573,32 @@ func assertReconciliationGuard(t *testing.T, err error, expected ReconciliationG
 	var guard *ReconciliationGuardError
 	if !errors.As(err, &guard) || guard.Code != expected {
 		t.Fatalf("reconciliation error = %#v, want guard %q", err, expected)
+	}
+}
+
+func TestSQLSourceFingerprintPreservesDatabaseValueTypes(t *testing.T) {
+	base := []map[string]interface{}{{"Code": "001", "value": int64(1)}}
+	baseFingerprint := SQLSourceFingerprint(base, "Code", []string{"protected"})
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "float", value: float64(1)},
+		{name: "text", value: "1"},
+		{name: "bytes", value: []byte("1")},
+		{name: "time text", value: time.Unix(1, 0).UTC().Format(time.RFC3339Nano)},
+		{name: "timestamp", value: time.Unix(1, 0).UTC()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := []map[string]interface{}{{"Code": "001", "value": test.value}}
+			if got := SQLSourceFingerprint(changed, "Code", []string{"protected"}); got == baseFingerprint {
+				t.Fatalf("typed source change %T(%v) reused int64 fingerprint", test.value, test.value)
+			}
+		})
+	}
+	if got := SQLSourceFingerprint(base, "Code", []string{"other"}); got == baseFingerprint {
+		t.Fatal("protected-key change reused source fingerprint")
 	}
 }
 

--- a/pkg/recordsink/soft_delete_test.go
+++ b/pkg/recordsink/soft_delete_test.go
@@ -2,14 +2,21 @@ package recordsink
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"hash"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 )
 
 func TestSQLiteSoftDeleteRequiresExactPreviewAndFreshNoOpRetry(t *testing.T) {
@@ -600,6 +607,208 @@ func TestSQLSourceFingerprintPreservesDatabaseValueTypes(t *testing.T) {
 	if got := SQLSourceFingerprint(base, "Code", []string{"other"}); got == baseFingerprint {
 		t.Fatal("protected-key change reused source fingerprint")
 	}
+}
+
+func TestSQLSourceFingerprintContextMatchesLegacyDigestBytes(t *testing.T) {
+	timestamp := time.Date(2026, time.July, 24, 12, 34, 56, 789, time.UTC)
+	rows := []map[string]interface{}{
+		{"Code": "B", "bytes": []byte{0, 0xff, 1}, "number": float64(1.25), "timestamp": timestamp},
+		{"Code": "A", "missing": nil, "number": int64(1), "text": strings.Repeat("x", sqlDigestChunkSize+17)},
+		{"Code": "A", "number": int64(2), "text": "stable duplicate"},
+	}
+	protected := []string{"Z", "A", "A", strings.Repeat("p", sqlDigestChunkSize+9)}
+
+	want := legacySQLSourceFingerprint(rows, "Code", protected)
+	got, err := SQLSourceFingerprintContext(context.Background(), rows, "Code", protected)
+	if err != nil {
+		t.Fatalf("context fingerprint: %v", err)
+	}
+	if got != want {
+		t.Fatalf("context fingerprint=%x, want legacy bytes %x", got, want)
+	}
+	if wrapper := SQLSourceFingerprint(rows, "Code", protected); wrapper != want {
+		t.Fatalf("background wrapper fingerprint=%x, want legacy bytes %x", wrapper, want)
+	}
+
+	sourceRows := []map[string]interface{}{
+		{"Code": "B", "price": int64(200)},
+		{"Code": "A", "price": []byte("100")},
+	}
+	sourceKeys := []string{"B", "A"}
+	keepKeys := []string{"protected", "A", "B"}
+	targetStates := []softDeleteTargetState{
+		{Key: "protected", Deleted: true},
+		{Key: "B", Deleted: false},
+		{Key: "A", Deleted: false},
+	}
+	wantToken := legacySoftDeleteConfirmationToken(
+		"Products",
+		"Code",
+		sourceRows,
+		sourceKeys,
+		keepKeys,
+		targetStates,
+	)
+	gotToken, err := softDeleteConfirmationTokenContext(
+		context.Background(),
+		"Products",
+		"Code",
+		sourceRows,
+		sourceKeys,
+		keepKeys,
+		targetStates,
+	)
+	if err != nil {
+		t.Fatalf("context confirmation token: %v", err)
+	}
+	if gotToken != wantToken {
+		t.Fatalf("context confirmation token=%q, want legacy bytes %q", gotToken, wantToken)
+	}
+	if wrapper := softDeleteConfirmationToken("Products", "Code", sourceRows, sourceKeys, keepKeys, targetStates); wrapper != wantToken {
+		t.Fatalf("background confirmation wrapper=%q, want legacy bytes %q", wrapper, wantToken)
+	}
+}
+
+type cancellingFingerprintValue struct {
+	cancel context.CancelFunc
+}
+
+func (value cancellingFingerprintValue) String() string {
+	value.cancel()
+	return "cancelled-during-value-materialization"
+}
+
+func TestSQLSourceFingerprintContextCancelsDuringTypedRowHash(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rows := []map[string]interface{}{{
+		"Code":  "A",
+		"value": cancellingFingerprintValue{cancel: cancel},
+	}}
+	if _, err := SQLSourceFingerprintContext(ctx, rows, "Code", []string{"protected"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("fingerprint error=%v, want context.Canceled", err)
+	}
+}
+
+func TestSnapshotKeysContextCancelsAfterKeyMaterialization(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rows := []map[string]interface{}{{
+		"Code": cancellingFingerprintValue{cancel: cancel},
+	}}
+	if _, err := snapshotKeysContext(ctx, rows, "Code", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("snapshot key error=%v, want context.Canceled", err)
+	}
+}
+
+type cancellingDigest struct {
+	hash.Hash
+	cancel   context.CancelFunc
+	cancelAt int
+	writes   int
+}
+
+func (digest *cancellingDigest) Write(value []byte) (int, error) {
+	written, err := digest.Hash.Write(value)
+	digest.writes++
+	if digest.writes == digest.cancelAt {
+		digest.cancel()
+	}
+	return written, err
+}
+
+func TestWriteDigestListContextCancelsDuringProtectedKeyHash(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	digest := &cancellingDigest{Hash: sha256.New(), cancel: cancel, cancelAt: 2}
+	err := writeDigestListContext(ctx, digest, []string{"protected-b", "protected-a"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("protected-key digest error=%v, want context.Canceled", err)
+	}
+	if digest.writes != digest.cancelAt {
+		t.Fatalf("protected-key digest writes=%d, want prompt stop at %d", digest.writes, digest.cancelAt)
+	}
+}
+
+func legacySQLSourceFingerprint(rows []map[string]interface{}, keyField string, protectedKeys []string) [sha256.Size]byte {
+	digest := sha256.New()
+	legacyWriteDigestPart(digest, "patris-sql-source-v1")
+	legacyWriteDigestPart(digest, strings.TrimSpace(keyField))
+	legacyWriteSourceRowsDigest(digest, rows, keyField)
+	legacyWriteDigestList(digest, protectedKeys)
+	var fingerprint [sha256.Size]byte
+	copy(fingerprint[:], digest.Sum(nil))
+	return fingerprint
+}
+
+func legacySoftDeleteConfirmationToken(
+	table, keyField string,
+	sourceRows []map[string]interface{},
+	sourceKeys, keepKeys []string,
+	targetStates []softDeleteTargetState,
+) string {
+	digest := sha256.New()
+	legacyWriteDigestPart(digest, "patris-soft-delete-v2")
+	legacyWriteDigestPart(digest, strings.ToLower(strings.TrimSpace(table)))
+	legacyWriteDigestPart(digest, strings.ToLower(strings.TrimSpace(keyField)))
+	legacyWriteSourceRowsDigest(digest, sourceRows, keyField)
+	legacyWriteDigestList(digest, sourceKeys)
+	legacyWriteDigestList(digest, keepKeys)
+	ordered := append([]softDeleteTargetState(nil), targetStates...)
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].Key < ordered[right].Key
+	})
+	legacyWriteDigestCount(digest, len(ordered))
+	for _, state := range ordered {
+		legacyWriteDigestPart(digest, state.Key)
+		if state.Deleted {
+			legacyWriteDigestPart(digest, "1")
+		} else {
+			legacyWriteDigestPart(digest, "0")
+		}
+	}
+	return SoftDeleteConfirmationTokenPrefix + hex.EncodeToString(digest.Sum(nil))
+}
+
+func legacyWriteSourceRowsDigest(digest hash.Hash, rows []map[string]interface{}, keyField string) {
+	fields := recordmap.Fields(rows, keyField)
+	legacyWriteDigestCount(digest, len(fields))
+	for _, field := range fields {
+		legacyWriteDigestPart(digest, field)
+	}
+	ordered := append([]map[string]interface{}(nil), rows...)
+	sort.SliceStable(ordered, func(left, right int) bool {
+		return databaseKey(ordered[left][keyField]) < databaseKey(ordered[right][keyField])
+	})
+	legacyWriteDigestCount(digest, len(ordered))
+	for _, row := range ordered {
+		for _, field := range fields {
+			value, exists := row[field]
+			if !exists {
+				value = nil
+			}
+			typeName, text := softDeleteDigestValue(value)
+			legacyWriteDigestPart(digest, typeName)
+			legacyWriteDigestPart(digest, text)
+		}
+	}
+}
+
+func legacyWriteDigestList(digest hash.Hash, values []string) {
+	ordered := append([]string(nil), values...)
+	sort.Strings(ordered)
+	legacyWriteDigestCount(digest, len(ordered))
+	for _, value := range ordered {
+		legacyWriteDigestPart(digest, value)
+	}
+}
+
+func legacyWriteDigestCount(digest hash.Hash, count int) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], uint64(count))
+	_, _ = digest.Write(encoded[:])
+}
+
+func legacyWriteDigestPart(digest hash.Hash, value string) {
+	legacyWriteDigestCount(digest, len(value))
+	_, _ = digest.Write([]byte(value))
 }
 
 func sqliteColumnExists(t *testing.T, path, table, column string) bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,7 @@ type Server struct {
 	catalogProvider      pricingcatalog.Provider
 	catalogProviderKey   string
 	catalogProviderMu    sync.Mutex
+	sqlOperations        *sqlOperationsState
 }
 
 type Options struct {
@@ -150,6 +151,7 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 		dataSource:       ds,
 		wsClients:        make(map[*websocket.Conn]*sync.Mutex),
 		eventSubscribers: make(map[chan map[string]interface{}]struct{}),
+		sqlOperations:    newSQLOperationsState(),
 		useTempFile:      copyBeforeRead,
 		config:           options.Config,
 		version:          options.Version,
@@ -224,6 +226,13 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/update/executable", s.handleGetExecutable).Methods("GET", "HEAD")
 	s.router.HandleFunc("/api/processes/patris81", s.handleGetPatris81Processes).Methods("GET")
 	s.router.HandleFunc("/api/processes/file", s.handleGetFileProcesses).Methods("GET")
+	s.router.HandleFunc("/api/sql-target/session", s.handlePostSQLTargetSession).Methods("POST")
+	s.router.HandleFunc("/api/sql-target/session", s.handleDeleteSQLTargetSession).Methods("DELETE")
+	s.router.HandleFunc("/api/sql-target/status", s.handleGetSQLTargetStatus).Methods("GET")
+	s.router.HandleFunc("/api/sql-target/test", s.handlePostSQLTargetTest).Methods("POST")
+	s.router.HandleFunc("/api/sql-target/preview", s.handlePostSQLTargetPreview).Methods("POST")
+	s.router.HandleFunc("/api/sql-target/sync", s.handlePostSQLTargetSync).Methods("POST")
+	s.router.HandleFunc("/api/sql-target/last-result", s.handleGetSQLTargetLastResult).Methods("GET")
 	s.router.HandleFunc("/static/notification.ogg", s.handleNotificationAudio).Methods("GET", "HEAD")
 	s.router.HandleFunc("/static/patris-api-icon.png", s.handleAppIcon).Methods("GET", "HEAD")
 	s.router.HandleFunc("/favicon.ico", s.handleFavicon).Methods("GET", "HEAD")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,7 +37,6 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/version"
 	"github.com/atomicdeploy/patris-export/pkg/watcher"
 	"github.com/atomicdeploy/patris-export/web"
-	"github.com/fsnotify/fsnotify"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 )
@@ -61,7 +60,7 @@ type Server struct {
 	lastModTimeMu        sync.RWMutex
 	useTempFile          bool
 	config               *appconfig.Manager
-	configWatcher        *fsnotify.Watcher
+	configWatcher        *appconfig.ConfigWatcher
 	version              version.Info
 	processMu            sync.Mutex
 	processStatusCache   map[string]interface{}
@@ -275,6 +274,17 @@ func categoriesPayload(result recordpipe.Result) map[string]interface{} {
 }
 
 func (s *Server) RecordResult() (recordpipe.Result, error) {
+	return s.RecordResultContext(context.Background())
+}
+
+// RecordResultContext prepares the shared source projection with cooperative
+// cancellation. Context-aware data sources stop file copies, downloads, and
+// JSON reads promptly; native pxlib record extraction checks cancellation
+// immediately before and after its non-interruptible native call.
+func (s *Server) RecordResultContext(ctx context.Context) (recordpipe.Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	s.dataSourceMu.RLock()
 	ds := s.dataSource
 	dbPath := s.dbPath
@@ -282,11 +292,32 @@ func (s *Server) RecordResult() (recordpipe.Result, error) {
 	if ds == nil {
 		return recordpipe.Result{}, fmt.Errorf("data source is not initialized")
 	}
-	records, err := ds.GetRawRecords()
+	if err := ctx.Err(); err != nil {
+		return recordpipe.Result{}, err
+	}
+	var (
+		records []map[string]interface{}
+		err     error
+	)
+	if contextSource, ok := ds.(datasource.ContextDataSource); ok {
+		records, err = contextSource.GetRawRecordsContext(ctx)
+	} else {
+		if ctx.Done() != nil {
+			return recordpipe.Result{}, fmt.Errorf("data source does not support bounded record reads")
+		}
+		records, err = ds.GetRawRecords()
+	}
 	if err != nil {
 		return recordpipe.Result{}, err
 	}
-	return recordpipe.Build(records, dbPath, s.recordOptions()), nil
+	if err := ctx.Err(); err != nil {
+		return recordpipe.Result{}, err
+	}
+	result := recordpipe.BuildContext(ctx, records, dbPath, s.recordOptions())
+	if err := ctx.Err(); err != nil {
+		return recordpipe.Result{}, err
+	}
+	return result, nil
 }
 
 // Info returns database schema and metadata using the same shape served by

--- a/pkg/server/sql_operations.go
+++ b/pkg/server/sql_operations.go
@@ -32,6 +32,7 @@ const (
 	sqlSessionCookieName     = "patris_sql_operator_session"
 	sqlManualSyncConfirm     = "manual_sync"
 	sqlOperatorSessionTTL    = 10 * time.Minute
+	sqlPreviewGrantTTL       = 2 * time.Minute
 	sqlOperationTimeout      = 2 * time.Minute
 	maximumSQLOperatorTokens = 128
 	maximumSQLRequestBytes   = 4096
@@ -39,12 +40,28 @@ const (
 
 type sqlProbeFunc func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error)
 type sqlSyncFunc func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error)
+type sqlRecordFunc func(context.Context) (recordpipe.Result, error)
 
 type sqlOperatorSession struct {
 	csrfHash  [sha256.Size]byte
 	origin    string
 	createdAt time.Time
 	expiresAt time.Time
+}
+
+type sqlAuthorizedSession struct {
+	hash      [sha256.Size]byte
+	expiresAt time.Time
+}
+
+type sqlIssuedPreviewGrant struct {
+	grantHash               [sha256.Size]byte
+	sessionHash             [sha256.Size]byte
+	targetFingerprint       [sha256.Size]byte
+	sourceFingerprint       [sha256.Size]byte
+	reconciliationTokenHash [sha256.Size]byte
+	hasReconciliationToken  bool
+	expiresAt               time.Time
 }
 
 type sqlOperationsState struct {
@@ -60,8 +77,12 @@ type sqlOperationsState struct {
 	lastMu sync.RWMutex
 	last   *sqlOperationDiagnostic
 
-	probe sqlProbeFunc
-	sync  sqlSyncFunc
+	grantMu sync.Mutex
+	grant   *sqlIssuedPreviewGrant
+
+	probe   sqlProbeFunc
+	sync    sqlSyncFunc
+	records sqlRecordFunc
 }
 
 type sqlTargetStatus struct {
@@ -93,14 +114,16 @@ type sqlSafeFailure struct {
 }
 
 type sqlOperationDiagnostic struct {
-	Operation   string                `json:"operation"`
-	Status      string                `json:"status"`
-	StartedAt   time.Time             `json:"started_at"`
-	FinishedAt  time.Time             `json:"finished_at"`
-	RecordCount *int                  `json:"record_count,omitempty"`
-	Probe       *sqlSafeProbeResult   `json:"probe,omitempty"`
-	Result      *recordsink.SQLResult `json:"result,omitempty"`
-	Failure     *sqlSafeFailure       `json:"failure,omitempty"`
+	Operation             string                `json:"operation"`
+	Status                string                `json:"status"`
+	StartedAt             time.Time             `json:"started_at"`
+	FinishedAt            time.Time             `json:"finished_at"`
+	RecordCount           *int                  `json:"record_count,omitempty"`
+	Probe                 *sqlSafeProbeResult   `json:"probe,omitempty"`
+	Result                *recordsink.SQLResult `json:"result,omitempty"`
+	Failure               *sqlSafeFailure       `json:"failure,omitempty"`
+	PreviewGrant          string                `json:"preview_grant,omitempty"`
+	PreviewGrantExpiresAt *time.Time            `json:"preview_grant_expires_at,omitempty"`
 }
 
 type sqlAPIError struct {
@@ -134,12 +157,17 @@ func (s *Server) handlePostSQLTargetSession(w http.ResponseWriter, r *http.Reque
 		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
 		return
 	}
-	localBootstrap := remoteAddressIsLoopback(r.RemoteAddr) && hostnameIsLoopback(originHost)
+	localBootstrap := remoteAddressIsLoopback(r.RemoteAddr) &&
+		hostnameIsLoopback(originHost) &&
+		!requestHasProxyEvidence(r)
 	if !localBootstrap {
 		if !strings.HasPrefix(origin, "https://") || !s.sqlOperations.operatorTokenAuthorized(r) {
 			writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
 			return
 		}
+	} else if s.sqlOperations.operatorToken != "" && !s.sqlOperations.operatorTokenAuthorized(r) {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return
 	}
 
 	sessionID, csrfToken, expiresAt, err := s.sqlOperations.createSession(origin)
@@ -200,16 +228,13 @@ func (s *Server) handleGetSQLTargetStatus(w http.ResponseWriter, r *http.Request
 	}
 	cfg := s.Config()
 	_, hasLast := s.sqlOperations.lastDiagnostic()
-	reconciliation := recordsink.ReconciliationMode(cfg.Export.Reconciliation)
-	if reconciliation == "" {
-		reconciliation = recordsink.UpsertOnly
-	}
+	_, tableConfigured := sqlTargetExplicitTable(cfg)
 	writeJSON(w, sqlTargetStatus{
 		Configured:            strings.TrimSpace(cfg.Export.MySQLDSN) != "",
 		Driver:                "mysql",
-		TableConfigured:       strings.TrimSpace(firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable)) != "",
+		TableConfigured:       tableConfigured,
 		BatchSize:             cfg.Export.BatchSize,
-		Reconciliation:        reconciliation,
+		Reconciliation:        safeSQLReconciliationMode(recordsink.ReconciliationMode(cfg.Export.Reconciliation)),
 		ConnectTimeoutMS:      recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout).Milliseconds(),
 		VerifiedTLSConfigured: strings.TrimSpace(cfg.Export.MySQLTLSCAFile) != "" || strings.TrimSpace(cfg.Export.MySQLTLSServerName) != "",
 		Busy:                  s.sqlOperations.active.Load(),
@@ -248,30 +273,11 @@ func (s *Server) handlePostSQLTargetTest(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handlePostSQLTargetPreview(w http.ResponseWriter, r *http.Request) {
-	s.handleSQLTargetSync(w, r, true)
-}
-
-func (s *Server) handlePostSQLTargetSync(w http.ResponseWriter, r *http.Request) {
 	setSQLOperationHeaders(w)
-	if !s.requireSQLOperatorSession(w, r) {
-		return
-	}
-	reconciliationToken, ok := decodeManualSyncConfirmation(w, r)
+	session, ok := s.requireSQLOperatorSessionBinding(w, r)
 	if !ok {
 		return
 	}
-	s.runSQLTargetSync(w, r, false, reconciliationToken)
-}
-
-func (s *Server) handleSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun bool) {
-	setSQLOperationHeaders(w)
-	if !s.requireSQLOperatorSession(w, r) {
-		return
-	}
-	s.runSQLTargetSync(w, r, dryRun, "")
-}
-
-func (s *Server) runSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun bool, reconciliationToken string) {
 	ctx, cancel := context.WithTimeout(r.Context(), sqlOperationTimeout)
 	defer cancel()
 	if !s.sqlOperations.acquire(ctx) {
@@ -280,8 +286,64 @@ func (s *Server) runSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun
 	}
 	defer s.sqlOperations.release()
 
+	// A preview attempt always replaces any older authorization, even when the
+	// new preview fails. Only the direct successful response may authorize an
+	// apply.
+	s.sqlOperations.clearPreviewGrant()
+	s.runSQLTargetSync(w, ctx, true, session, "", "")
+}
+
+func (s *Server) handlePostSQLTargetSync(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	session, ok := s.requireSQLOperatorSessionBinding(w, r)
+	if !ok {
+		return
+	}
+	previewGrant, reconciliationToken, ok := decodeManualSyncConfirmation(w, r)
+	if !ok {
+		// Parsing happens before the global operation permit so a slow request
+		// body cannot wedge probes/previews. Clearing is synchronized; a newer
+		// preview issued after this point remains valid.
+		s.sqlOperations.clearPreviewGrant()
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), sqlOperationTimeout)
+	defer cancel()
+	if !s.sqlOperations.acquire(ctx) {
+		writeSQLAPIError(w, http.StatusGatewayTimeout, "operation_timeout", "The SQL operation could not start before its deadline.")
+		return
+	}
+	defer s.sqlOperations.release()
+
+	s.runSQLTargetSync(w, ctx, false, session, previewGrant, reconciliationToken)
+}
+
+func (s *Server) runSQLTargetSync(
+	w http.ResponseWriter,
+	ctx context.Context,
+	dryRun bool,
+	session sqlAuthorizedSession,
+	previewGrant string,
+	reconciliationToken string,
+) {
+	var issued *sqlIssuedPreviewGrant
+	if !dryRun {
+		// Consume before every apply outcome, including validation, source, or
+		// sink failure. A retry always requires a fresh preview.
+		issued = s.sqlOperations.takePreviewGrant()
+	}
+
 	cfg := s.Config()
-	reconciliation := recordsink.ReconciliationMode(cfg.Export.Reconciliation)
+	reconciliation := safeSQLReconciliationMode(recordsink.ReconciliationMode(cfg.Export.Reconciliation))
+	table, tableConfigured := sqlTargetExplicitTable(cfg)
+	if !tableConfigured {
+		if firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable) != "" {
+			writeSQLAPIError(w, http.StatusUnprocessableEntity, "target_table_invalid", "The explicit MySQL target table must be 1 to 64 characters, start with a letter, end with a letter or number, and contain only letters, numbers, and underscores.")
+			return
+		}
+		writeSQLAPIError(w, http.StatusUnprocessableEntity, "target_table_required", "An explicit MySQL target table is required.")
+		return
+	}
 	if !dryRun {
 		switch reconciliation {
 		case recordsink.DeleteMissing:
@@ -295,33 +357,58 @@ func (s *Server) runSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun
 			}
 		}
 	}
+	targetFingerprint, err := s.sqlTargetFingerprint(cfg, table)
+	if err != nil {
+		writeSQLAPIError(w, http.StatusInternalServerError, "preview_unavailable", "The SQL preview authorization could not be verified.")
+		return
+	}
+	if !dryRun && !issuedPreviewGrantMatches(
+		issued,
+		s.sqlOperations.currentTime(),
+		previewGrant,
+		reconciliationToken,
+		session.hash,
+		targetFingerprint,
+		reconciliation == recordsink.SoftDeleteMissing,
+	) {
+		s.writePreviewRequired(w, reconciliation)
+		return
+	}
 
 	operation := "sync"
 	if dryRun {
 		operation = "preview"
 	}
 	startedAt := s.sqlOperations.currentTime()
-	result, err := s.RecordResult()
+	var result recordpipe.Result
+	if s.sqlOperations.records != nil {
+		result, err = s.sqlOperations.records(ctx)
+	} else {
+		result, err = s.RecordResultContext(ctx)
+	}
+	if err == nil {
+		err = ctx.Err()
+	}
 	if err != nil {
+		failure, status := safeSQLSourceFailure(err)
 		diagnostic := sqlOperationDiagnostic{
 			Operation:  operation,
 			Status:     "failed",
 			StartedAt:  startedAt,
 			FinishedAt: s.sqlOperations.currentTime(),
-			Failure: &sqlSafeFailure{
-				Code:      "source_unavailable",
-				Stage:     "source",
-				Retryable: true,
-				Message:   "The source records could not be prepared.",
-			},
+			Failure:    failure,
 		}
 		s.sqlOperations.storeLast(diagnostic)
-		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]interface{}{"success": false, "diagnostic": diagnostic})
+		writeJSONStatus(w, status, map[string]interface{}{"success": false, "diagnostic": diagnostic})
 		return
 	}
-
+	sourceFingerprint := sqlSourceFingerprint(result)
+	if !dryRun && subtle.ConstantTimeCompare(issued.sourceFingerprint[:], sourceFingerprint[:]) != 1 {
+		s.writePreviewRequired(w, reconciliation)
+		return
+	}
 	recordCount := len(result.Rows)
-	options := s.sqlTargetSyncOptions(cfg, result, dryRun)
+	options := s.sqlTargetSyncOptions(cfg, result, table, dryRun)
 	if !dryRun {
 		options.ReconciliationToken = reconciliationToken
 	}
@@ -338,9 +425,73 @@ func (s *Server) runSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun
 	if syncErr != nil {
 		diagnostic.Status = "failed"
 		diagnostic.Failure = safeSQLFailure(recordsink.SQLStageSync, syncErr)
+	} else if dryRun {
+		reconciliationToken := ""
+		grantAllowed := reconciliation == recordsink.UpsertOnly
+		if reconciliation == recordsink.SoftDeleteMissing &&
+			syncResult.ReconciliationEvidence != nil &&
+			syncResult.ReconciliationEvidence.ApplyAllowed &&
+			validSoftDeleteConfirmationToken(syncResult.ReconciliationEvidence.ConfirmationToken) {
+			grantAllowed = true
+			reconciliationToken = syncResult.ReconciliationEvidence.ConfirmationToken
+		}
+		if grantAllowed {
+			grant, grantErr := randomSQLToken()
+			if grantErr != nil {
+				syncErr = grantErr
+				diagnostic.Status = "failed"
+				diagnostic.Failure = safeSQLFailure(recordsink.SQLStageSync, grantErr)
+				diagnostic.Result = nil
+			} else {
+				expiresAt := s.sqlOperations.currentTime().Add(sqlPreviewGrantTTL)
+				if session.expiresAt.Before(expiresAt) {
+					expiresAt = session.expiresAt
+				}
+				issued := s.sqlOperations.issuePreviewGrant(sqlIssuedPreviewGrant{
+					grantHash:               sha256.Sum256([]byte(grant)),
+					sessionHash:             session.hash,
+					targetFingerprint:       targetFingerprint,
+					sourceFingerprint:       sourceFingerprint,
+					reconciliationTokenHash: sha256.Sum256([]byte(reconciliationToken)),
+					hasReconciliationToken:  reconciliationToken != "",
+					expiresAt:               expiresAt,
+				})
+				if !issued {
+					syncErr = &recordsink.ReconciliationGuardError{Code: recordsink.ReconciliationGuardPreviewRequired}
+					diagnostic.Status = "failed"
+					diagnostic.Failure = safeSQLFailure(recordsink.SQLStageSync, syncErr)
+					diagnostic.Result = nil
+				} else {
+					diagnostic.PreviewGrant = grant
+					diagnostic.PreviewGrantExpiresAt = &expiresAt
+				}
+			}
+		}
 	}
 	s.sqlOperations.storeLast(diagnostic)
 	writeSQLOperationDiagnostic(w, diagnostic, syncErr)
+}
+
+func safeSQLSourceFailure(err error) (*sqlSafeFailure, int) {
+	failure := &sqlSafeFailure{
+		Code:      "source_unavailable",
+		Stage:     "source",
+		Retryable: true,
+		Message:   "The source records could not be prepared.",
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		failure.Code = string(recordsink.SQLFailureTimeout)
+		failure.Message = "The source preparation timed out."
+		return failure, http.StatusGatewayTimeout
+	case errors.Is(err, context.Canceled):
+		failure.Code = string(recordsink.SQLFailureCancelled)
+		failure.Retryable = false
+		failure.Message = "The source preparation was cancelled."
+		return failure, http.StatusRequestTimeout
+	default:
+		return failure, http.StatusServiceUnavailable
+	}
 }
 
 func (s *Server) handleGetSQLTargetLastResult(w http.ResponseWriter, r *http.Request) {
@@ -368,12 +519,12 @@ func (s *Server) sqlTargetProbeOptions(cfg appconfig.Config) recordsink.SQLOptio
 	}
 }
 
-func (s *Server) sqlTargetSyncOptions(cfg appconfig.Config, result recordpipe.Result, dryRun bool) recordsink.SQLOptions {
+func (s *Server) sqlTargetSyncOptions(cfg appconfig.Config, result recordpipe.Result, table string, dryRun bool) recordsink.SQLOptions {
 	options := s.sqlTargetProbeOptions(cfg)
-	options.Table = firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable, recordpipe.SourceTableName(s.currentDBPath()))
+	options.Table = table
 	options.KeyField = result.KeyField
 	options.Batch = cfg.Export.BatchSize
-	options.Reconciliation = recordsink.ReconciliationMode(cfg.Export.Reconciliation)
+	options.Reconciliation = safeSQLReconciliationMode(recordsink.ReconciliationMode(cfg.Export.Reconciliation))
 	options.DryRun = dryRun
 	if result.Contract != nil {
 		options.ProtectedKeys = append([]string(nil), result.Contract.QuarantinedCodes...)
@@ -381,23 +532,130 @@ func (s *Server) sqlTargetSyncOptions(cfg appconfig.Config, result recordpipe.Re
 	return options
 }
 
+func sqlTargetExplicitTable(cfg appconfig.Config) (string, bool) {
+	table := firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable)
+	normalized := recordsink.NormalizeSQLIdentifier(table)
+	return normalized, table != "" && len(table) <= 64 && normalized != "" && normalized == table
+}
+
+func (s *Server) sqlTargetFingerprint(cfg appconfig.Config, table string) ([sha256.Size]byte, error) {
+	s.dataSourceMu.RLock()
+	sourcePath := s.dbPath
+	useTempFile := s.useTempFile
+	s.dataSourceMu.RUnlock()
+	payload := struct {
+		Config      appconfig.Config `json:"config"`
+		Table       string           `json:"table"`
+		SourcePath  string           `json:"source_path"`
+		UseTempFile bool             `json:"use_temp_file"`
+	}{
+		Config:      cfg,
+		Table:       table,
+		SourcePath:  sourcePath,
+		UseTempFile: useTempFile,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(encoded), nil
+}
+
+func sqlSourceFingerprint(result recordpipe.Result) [sha256.Size]byte {
+	protectedKeys := []string(nil)
+	if result.Contract != nil {
+		protectedKeys = append(protectedKeys, result.Contract.QuarantinedCodes...)
+	}
+	return recordsink.SQLSourceFingerprint(result.Rows, result.KeyField, protectedKeys)
+}
+
+func issuedPreviewGrantMatches(
+	issued *sqlIssuedPreviewGrant,
+	now time.Time,
+	previewGrant string,
+	reconciliationToken string,
+	sessionHash [sha256.Size]byte,
+	targetFingerprint [sha256.Size]byte,
+	requiresReconciliationToken bool,
+) bool {
+	if issued == nil || !validSQLPreviewGrant(previewGrant) || !now.Before(issued.expiresAt) {
+		return false
+	}
+	grantHash := sha256.Sum256([]byte(previewGrant))
+	reconciliationHash := sha256.Sum256([]byte(reconciliationToken))
+	if subtle.ConstantTimeCompare(issued.grantHash[:], grantHash[:]) != 1 ||
+		subtle.ConstantTimeCompare(issued.sessionHash[:], sessionHash[:]) != 1 ||
+		subtle.ConstantTimeCompare(issued.targetFingerprint[:], targetFingerprint[:]) != 1 ||
+		issued.hasReconciliationToken != requiresReconciliationToken {
+		return false
+	}
+	if requiresReconciliationToken {
+		return validSoftDeleteConfirmationToken(reconciliationToken) &&
+			subtle.ConstantTimeCompare(issued.reconciliationTokenHash[:], reconciliationHash[:]) == 1
+	}
+	return reconciliationToken == ""
+}
+
+func validSQLPreviewGrant(value string) bool {
+	if len(value) != base64.RawURLEncoding.EncodedLen(32) {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	return err == nil && len(decoded) == 32 &&
+		subtle.ConstantTimeCompare([]byte(base64.RawURLEncoding.EncodeToString(decoded)), []byte(value)) == 1
+}
+
+func (s *Server) writePreviewRequired(w http.ResponseWriter, reconciliation recordsink.ReconciliationMode) {
+	err := &recordsink.ReconciliationGuardError{Code: recordsink.ReconciliationGuardPreviewRequired}
+	diagnostic := sqlOperationDiagnostic{
+		Operation:  "sync",
+		Status:     "failed",
+		StartedAt:  s.sqlOperations.currentTime(),
+		FinishedAt: s.sqlOperations.currentTime(),
+		Failure:    safeSQLFailure(recordsink.SQLStageSync, err),
+	}
+	if reconciliation == recordsink.SoftDeleteMissing {
+		diagnostic.Result = &recordsink.SQLResult{
+			DryRun:         false,
+			Reconciliation: recordsink.SoftDeleteMissing,
+			ReconciliationEvidence: &recordsink.SQLReconciliationEvidence{
+				ConfirmationRequired: true,
+				ApplyAllowed:         false,
+				GuardCode:            recordsink.ReconciliationGuardPreviewRequired,
+			},
+		}
+	}
+	s.sqlOperations.storeLast(diagnostic)
+	writeSQLOperationDiagnostic(w, diagnostic, err)
+}
+
 func (s *Server) requireSQLOperatorSession(w http.ResponseWriter, r *http.Request) bool {
+	_, ok := s.requireSQLOperatorSessionBinding(w, r)
+	return ok
+}
+
+func (s *Server) requireSQLOperatorSessionBinding(w http.ResponseWriter, r *http.Request) (sqlAuthorizedSession, bool) {
 	origin, _, ok := protectedRequestOrigin(r)
 	if !ok {
 		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
-		return false
+		return sqlAuthorizedSession{}, false
 	}
 	cookie, err := r.Cookie(sqlSessionCookieName)
 	if err != nil || cookie.Value == "" {
 		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
-		return false
+		return sqlAuthorizedSession{}, false
 	}
 	csrfValues := r.Header.Values(sqlCSRFHeader)
-	if len(csrfValues) != 1 || csrfValues[0] == "" || !s.sqlOperations.sessionAuthorized(cookie.Value, csrfValues[0], origin) {
+	if len(csrfValues) != 1 || csrfValues[0] == "" {
 		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
-		return false
+		return sqlAuthorizedSession{}, false
 	}
-	return true
+	session, authorized := s.sqlOperations.authorizedSession(cookie.Value, csrfValues[0], origin)
+	if !authorized {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return sqlAuthorizedSession{}, false
+	}
+	return session, true
 }
 
 func (state *sqlOperationsState) createSession(origin string) (string, string, time.Time, error) {
@@ -428,7 +686,7 @@ func (state *sqlOperationsState) createSession(origin string) (string, string, t
 	return sessionID, csrfToken, expiresAt, nil
 }
 
-func (state *sqlOperationsState) sessionAuthorized(sessionID, csrfToken, origin string) bool {
+func (state *sqlOperationsState) authorizedSession(sessionID, csrfToken, origin string) (sqlAuthorizedSession, bool) {
 	sessionHash := sha256.Sum256([]byte(sessionID))
 	csrfHash := sha256.Sum256([]byte(csrfToken))
 	now := state.currentTime()
@@ -437,9 +695,12 @@ func (state *sqlOperationsState) sessionAuthorized(sessionID, csrfToken, origin 
 	state.pruneSessionsLocked(now)
 	session, ok := state.sessions[sessionHash]
 	if !ok || session.origin != origin || !now.Before(session.expiresAt) {
-		return false
+		return sqlAuthorizedSession{}, false
 	}
-	return subtle.ConstantTimeCompare(session.csrfHash[:], csrfHash[:]) == 1
+	if subtle.ConstantTimeCompare(session.csrfHash[:], csrfHash[:]) != 1 {
+		return sqlAuthorizedSession{}, false
+	}
+	return sqlAuthorizedSession{hash: sessionHash, expiresAt: session.expiresAt}, true
 }
 
 func (state *sqlOperationsState) revokeSession(sessionID string) {
@@ -447,6 +708,7 @@ func (state *sqlOperationsState) revokeSession(sessionID string) {
 	state.sessionsMu.Lock()
 	delete(state.sessions, sessionHash)
 	state.sessionsMu.Unlock()
+	state.clearPreviewGrantForSession(sessionHash)
 }
 
 func (state *sqlOperationsState) operatorTokenAuthorized(r *http.Request) bool {
@@ -466,6 +728,7 @@ func (state *sqlOperationsState) pruneSessionsLocked(now time.Time) {
 	for key, session := range state.sessions {
 		if !now.Before(session.expiresAt) {
 			delete(state.sessions, key)
+			state.clearPreviewGrantForSession(key)
 		}
 	}
 }
@@ -505,8 +768,59 @@ func (state *sqlOperationsState) currentTime() time.Time {
 	return state.now().UTC()
 }
 
+func (state *sqlOperationsState) issuePreviewGrant(grant sqlIssuedPreviewGrant) bool {
+	copy := grant
+	state.sessionsMu.Lock()
+	defer state.sessionsMu.Unlock()
+	session, active := state.sessions[grant.sessionHash]
+	if !active || !state.currentTime().Before(session.expiresAt) {
+		return false
+	}
+	state.grantMu.Lock()
+	state.grant = &copy
+	state.grantMu.Unlock()
+	return true
+}
+
+func (state *sqlOperationsState) takePreviewGrant() *sqlIssuedPreviewGrant {
+	state.grantMu.Lock()
+	defer state.grantMu.Unlock()
+	if state.grant == nil {
+		return nil
+	}
+	copy := *state.grant
+	state.grant = nil
+	return &copy
+}
+
+func (state *sqlOperationsState) clearPreviewGrant() {
+	state.grantMu.Lock()
+	state.grant = nil
+	state.grantMu.Unlock()
+}
+
+func (state *sqlOperationsState) clearPreviewGrantForSession(sessionHash [sha256.Size]byte) {
+	state.grantMu.Lock()
+	if state.grant != nil && subtle.ConstantTimeCompare(state.grant.sessionHash[:], sessionHash[:]) == 1 {
+		state.grant = nil
+	}
+	state.grantMu.Unlock()
+}
+
 func (state *sqlOperationsState) storeLast(diagnostic sqlOperationDiagnostic) {
 	copy := cloneSQLOperationDiagnostic(diagnostic)
+	copy.PreviewGrant = ""
+	copy.PreviewGrantExpiresAt = nil
+	if copy.Result != nil && copy.Result.ReconciliationEvidence != nil {
+		evidence := copy.Result.ReconciliationEvidence
+		if evidence.ConfirmationToken != "" {
+			evidence.ConfirmationToken = ""
+			evidence.ApplyAllowed = false
+			if evidence.SourceRows > 0 && evidence.ConfirmationRequired && evidence.GuardCode == "" {
+				evidence.GuardCode = recordsink.ReconciliationGuardPreviewRequired
+			}
+		}
+	}
 	state.lastMu.Lock()
 	state.last = &copy
 	state.lastMu.Unlock()
@@ -542,6 +856,10 @@ func cloneSQLOperationDiagnostic(value sqlOperationDiagnostic) sqlOperationDiagn
 	if value.Failure != nil {
 		failure := *value.Failure
 		copy.Failure = &failure
+	}
+	if value.PreviewGrantExpiresAt != nil {
+		expiresAt := *value.PreviewGrantExpiresAt
+		copy.PreviewGrantExpiresAt = &expiresAt
 	}
 	return copy
 }
@@ -632,6 +950,19 @@ func effectiveRequestOrigin(r *http.Request) (string, string, bool) {
 		}
 	}
 	return canonicalHTTPOrigin(scheme, authority)
+}
+
+func requestHasProxyEvidence(r *http.Request) bool {
+	for name := range r.Header {
+		lowerName := strings.ToLower(name)
+		if lowerName == "forwarded" ||
+			lowerName == "via" ||
+			lowerName == "x-real-ip" ||
+			strings.HasPrefix(lowerName, "x-forwarded-") {
+			return true
+		}
+	}
+	return false
 }
 
 func canonicalHTTPOrigin(scheme, authority string) (string, string, bool) {
@@ -735,14 +1066,7 @@ func safeSQLResult(result recordsink.SQLResult, options recordsink.SQLOptions, r
 	result.Failed = nonNegativeSQLCount(result.Failed)
 	result.ElapsedMS = max(result.ElapsedMS, 0)
 	result.DryRun = options.DryRun
-	switch options.Reconciliation {
-	case recordsink.SoftDeleteMissing:
-		result.Reconciliation = recordsink.SoftDeleteMissing
-	case recordsink.DeleteMissing:
-		result.Reconciliation = recordsink.DeleteMissing
-	default:
-		result.Reconciliation = recordsink.UpsertOnly
-	}
+	result.Reconciliation = safeSQLReconciliationMode(options.Reconciliation)
 	if result.Reconciliation == recordsink.SoftDeleteMissing {
 		result.ReconciliationEvidence = safeSQLReconciliationEvidence(result.ReconciliationEvidence, result.DryRun)
 	} else {
@@ -759,6 +1083,17 @@ func safeSQLResult(result recordsink.SQLResult, options recordsink.SQLOptions, r
 		result.Failed = nonNegativeSQLCount(recordCount)
 	}
 	return result
+}
+
+func safeSQLReconciliationMode(value recordsink.ReconciliationMode) recordsink.ReconciliationMode {
+	switch value {
+	case recordsink.SoftDeleteMissing:
+		return recordsink.SoftDeleteMissing
+	case recordsink.DeleteMissing:
+		return recordsink.DeleteMissing
+	default:
+		return recordsink.UpsertOnly
+	}
 }
 
 func safeSQLReconciliationEvidence(value *recordsink.SQLReconciliationEvidence, dryRun bool) *recordsink.SQLReconciliationEvidence {
@@ -834,36 +1169,41 @@ func nonNegativeSQLCount(value int) int {
 	return value
 }
 
-func decodeManualSyncConfirmation(w http.ResponseWriter, r *http.Request) (string, bool) {
+func decodeManualSyncConfirmation(w http.ResponseWriter, r *http.Request) (string, string, bool) {
 	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil || mediaType != "application/json" {
 		writeSQLAPIError(w, http.StatusUnsupportedMediaType, "json_required", "Manual sync requires an application/json request.")
-		return "", false
+		return "", "", false
 	}
 	body := http.MaxBytesReader(w, r.Body, maximumSQLRequestBytes)
 	decoder := json.NewDecoder(body)
 	decoder.DisallowUnknownFields()
 	var request struct {
 		Confirm             string `json:"confirm"`
+		PreviewGrant        string `json:"preview_grant,omitempty"`
 		ReconciliationToken string `json:"reconciliation_token,omitempty"`
 	}
 	if err := decoder.Decode(&request); err != nil {
 		writeSQLAPIError(w, http.StatusBadRequest, "invalid_request", "Manual sync requires an explicit confirmation.")
-		return "", false
+		return "", "", false
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		writeSQLAPIError(w, http.StatusBadRequest, "invalid_request", "Manual sync requires one JSON object.")
-		return "", false
+		return "", "", false
 	}
 	if request.Confirm != sqlManualSyncConfirm {
 		writeSQLAPIError(w, http.StatusBadRequest, "confirmation_required", "Manual sync requires an explicit confirmation.")
-		return "", false
+		return "", "", false
+	}
+	if request.PreviewGrant != "" && !validSQLPreviewGrant(request.PreviewGrant) {
+		writeSQLAPIError(w, http.StatusBadRequest, "invalid_preview_grant", "The SQL preview grant is invalid.")
+		return "", "", false
 	}
 	if request.ReconciliationToken != "" && !validSoftDeleteConfirmationToken(request.ReconciliationToken) {
 		writeSQLAPIError(w, http.StatusBadRequest, "invalid_reconciliation_token", "The reconciliation preview token is invalid.")
-		return "", false
+		return "", "", false
 	}
-	return request.ReconciliationToken, true
+	return request.PreviewGrant, request.ReconciliationToken, true
 }
 
 func writeSQLOperationDiagnostic(w http.ResponseWriter, diagnostic sqlOperationDiagnostic, err error) {

--- a/pkg/server/sql_operations.go
+++ b/pkg/server/sql_operations.go
@@ -380,6 +380,18 @@ func (s *Server) runSQLTargetSync(
 		operation = "preview"
 	}
 	startedAt := s.sqlOperations.currentTime()
+	writeSourceFailure := func(sourceErr error) {
+		failure, status := safeSQLSourceFailure(sourceErr)
+		diagnostic := sqlOperationDiagnostic{
+			Operation:  operation,
+			Status:     "failed",
+			StartedAt:  startedAt,
+			FinishedAt: s.sqlOperations.currentTime(),
+			Failure:    failure,
+		}
+		s.sqlOperations.storeLast(diagnostic)
+		writeJSONStatus(w, status, map[string]interface{}{"success": false, "diagnostic": diagnostic})
+	}
 	var result recordpipe.Result
 	if s.sqlOperations.records != nil {
 		result, err = s.sqlOperations.records(ctx)
@@ -390,19 +402,14 @@ func (s *Server) runSQLTargetSync(
 		err = ctx.Err()
 	}
 	if err != nil {
-		failure, status := safeSQLSourceFailure(err)
-		diagnostic := sqlOperationDiagnostic{
-			Operation:  operation,
-			Status:     "failed",
-			StartedAt:  startedAt,
-			FinishedAt: s.sqlOperations.currentTime(),
-			Failure:    failure,
-		}
-		s.sqlOperations.storeLast(diagnostic)
-		writeJSONStatus(w, status, map[string]interface{}{"success": false, "diagnostic": diagnostic})
+		writeSourceFailure(err)
 		return
 	}
-	sourceFingerprint := sqlSourceFingerprint(result)
+	sourceFingerprint, err := sqlSourceFingerprint(ctx, result)
+	if err != nil {
+		writeSourceFailure(err)
+		return
+	}
 	if !dryRun && subtle.ConstantTimeCompare(issued.sourceFingerprint[:], sourceFingerprint[:]) != 1 {
 		s.writePreviewRequired(w, reconciliation)
 		return
@@ -411,6 +418,10 @@ func (s *Server) runSQLTargetSync(
 	options := s.sqlTargetSyncOptions(cfg, result, table, dryRun)
 	if !dryRun {
 		options.ReconciliationToken = reconciliationToken
+	}
+	if err := ctx.Err(); err != nil {
+		writeSourceFailure(err)
+		return
 	}
 	syncResult, syncErr := s.sqlOperations.sync(ctx, options, result.Rows)
 	syncResult = safeSQLResult(syncResult, options, recordCount, syncErr)
@@ -561,12 +572,12 @@ func (s *Server) sqlTargetFingerprint(cfg appconfig.Config, table string) ([sha2
 	return sha256.Sum256(encoded), nil
 }
 
-func sqlSourceFingerprint(result recordpipe.Result) [sha256.Size]byte {
-	protectedKeys := []string(nil)
+func sqlSourceFingerprint(ctx context.Context, result recordpipe.Result) ([sha256.Size]byte, error) {
+	var protectedKeys []string
 	if result.Contract != nil {
-		protectedKeys = append(protectedKeys, result.Contract.QuarantinedCodes...)
+		protectedKeys = result.Contract.QuarantinedCodes
 	}
-	return recordsink.SQLSourceFingerprint(result.Rows, result.KeyField, protectedKeys)
+	return recordsink.SQLSourceFingerprintContext(ctx, result.Rows, result.KeyField, protectedKeys)
 }
 
 func issuedPreviewGrantMatches(

--- a/pkg/server/sql_operations.go
+++ b/pkg/server/sql_operations.go
@@ -1,0 +1,913 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
+	"github.com/atomicdeploy/patris-export/pkg/recordsink"
+)
+
+const (
+	sqlOperatorTokenEnv      = "PATRIS_EXPORT_SQL_OPERATOR_TOKEN"
+	sqlOperatorTokenHeader   = "X-Patris-SQL-Operator-Token"
+	sqlCSRFHeader            = "X-Patris-CSRF-Token"
+	sqlSessionCookieName     = "patris_sql_operator_session"
+	sqlManualSyncConfirm     = "manual_sync"
+	sqlOperatorSessionTTL    = 10 * time.Minute
+	sqlOperationTimeout      = 2 * time.Minute
+	maximumSQLOperatorTokens = 128
+	maximumSQLRequestBytes   = 4096
+)
+
+type sqlProbeFunc func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error)
+type sqlSyncFunc func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error)
+
+type sqlOperatorSession struct {
+	csrfHash  [sha256.Size]byte
+	origin    string
+	createdAt time.Time
+	expiresAt time.Time
+}
+
+type sqlOperationsState struct {
+	sessionsMu    sync.Mutex
+	sessions      map[[sha256.Size]byte]sqlOperatorSession
+	operatorToken string
+	sessionTTL    time.Duration
+	now           func() time.Time
+
+	permit chan struct{}
+	active atomic.Bool
+
+	lastMu sync.RWMutex
+	last   *sqlOperationDiagnostic
+
+	probe sqlProbeFunc
+	sync  sqlSyncFunc
+}
+
+type sqlTargetStatus struct {
+	Configured            bool                          `json:"configured"`
+	Driver                string                        `json:"driver"`
+	TableConfigured       bool                          `json:"table_configured"`
+	BatchSize             int                           `json:"batch_size"`
+	Reconciliation        recordsink.ReconciliationMode `json:"reconciliation"`
+	ConnectTimeoutMS      int64                         `json:"connect_timeout_ms"`
+	VerifiedTLSConfigured bool                          `json:"verified_tls_configured"`
+	Busy                  bool                          `json:"busy"`
+	LastResultAvailable   bool                          `json:"last_result_available"`
+}
+
+type sqlSafeProbeResult struct {
+	Connected bool                   `json:"connected"`
+	Driver    string                 `json:"driver"`
+	Vendor    string                 `json:"vendor,omitempty"`
+	TLS       recordsink.SQLTLSState `json:"tls"`
+	ElapsedMS int64                  `json:"elapsed_ms"`
+}
+
+type sqlSafeFailure struct {
+	Code      string                             `json:"code"`
+	Stage     string                             `json:"stage"`
+	Retryable bool                               `json:"retryable"`
+	Message   string                             `json:"message"`
+	Reason    recordsink.ReconciliationGuardCode `json:"reason,omitempty"`
+}
+
+type sqlOperationDiagnostic struct {
+	Operation   string                `json:"operation"`
+	Status      string                `json:"status"`
+	StartedAt   time.Time             `json:"started_at"`
+	FinishedAt  time.Time             `json:"finished_at"`
+	RecordCount *int                  `json:"record_count,omitempty"`
+	Probe       *sqlSafeProbeResult   `json:"probe,omitempty"`
+	Result      *recordsink.SQLResult `json:"result,omitempty"`
+	Failure     *sqlSafeFailure       `json:"failure,omitempty"`
+}
+
+type sqlAPIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type sqlAPIErrorResponse struct {
+	Success bool        `json:"success"`
+	Error   sqlAPIError `json:"error"`
+}
+
+func newSQLOperationsState() *sqlOperationsState {
+	state := &sqlOperationsState{
+		sessions:      make(map[[sha256.Size]byte]sqlOperatorSession),
+		operatorToken: os.Getenv(sqlOperatorTokenEnv),
+		sessionTTL:    sqlOperatorSessionTTL,
+		now:           time.Now,
+		permit:        make(chan struct{}, 1),
+		probe:         recordsink.ProbeSQLTarget,
+		sync:          recordsink.SyncSQLWithResult,
+	}
+	state.permit <- struct{}{}
+	return state
+}
+
+func (s *Server) handlePostSQLTargetSession(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	origin, originHost, ok := strictSameOrigin(r)
+	if !ok {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return
+	}
+	localBootstrap := remoteAddressIsLoopback(r.RemoteAddr) && hostnameIsLoopback(originHost)
+	if !localBootstrap {
+		if !strings.HasPrefix(origin, "https://") || !s.sqlOperations.operatorTokenAuthorized(r) {
+			writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+			return
+		}
+	}
+
+	sessionID, csrfToken, expiresAt, err := s.sqlOperations.createSession(origin)
+	if err != nil {
+		writeSQLAPIError(w, http.StatusInternalServerError, "session_unavailable", "The SQL operator session could not be created.")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sqlSessionCookieName,
+		Value:    sessionID,
+		Path:     "/api/sql-target",
+		Expires:  expiresAt,
+		MaxAge:   int(s.sqlOperations.sessionTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   strings.HasPrefix(origin, "https://"),
+		SameSite: http.SameSiteStrictMode,
+	})
+	writeJSON(w, map[string]interface{}{
+		"authenticated": true,
+		"csrf_token":    csrfToken,
+		"expires_at":    expiresAt,
+	})
+}
+
+func (s *Server) handleDeleteSQLTargetSession(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	cookie, err := r.Cookie(sqlSessionCookieName)
+	if err != nil || cookie.Value == "" {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return
+	}
+	origin, _, ok := strictSameOrigin(r)
+	if !ok {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return
+	}
+	s.sqlOperations.revokeSession(cookie.Value)
+	http.SetCookie(w, &http.Cookie{
+		Name:     sqlSessionCookieName,
+		Value:    "",
+		Path:     "/api/sql-target",
+		Expires:  time.Unix(1, 0).UTC(),
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   strings.HasPrefix(origin, "https://"),
+		SameSite: http.SameSiteStrictMode,
+	})
+	writeJSON(w, map[string]interface{}{"authenticated": false})
+}
+
+func (s *Server) handleGetSQLTargetStatus(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	cfg := s.Config()
+	_, hasLast := s.sqlOperations.lastDiagnostic()
+	reconciliation := recordsink.ReconciliationMode(cfg.Export.Reconciliation)
+	if reconciliation == "" {
+		reconciliation = recordsink.UpsertOnly
+	}
+	writeJSON(w, sqlTargetStatus{
+		Configured:            strings.TrimSpace(cfg.Export.MySQLDSN) != "",
+		Driver:                "mysql",
+		TableConfigured:       strings.TrimSpace(firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable)) != "",
+		BatchSize:             cfg.Export.BatchSize,
+		Reconciliation:        reconciliation,
+		ConnectTimeoutMS:      recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout).Milliseconds(),
+		VerifiedTLSConfigured: strings.TrimSpace(cfg.Export.MySQLTLSCAFile) != "" || strings.TrimSpace(cfg.Export.MySQLTLSServerName) != "",
+		Busy:                  s.sqlOperations.active.Load(),
+		LastResultAvailable:   hasLast,
+	})
+}
+
+func (s *Server) handlePostSQLTargetTest(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), sqlOperationTimeout)
+	defer cancel()
+	if !s.sqlOperations.acquire(ctx) {
+		writeSQLAPIError(w, http.StatusGatewayTimeout, "operation_timeout", "The SQL operation could not start before its deadline.")
+		return
+	}
+	defer s.sqlOperations.release()
+
+	startedAt := s.sqlOperations.currentTime()
+	result, err := s.sqlOperations.probe(ctx, s.sqlTargetProbeOptions(s.Config()))
+	diagnostic := sqlOperationDiagnostic{
+		Operation:  "test",
+		Status:     "succeeded",
+		StartedAt:  startedAt,
+		FinishedAt: s.sqlOperations.currentTime(),
+		Probe:      safeSQLProbeResult(result),
+	}
+	if err != nil {
+		diagnostic.Status = "failed"
+		diagnostic.Failure = safeSQLFailure(recordsink.SQLStageProbe, err)
+	}
+	s.sqlOperations.storeLast(diagnostic)
+	writeSQLOperationDiagnostic(w, diagnostic, err)
+}
+
+func (s *Server) handlePostSQLTargetPreview(w http.ResponseWriter, r *http.Request) {
+	s.handleSQLTargetSync(w, r, true)
+}
+
+func (s *Server) handlePostSQLTargetSync(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	reconciliationToken, ok := decodeManualSyncConfirmation(w, r)
+	if !ok {
+		return
+	}
+	s.runSQLTargetSync(w, r, false, reconciliationToken)
+}
+
+func (s *Server) handleSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun bool) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	s.runSQLTargetSync(w, r, dryRun, "")
+}
+
+func (s *Server) runSQLTargetSync(w http.ResponseWriter, r *http.Request, dryRun bool, reconciliationToken string) {
+	ctx, cancel := context.WithTimeout(r.Context(), sqlOperationTimeout)
+	defer cancel()
+	if !s.sqlOperations.acquire(ctx) {
+		writeSQLAPIError(w, http.StatusGatewayTimeout, "operation_timeout", "The SQL operation could not start before its deadline.")
+		return
+	}
+	defer s.sqlOperations.release()
+
+	cfg := s.Config()
+	reconciliation := recordsink.ReconciliationMode(cfg.Export.Reconciliation)
+	if !dryRun {
+		switch reconciliation {
+		case recordsink.DeleteMissing:
+			writeSQLAPIError(w, http.StatusUnprocessableEntity, "hard_delete_unavailable", "Browser-triggered hard deletion is not available.")
+			return
+		case recordsink.SoftDeleteMissing:
+		default:
+			if reconciliationToken != "" {
+				writeSQLAPIError(w, http.StatusBadRequest, "unexpected_reconciliation_token", "This SQL reconciliation mode does not accept a preview token.")
+				return
+			}
+		}
+	}
+
+	operation := "sync"
+	if dryRun {
+		operation = "preview"
+	}
+	startedAt := s.sqlOperations.currentTime()
+	result, err := s.RecordResult()
+	if err != nil {
+		diagnostic := sqlOperationDiagnostic{
+			Operation:  operation,
+			Status:     "failed",
+			StartedAt:  startedAt,
+			FinishedAt: s.sqlOperations.currentTime(),
+			Failure: &sqlSafeFailure{
+				Code:      "source_unavailable",
+				Stage:     "source",
+				Retryable: true,
+				Message:   "The source records could not be prepared.",
+			},
+		}
+		s.sqlOperations.storeLast(diagnostic)
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]interface{}{"success": false, "diagnostic": diagnostic})
+		return
+	}
+
+	recordCount := len(result.Rows)
+	options := s.sqlTargetSyncOptions(cfg, result, dryRun)
+	if !dryRun {
+		options.ReconciliationToken = reconciliationToken
+	}
+	syncResult, syncErr := s.sqlOperations.sync(ctx, options, result.Rows)
+	syncResult = safeSQLResult(syncResult, options, recordCount, syncErr)
+	diagnostic := sqlOperationDiagnostic{
+		Operation:   operation,
+		Status:      "succeeded",
+		StartedAt:   startedAt,
+		FinishedAt:  s.sqlOperations.currentTime(),
+		RecordCount: &recordCount,
+		Result:      &syncResult,
+	}
+	if syncErr != nil {
+		diagnostic.Status = "failed"
+		diagnostic.Failure = safeSQLFailure(recordsink.SQLStageSync, syncErr)
+	}
+	s.sqlOperations.storeLast(diagnostic)
+	writeSQLOperationDiagnostic(w, diagnostic, syncErr)
+}
+
+func (s *Server) handleGetSQLTargetLastResult(w http.ResponseWriter, r *http.Request) {
+	setSQLOperationHeaders(w)
+	if !s.requireSQLOperatorSession(w, r) {
+		return
+	}
+	diagnostic, ok := s.sqlOperations.lastDiagnostic()
+	if !ok {
+		writeJSON(w, map[string]interface{}{"available": false})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"available": true, "diagnostic": diagnostic})
+}
+
+func (s *Server) sqlTargetProbeOptions(cfg appconfig.Config) recordsink.SQLOptions {
+	return recordsink.SQLOptions{
+		Driver:         "mysql",
+		DSN:            cfg.Export.MySQLDSN,
+		ConnectTimeout: recordsink.ParseSQLConnectTimeout(cfg.Export.MySQLConnectTimeout),
+		MySQLTLS: recordsink.MySQLTLSOptions{
+			CAFile:     cfg.Export.MySQLTLSCAFile,
+			ServerName: cfg.Export.MySQLTLSServerName,
+		},
+	}
+}
+
+func (s *Server) sqlTargetSyncOptions(cfg appconfig.Config, result recordpipe.Result, dryRun bool) recordsink.SQLOptions {
+	options := s.sqlTargetProbeOptions(cfg)
+	options.Table = firstNonEmpty(cfg.Convert.Table, cfg.Export.MySQLTable, recordpipe.SourceTableName(s.currentDBPath()))
+	options.KeyField = result.KeyField
+	options.Batch = cfg.Export.BatchSize
+	options.Reconciliation = recordsink.ReconciliationMode(cfg.Export.Reconciliation)
+	options.DryRun = dryRun
+	if result.Contract != nil {
+		options.ProtectedKeys = append([]string(nil), result.Contract.QuarantinedCodes...)
+	}
+	return options
+}
+
+func (s *Server) requireSQLOperatorSession(w http.ResponseWriter, r *http.Request) bool {
+	origin, _, ok := protectedRequestOrigin(r)
+	if !ok {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return false
+	}
+	cookie, err := r.Cookie(sqlSessionCookieName)
+	if err != nil || cookie.Value == "" {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return false
+	}
+	csrfValues := r.Header.Values(sqlCSRFHeader)
+	if len(csrfValues) != 1 || csrfValues[0] == "" || !s.sqlOperations.sessionAuthorized(cookie.Value, csrfValues[0], origin) {
+		writeSQLAPIError(w, http.StatusForbidden, "forbidden", "SQL operator authorization failed.")
+		return false
+	}
+	return true
+}
+
+func (state *sqlOperationsState) createSession(origin string) (string, string, time.Time, error) {
+	sessionID, err := randomSQLToken()
+	if err != nil {
+		return "", "", time.Time{}, err
+	}
+	csrfToken, err := randomSQLToken()
+	if err != nil {
+		return "", "", time.Time{}, err
+	}
+	now := state.currentTime()
+	expiresAt := now.Add(state.sessionTTL)
+	sessionHash := sha256.Sum256([]byte(sessionID))
+
+	state.sessionsMu.Lock()
+	defer state.sessionsMu.Unlock()
+	state.pruneSessionsLocked(now)
+	if len(state.sessions) >= maximumSQLOperatorTokens {
+		state.evictOldestSessionLocked()
+	}
+	state.sessions[sessionHash] = sqlOperatorSession{
+		csrfHash:  sha256.Sum256([]byte(csrfToken)),
+		origin:    origin,
+		createdAt: now,
+		expiresAt: expiresAt,
+	}
+	return sessionID, csrfToken, expiresAt, nil
+}
+
+func (state *sqlOperationsState) sessionAuthorized(sessionID, csrfToken, origin string) bool {
+	sessionHash := sha256.Sum256([]byte(sessionID))
+	csrfHash := sha256.Sum256([]byte(csrfToken))
+	now := state.currentTime()
+	state.sessionsMu.Lock()
+	defer state.sessionsMu.Unlock()
+	state.pruneSessionsLocked(now)
+	session, ok := state.sessions[sessionHash]
+	if !ok || session.origin != origin || !now.Before(session.expiresAt) {
+		return false
+	}
+	return subtle.ConstantTimeCompare(session.csrfHash[:], csrfHash[:]) == 1
+}
+
+func (state *sqlOperationsState) revokeSession(sessionID string) {
+	sessionHash := sha256.Sum256([]byte(sessionID))
+	state.sessionsMu.Lock()
+	delete(state.sessions, sessionHash)
+	state.sessionsMu.Unlock()
+}
+
+func (state *sqlOperationsState) operatorTokenAuthorized(r *http.Request) bool {
+	if len(state.operatorToken) < 32 || len(state.operatorToken) > 512 {
+		return false
+	}
+	values := r.Header.Values(sqlOperatorTokenHeader)
+	if len(values) != 1 || len(values[0]) == 0 || len(values[0]) > 512 {
+		return false
+	}
+	want := sha256.Sum256([]byte(state.operatorToken))
+	got := sha256.Sum256([]byte(values[0]))
+	return subtle.ConstantTimeCompare(want[:], got[:]) == 1
+}
+
+func (state *sqlOperationsState) pruneSessionsLocked(now time.Time) {
+	for key, session := range state.sessions {
+		if !now.Before(session.expiresAt) {
+			delete(state.sessions, key)
+		}
+	}
+}
+
+func (state *sqlOperationsState) evictOldestSessionLocked() {
+	var oldestKey [sha256.Size]byte
+	var oldest time.Time
+	found := false
+	for key, session := range state.sessions {
+		if !found || session.createdAt.Before(oldest) {
+			oldestKey = key
+			oldest = session.createdAt
+			found = true
+		}
+	}
+	if found {
+		delete(state.sessions, oldestKey)
+	}
+}
+
+func (state *sqlOperationsState) acquire(ctx context.Context) bool {
+	select {
+	case <-state.permit:
+		state.active.Store(true)
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (state *sqlOperationsState) release() {
+	state.active.Store(false)
+	state.permit <- struct{}{}
+}
+
+func (state *sqlOperationsState) currentTime() time.Time {
+	return state.now().UTC()
+}
+
+func (state *sqlOperationsState) storeLast(diagnostic sqlOperationDiagnostic) {
+	copy := cloneSQLOperationDiagnostic(diagnostic)
+	state.lastMu.Lock()
+	state.last = &copy
+	state.lastMu.Unlock()
+}
+
+func (state *sqlOperationsState) lastDiagnostic() (sqlOperationDiagnostic, bool) {
+	state.lastMu.RLock()
+	defer state.lastMu.RUnlock()
+	if state.last == nil {
+		return sqlOperationDiagnostic{}, false
+	}
+	return cloneSQLOperationDiagnostic(*state.last), true
+}
+
+func cloneSQLOperationDiagnostic(value sqlOperationDiagnostic) sqlOperationDiagnostic {
+	copy := value
+	if value.RecordCount != nil {
+		recordCount := *value.RecordCount
+		copy.RecordCount = &recordCount
+	}
+	if value.Probe != nil {
+		probe := *value.Probe
+		copy.Probe = &probe
+	}
+	if value.Result != nil {
+		result := *value.Result
+		if value.Result.ReconciliationEvidence != nil {
+			evidence := *value.Result.ReconciliationEvidence
+			result.ReconciliationEvidence = &evidence
+		}
+		copy.Result = &result
+	}
+	if value.Failure != nil {
+		failure := *value.Failure
+		copy.Failure = &failure
+	}
+	return copy
+}
+
+func randomSQLToken() (string, error) {
+	buffer := make([]byte, 32)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func strictSameOrigin(r *http.Request) (string, string, bool) {
+	values := r.Header.Values("Origin")
+	if len(values) != 1 {
+		return "", "", false
+	}
+	rawOrigin := strings.TrimSpace(values[0])
+	if rawOrigin == "" || strings.Contains(rawOrigin, ",") {
+		return "", "", false
+	}
+	parsed, err := url.Parse(rawOrigin)
+	if err != nil || parsed.User != nil || parsed.Opaque != "" || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", false
+	}
+	origin, originHost, ok := canonicalHTTPOrigin(parsed.Scheme, parsed.Host)
+	if !ok {
+		return "", "", false
+	}
+	expected, _, ok := effectiveRequestOrigin(r)
+	if !ok || origin != expected {
+		return "", "", false
+	}
+	return origin, originHost, true
+}
+
+func protectedRequestOrigin(r *http.Request) (string, string, bool) {
+	if len(r.Header.Values("Origin")) > 0 || (r.Method != http.MethodGet && r.Method != http.MethodHead) {
+		return strictSameOrigin(r)
+	}
+
+	fetchSite := r.Header.Values("Sec-Fetch-Site")
+	referers := r.Header.Values("Referer")
+	if len(fetchSite) != 1 || fetchSite[0] != "same-origin" || len(referers) != 1 {
+		return "", "", false
+	}
+	referer, err := url.Parse(strings.TrimSpace(referers[0]))
+	if err != nil || referer.User != nil || referer.Opaque != "" || referer.Host == "" {
+		return "", "", false
+	}
+	refererOrigin, refererHost, ok := canonicalHTTPOrigin(referer.Scheme, referer.Host)
+	if !ok {
+		return "", "", false
+	}
+	expected, _, ok := effectiveRequestOrigin(r)
+	if !ok || refererOrigin != expected {
+		return "", "", false
+	}
+	return refererOrigin, refererHost, true
+}
+
+func effectiveRequestOrigin(r *http.Request) (string, string, bool) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	authority := r.Host
+
+	// Patris serves HTTP directly, so a remote HTTPS deployment normally
+	// terminates TLS at a local reverse proxy. Forwarded values are honored
+	// only from a loopback peer and only as singular, canonical values.
+	if r.TLS == nil && remoteAddressIsLoopback(r.RemoteAddr) {
+		forwardedProto := r.Header.Values("X-Forwarded-Proto")
+		forwardedHost := r.Header.Values("X-Forwarded-Host")
+		if len(forwardedProto) > 1 || len(forwardedHost) > 1 {
+			return "", "", false
+		}
+		if len(forwardedProto) == 1 {
+			scheme = strings.ToLower(strings.TrimSpace(forwardedProto[0]))
+			if scheme != "http" && scheme != "https" {
+				return "", "", false
+			}
+			if len(forwardedHost) == 1 {
+				authority = strings.TrimSpace(forwardedHost[0])
+			}
+		} else if len(forwardedHost) != 0 {
+			return "", "", false
+		}
+	}
+	return canonicalHTTPOrigin(scheme, authority)
+}
+
+func canonicalHTTPOrigin(scheme, authority string) (string, string, bool) {
+	scheme = strings.ToLower(strings.TrimSpace(scheme))
+	authority = strings.TrimSpace(authority)
+	if (scheme != "http" && scheme != "https") || authority == "" || strings.ContainsAny(authority, "/?#") {
+		return "", "", false
+	}
+	parsed, err := url.Parse(scheme + "://" + authority)
+	if err != nil || parsed.User != nil || parsed.Host == "" || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", false
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" || strings.Contains(hostname, "%") {
+		return "", "", false
+	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		hostname = ip.String()
+	}
+	port := parsed.Port()
+	if port != "" {
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return "", "", false
+		}
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			port = ""
+		}
+	}
+	normalizedAuthority := hostname
+	if strings.Contains(hostname, ":") {
+		normalizedAuthority = "[" + hostname + "]"
+	}
+	if port != "" {
+		normalizedAuthority = net.JoinHostPort(hostname, port)
+	}
+	return scheme + "://" + normalizedAuthority, hostname, true
+}
+
+func remoteAddressIsLoopback(remoteAddress string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(remoteAddress))
+	if err != nil {
+		host = strings.Trim(strings.TrimSpace(remoteAddress), "[]")
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func hostnameIsLoopback(hostname string) bool {
+	hostname = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(hostname)), ".")
+	if hostname == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
+}
+
+func safeSQLProbeResult(result recordsink.SQLProbeResult) *sqlSafeProbeResult {
+	vendor := strings.ToLower(strings.TrimSpace(result.Vendor))
+	if vendor != "mysql" && vendor != "mariadb" {
+		vendor = ""
+	}
+	tlsState := result.TLS
+	switch tlsState {
+	case recordsink.SQLTLSUnknown, recordsink.SQLTLSEncrypted, recordsink.SQLTLSPlaintext:
+	default:
+		tlsState = recordsink.SQLTLSUnknown
+	}
+	elapsedMS := result.ElapsedMS
+	if elapsedMS < 0 {
+		elapsedMS = 0
+	}
+	return &sqlSafeProbeResult{
+		Connected: result.Connected,
+		Driver:    "mysql",
+		Vendor:    vendor,
+		TLS:       tlsState,
+		ElapsedMS: elapsedMS,
+	}
+}
+
+func safeSQLFailure(stage recordsink.SQLFailureStage, err error) *sqlSafeFailure {
+	failure := recordsink.ClassifySQLError(stage, err)
+	if failure == nil {
+		return nil
+	}
+	return &sqlSafeFailure{
+		Code:      string(failure.Code),
+		Stage:     string(failure.Stage),
+		Retryable: failure.Retryable,
+		Message:   failure.Message,
+		Reason:    safeReconciliationGuardCode(failure.Reason),
+	}
+}
+
+func safeSQLResult(result recordsink.SQLResult, options recordsink.SQLOptions, recordCount int, err error) recordsink.SQLResult {
+	result.Inserted = nonNegativeSQLCount(result.Inserted)
+	result.Updated = nonNegativeSQLCount(result.Updated)
+	result.Unchanged = nonNegativeSQLCount(result.Unchanged)
+	result.Deleted = nonNegativeSQLCount(result.Deleted)
+	result.Failed = nonNegativeSQLCount(result.Failed)
+	result.ElapsedMS = max(result.ElapsedMS, 0)
+	result.DryRun = options.DryRun
+	switch options.Reconciliation {
+	case recordsink.SoftDeleteMissing:
+		result.Reconciliation = recordsink.SoftDeleteMissing
+	case recordsink.DeleteMissing:
+		result.Reconciliation = recordsink.DeleteMissing
+	default:
+		result.Reconciliation = recordsink.UpsertOnly
+	}
+	if result.Reconciliation == recordsink.SoftDeleteMissing {
+		result.ReconciliationEvidence = safeSQLReconciliationEvidence(result.ReconciliationEvidence, result.DryRun)
+	} else {
+		result.ReconciliationEvidence = nil
+	}
+	if err != nil {
+		// SyncSQLWithResult is transactional and already reports this shape.
+		// Enforce it again at the HTTP boundary so a future sink implementation
+		// cannot expose partial-looking successes for an unconfirmed transaction.
+		result.Inserted = 0
+		result.Updated = 0
+		result.Unchanged = 0
+		result.Deleted = 0
+		result.Failed = nonNegativeSQLCount(recordCount)
+	}
+	return result
+}
+
+func safeSQLReconciliationEvidence(value *recordsink.SQLReconciliationEvidence, dryRun bool) *recordsink.SQLReconciliationEvidence {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	copy.SourceRows = nonNegativeSQLCount(copy.SourceRows)
+	copy.ProtectedRows = nonNegativeSQLCount(copy.ProtectedRows)
+	copy.TargetRows = nonNegativeSQLCount(copy.TargetRows)
+	copy.MissingRows = nonNegativeSQLCount(copy.MissingRows)
+	copy.WouldSoftDelete = nonNegativeSQLCount(copy.WouldSoftDelete)
+	copy.AlreadySoftDeleted = nonNegativeSQLCount(copy.AlreadySoftDeleted)
+	copy.WouldRestore = nonNegativeSQLCount(copy.WouldRestore)
+	copy.GuardCode = safeReconciliationGuardCode(copy.GuardCode)
+
+	tokenValid := validSoftDeleteConfirmationToken(copy.ConfirmationToken)
+	if copy.ConfirmationToken != "" && !tokenValid {
+		copy.ApplyAllowed = false
+		copy.GuardCode = recordsink.ReconciliationGuardUnknown
+	}
+	if copy.SourceRows == 0 {
+		copy.ApplyAllowed = false
+		if copy.GuardCode == "" {
+			copy.GuardCode = recordsink.ReconciliationGuardEmptySource
+		}
+	}
+	if !copy.ConfirmationRequired {
+		copy.ApplyAllowed = false
+	}
+	if !dryRun || !copy.ApplyAllowed || copy.GuardCode != "" || !tokenValid {
+		copy.ConfirmationToken = ""
+	}
+	if dryRun && copy.ApplyAllowed && copy.ConfirmationRequired && copy.ConfirmationToken == "" {
+		copy.ApplyAllowed = false
+		copy.GuardCode = recordsink.ReconciliationGuardUnknown
+	}
+	return &copy
+}
+
+func safeReconciliationGuardCode(value recordsink.ReconciliationGuardCode) recordsink.ReconciliationGuardCode {
+	switch value {
+	case "",
+		recordsink.ReconciliationGuardEmptySource,
+		recordsink.ReconciliationGuardPreviewRequired,
+		recordsink.ReconciliationGuardPreviewMismatch,
+		recordsink.ReconciliationGuardReservedField,
+		recordsink.ReconciliationGuardInvalidTombstone,
+		recordsink.ReconciliationGuardUnknown:
+		return value
+	default:
+		return recordsink.ReconciliationGuardUnknown
+	}
+}
+
+func validSoftDeleteConfirmationToken(value string) bool {
+	if len(value) != recordsink.SoftDeleteConfirmationTokenLength ||
+		!strings.HasPrefix(value, recordsink.SoftDeleteConfirmationTokenPrefix) {
+		return false
+	}
+	for _, character := range value[len(recordsink.SoftDeleteConfirmationTokenPrefix):] {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func nonNegativeSQLCount(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func decodeManualSyncConfirmation(w http.ResponseWriter, r *http.Request) (string, bool) {
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		writeSQLAPIError(w, http.StatusUnsupportedMediaType, "json_required", "Manual sync requires an application/json request.")
+		return "", false
+	}
+	body := http.MaxBytesReader(w, r.Body, maximumSQLRequestBytes)
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	var request struct {
+		Confirm             string `json:"confirm"`
+		ReconciliationToken string `json:"reconciliation_token,omitempty"`
+	}
+	if err := decoder.Decode(&request); err != nil {
+		writeSQLAPIError(w, http.StatusBadRequest, "invalid_request", "Manual sync requires an explicit confirmation.")
+		return "", false
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeSQLAPIError(w, http.StatusBadRequest, "invalid_request", "Manual sync requires one JSON object.")
+		return "", false
+	}
+	if request.Confirm != sqlManualSyncConfirm {
+		writeSQLAPIError(w, http.StatusBadRequest, "confirmation_required", "Manual sync requires an explicit confirmation.")
+		return "", false
+	}
+	if request.ReconciliationToken != "" && !validSoftDeleteConfirmationToken(request.ReconciliationToken) {
+		writeSQLAPIError(w, http.StatusBadRequest, "invalid_reconciliation_token", "The reconciliation preview token is invalid.")
+		return "", false
+	}
+	return request.ReconciliationToken, true
+}
+
+func writeSQLOperationDiagnostic(w http.ResponseWriter, diagnostic sqlOperationDiagnostic, err error) {
+	status := http.StatusOK
+	if err != nil {
+		status = sqlOperationFailureStatus(diagnostic.Failure)
+	}
+	writeJSONStatus(w, status, map[string]interface{}{"success": err == nil, "diagnostic": diagnostic})
+}
+
+func sqlOperationFailureStatus(failure *sqlSafeFailure) int {
+	if failure == nil {
+		return http.StatusBadGateway
+	}
+	switch failure.Code {
+	case string(recordsink.SQLFailureInvalidConfiguration), string(recordsink.SQLFailureConstraint):
+		return http.StatusUnprocessableEntity
+	case string(recordsink.SQLFailureReconciliation):
+		return http.StatusConflict
+	case string(recordsink.SQLFailureTimeout):
+		return http.StatusGatewayTimeout
+	case string(recordsink.SQLFailureCancelled):
+		return http.StatusRequestTimeout
+	case string(recordsink.SQLFailureTransient), string(recordsink.SQLFailureUnavailable):
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func writeSQLAPIError(w http.ResponseWriter, status int, code, message string) {
+	writeJSONStatus(w, status, sqlAPIErrorResponse{
+		Success: false,
+		Error: sqlAPIError{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+func setSQLOperationHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Add("Vary", "Origin")
+}

--- a/pkg/server/sql_operations_test.go
+++ b/pkg/server/sql_operations_test.go
@@ -1,0 +1,857 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/recordsink"
+)
+
+const (
+	sqlTestOperatorToken = "operator-token-that-is-deliberately-longer-than-32-bytes"
+	sqlTestEdgeToken     = "edge-token-must-never-authorize-sql-operations"
+	sqlTestDSN           = "sql_api_user:super-secret-password@tcp(secret-db.internal:3306)/patris?tls=true"
+	sqlTestCAPath        = "C:/protected/secret-database-ca.pem"
+	sqlTestServerName    = "secret-db.internal"
+)
+
+type sqlTestCredentials struct {
+	origin string
+	scheme string
+	host   string
+	cookie *http.Cookie
+	csrf   string
+}
+
+func newSQLOperationsTestServer(t *testing.T) *Server {
+	t.Helper()
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "products.json")
+	source := []byte(`{
+  "001": {"Code": "001", "Name": "Alpha"},
+  "002": {"Code": "002", "Name": "Beta"}
+}`)
+	if err := os.WriteFile(sourcePath, source, 0o600); err != nil {
+		t.Fatalf("write SQL operations source: %v", err)
+	}
+	manager, err := appconfig.Load(filepath.Join(tempDir, "config.json"))
+	if err != nil {
+		t.Fatalf("load SQL operations config: %v", err)
+	}
+	if err := manager.Update(func(cfg *appconfig.Config) {
+		cfg.Database.Raw = true
+		cfg.Export.MySQLDSN = sqlTestDSN
+		cfg.Export.SQLiteTable = "must_not_be_used_for_mysql_operations"
+		cfg.Export.MySQLTable = "products"
+		cfg.Export.MySQLTLSCAFile = sqlTestCAPath
+		cfg.Export.MySQLTLSServerName = sqlTestServerName
+		cfg.Export.MySQLConnectTimeout = "3s"
+		cfg.Export.BatchSize = 2
+		cfg.Export.Reconciliation = string(recordsink.SoftDeleteMissing)
+		cfg.Edge.Token = sqlTestEdgeToken
+	}); err != nil {
+		t.Fatalf("configure SQL operations server: %v", err)
+	}
+	server, err := NewServerWithOptions(sourcePath, nil, Options{Config: manager}, false)
+	if err != nil {
+		t.Fatalf("create SQL operations server: %v", err)
+	}
+	server.sqlOperations.operatorToken = sqlTestOperatorToken
+	t.Cleanup(func() { server.Close() })
+	return server
+}
+
+func createSQLTestSession(t *testing.T, server *Server, remote bool) sqlTestCredentials {
+	t.Helper()
+	credentials := sqlTestCredentials{
+		origin: "http://127.0.0.1:18080",
+		scheme: "http",
+		host:   "127.0.0.1:18080",
+	}
+	remoteAddress := "127.0.0.1:41234"
+	if remote {
+		credentials.origin = "https://patris.example"
+		credentials.scheme = "https"
+		credentials.host = "patris.example"
+		remoteAddress = "203.0.113.19:41234"
+	}
+	request := httptest.NewRequest(http.MethodPost, credentials.origin+"/api/sql-target/session", nil)
+	request.RemoteAddr = remoteAddress
+	request.Header.Set("Origin", credentials.origin)
+	if remote {
+		request.Header.Set(sqlOperatorTokenHeader, sqlTestOperatorToken)
+	}
+	response := httptest.NewRecorder()
+	server.router.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("create SQL operator session: status=%d body=%s", response.Code, response.Body)
+	}
+	var payload struct {
+		Authenticated bool   `json:"authenticated"`
+		CSRFToken     string `json:"csrf_token"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode SQL operator session: %v", err)
+	}
+	if !payload.Authenticated || len(payload.CSRFToken) < 32 {
+		t.Fatalf("invalid SQL operator session payload: %#v", payload)
+	}
+	cookies := response.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("SQL operator session cookies=%d, want 1", len(cookies))
+	}
+	credentials.cookie = cookies[0]
+	credentials.csrf = payload.CSRFToken
+	return credentials
+}
+
+func newAuthenticatedSQLRequest(credentials sqlTestCredentials, method, path string, body []byte) *http.Request {
+	request := httptest.NewRequest(method, credentials.scheme+"://"+credentials.host+path, bytes.NewReader(body))
+	request.Header.Set("Origin", credentials.origin)
+	request.Header.Set(sqlCSRFHeader, credentials.csrf)
+	request.AddCookie(credentials.cookie)
+	return request
+}
+
+func serveSQLRequest(server *Server, request *http.Request) *httptest.ResponseRecorder {
+	response := httptest.NewRecorder()
+	server.router.ServeHTTP(response, request)
+	return response
+}
+
+func responseContainsAny(response *httptest.ResponseRecorder, values ...string) (string, bool) {
+	body := response.Body.String()
+	for _, value := range values {
+		if value != "" && strings.Contains(body, value) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	tests := []struct {
+		name       string
+		target     string
+		origin     []string
+		remoteAddr string
+		token      string
+		wantStatus int
+	}{
+		{
+			name:       "loopback bootstrap",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "localhost bootstrap",
+			target:     "http://localhost:18080/api/sql-target/session",
+			origin:     []string{"http://localhost:18080"},
+			remoteAddr: "[::1]:41000",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "public host is not loopback bootstrap",
+			target:     "http://patris.example/api/sql-target/session",
+			origin:     []string{"http://patris.example"},
+			remoteAddr: "127.0.0.1:41000",
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "remote plaintext rejected",
+			target:     "http://patris.example/api/sql-target/session",
+			origin:     []string{"http://patris.example"},
+			remoteAddr: "203.0.113.19:41000",
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "remote missing operator token",
+			target:     "https://patris.example/api/sql-target/session",
+			origin:     []string{"https://patris.example"},
+			remoteAddr: "203.0.113.19:41000",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "edge token cannot authorize SQL",
+			target:     "https://patris.example/api/sql-target/session",
+			origin:     []string{"https://patris.example"},
+			remoteAddr: "203.0.113.19:41000",
+			token:      sqlTestEdgeToken,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "remote dedicated token over TLS",
+			target:     "https://patris.example/api/sql-target/session",
+			origin:     []string{"https://patris.example"},
+			remoteAddr: "203.0.113.19:41000",
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "trusted loopback reverse proxy",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"https://patris.example"},
+			remoteAddr: "127.0.0.1:41000",
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "untrusted peer cannot spoof forwarded TLS",
+			target:     "http://patris.example/api/sql-target/session",
+			origin:     []string{"https://patris.example"},
+			remoteAddr: "203.0.113.19:41000",
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "missing origin",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "multiple origin headers",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080", "http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "origin host mismatch",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://localhost:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "origin with path rejected",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080/path"},
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "opaque origin rejected",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"null"},
+			remoteAddr: "127.0.0.1:41000",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, test.target, nil)
+			request.RemoteAddr = test.remoteAddr
+			for _, origin := range test.origin {
+				request.Header.Add("Origin", origin)
+			}
+			if test.token != "" {
+				request.Header.Set(sqlOperatorTokenHeader, test.token)
+			}
+			if test.name == "trusted loopback reverse proxy" {
+				request.Header.Set("X-Forwarded-Proto", "https")
+				request.Header.Set("X-Forwarded-Host", "patris.example")
+			}
+			if test.name == "untrusted peer cannot spoof forwarded TLS" {
+				request.Header.Set("X-Forwarded-Proto", "https")
+			}
+			response := serveSQLRequest(server, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status=%d, want %d: %s", response.Code, test.wantStatus, response.Body)
+			}
+			if value, found := responseContainsAny(response, sqlTestOperatorToken, sqlTestEdgeToken, sqlTestDSN, sqlTestCAPath, sqlTestServerName); found {
+				t.Fatalf("response exposed protected value %q: %s", value, response.Body)
+			}
+		})
+	}
+}
+
+func TestSQLOperatorSessionCookieCSRFOriginAndExpiry(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	now := time.Date(2026, time.July, 24, 10, 0, 0, 0, time.UTC)
+	server.sqlOperations.now = func() time.Time { return now }
+	server.sqlOperations.sessionTTL = 2 * time.Minute
+	credentials := createSQLTestSession(t, server, false)
+
+	if !credentials.cookie.HttpOnly || credentials.cookie.SameSite != http.SameSiteStrictMode ||
+		credentials.cookie.Path != "/api/sql-target" || credentials.cookie.Secure {
+		t.Fatalf("unsafe loopback session cookie: %#v", credentials.cookie)
+	}
+	if !credentials.cookie.Expires.Equal(now.Add(2 * time.Minute)) {
+		t.Fatalf("cookie expiry=%v, want %v", credentials.cookie.Expires, now.Add(2*time.Minute))
+	}
+
+	valid := newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil)
+	if response := serveSQLRequest(server, valid); response.Code != http.StatusOK {
+		t.Fatalf("valid session status=%d: %s", response.Code, response.Body)
+	}
+	browserRealisticGET := newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil)
+	browserRealisticGET.Header.Del("Origin")
+	browserRealisticGET.Header.Set("Sec-Fetch-Site", "same-origin")
+	browserRealisticGET.Header.Set("Sec-Fetch-Mode", "cors")
+	browserRealisticGET.Header.Set("Referer", credentials.origin+"/")
+	if response := serveSQLRequest(server, browserRealisticGET); response.Code != http.StatusOK {
+		t.Fatalf("browser-realistic GET without Origin status=%d: %s", response.Code, response.Body)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*http.Request)
+	}{
+		{"missing CSRF", func(request *http.Request) { request.Header.Del(sqlCSRFHeader) }},
+		{"wrong CSRF", func(request *http.Request) { request.Header.Set(sqlCSRFHeader, "wrong") }},
+		{"multiple CSRF", func(request *http.Request) { request.Header.Add(sqlCSRFHeader, "second") }},
+		{"missing cookie", func(request *http.Request) { request.Header.Del("Cookie") }},
+		{"missing origin", func(request *http.Request) { request.Header.Del("Origin") }},
+		{"wrong origin", func(request *http.Request) { request.Header.Set("Origin", "http://localhost:18080") }},
+		{"cross-site fetch metadata", func(request *http.Request) {
+			request.Header.Del("Origin")
+			request.Header.Set("Sec-Fetch-Site", "cross-site")
+			request.Header.Set("Referer", credentials.origin+"/")
+		}},
+		{"missing referer fallback", func(request *http.Request) {
+			request.Header.Del("Origin")
+			request.Header.Set("Sec-Fetch-Site", "same-origin")
+		}},
+		{"mismatched referer fallback", func(request *http.Request) {
+			request.Header.Del("Origin")
+			request.Header.Set("Sec-Fetch-Site", "same-origin")
+			request.Header.Set("Referer", "http://localhost:18080/")
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil)
+			test.mutate(request)
+			response := serveSQLRequest(server, request)
+			if response.Code != http.StatusForbidden {
+				t.Fatalf("status=%d, want 403: %s", response.Code, response.Body)
+			}
+		})
+	}
+
+	now = now.Add(2 * time.Minute)
+	expired := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil))
+	if expired.Code != http.StatusForbidden {
+		t.Fatalf("expired session status=%d, want 403: %s", expired.Code, expired.Body)
+	}
+}
+
+func TestSQLOperatorSessionRevokeRequiresOriginAndCSRF(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+
+	wrongOrigin := newAuthenticatedSQLRequest(credentials, http.MethodDelete, "/api/sql-target/session", nil)
+	wrongOrigin.Header.Set("Origin", "http://localhost:18080")
+	if response := serveSQLRequest(server, wrongOrigin); response.Code != http.StatusForbidden {
+		t.Fatalf("wrong-origin revoke status=%d, want 403: %s", response.Code, response.Body)
+	}
+	missingCSRF := newAuthenticatedSQLRequest(credentials, http.MethodDelete, "/api/sql-target/session", nil)
+	missingCSRF.Header.Del(sqlCSRFHeader)
+	if response := serveSQLRequest(server, missingCSRF); response.Code != http.StatusForbidden {
+		t.Fatalf("missing-CSRF revoke status=%d, want 403: %s", response.Code, response.Body)
+	}
+	if response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil)); response.Code != http.StatusOK {
+		t.Fatalf("failed revoke attempts invalidated session: status=%d body=%s", response.Code, response.Body)
+	}
+
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodDelete, "/api/sql-target/session", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("revoke status=%d: %s", response.Code, response.Body)
+	}
+	var payload struct {
+		Authenticated bool `json:"authenticated"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode revoke response: %v", err)
+	}
+	if payload.Authenticated {
+		t.Fatalf("revoke response remained authenticated: %s", response.Body)
+	}
+	cookies := response.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != sqlSessionCookieName || cookies[0].Value != "" ||
+		cookies[0].MaxAge >= 0 || !cookies[0].HttpOnly || cookies[0].SameSite != http.SameSiteStrictMode {
+		t.Fatalf("revoke did not expire the protected session cookie: %#v", cookies)
+	}
+	if followup := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil)); followup.Code != http.StatusForbidden {
+		t.Fatalf("revoked session status=%d, want 403: %s", followup.Code, followup.Body)
+	}
+
+	remoteCredentials := createSQLTestSession(t, server, true)
+	if !remoteCredentials.cookie.Secure {
+		t.Fatalf("remote TLS session cookie is not Secure: %#v", remoteCredentials.cookie)
+	}
+}
+
+func TestSQLTargetStatusIsUsefulAndSecretFree(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status endpoint=%d: %s", response.Code, response.Body)
+	}
+	var status sqlTargetStatus
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatalf("decode target status: %v", err)
+	}
+	if !status.Configured || !status.TableConfigured || status.Driver != "mysql" || status.BatchSize != 2 ||
+		status.Reconciliation != recordsink.SoftDeleteMissing || status.ConnectTimeoutMS != 3000 ||
+		!status.VerifiedTLSConfigured || status.Busy || status.LastResultAvailable {
+		t.Fatalf("unexpected SQL target status: %#v", status)
+	}
+	if cacheControl := response.Header().Get("Cache-Control"); cacheControl != "no-store" {
+		t.Fatalf("Cache-Control=%q, want no-store", cacheControl)
+	}
+	if value, found := responseContainsAny(response, sqlTestOperatorToken, sqlTestEdgeToken, sqlTestDSN, "super-secret-password", sqlTestCAPath, sqlTestServerName); found {
+		t.Fatalf("status exposed protected value %q: %s", value, response.Body)
+	}
+}
+
+func TestSQLTargetProbeAndLastResultRedactTargetAndDriverErrors(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	var captured recordsink.SQLOptions
+	server.sqlOperations.probe = func(_ context.Context, options recordsink.SQLOptions) (recordsink.SQLProbeResult, error) {
+		captured = options
+		return recordsink.SQLProbeResult{
+			Connected:     true,
+			Driver:        "mysql",
+			Vendor:        "MariaDB",
+			ServerVersion: "11.4.2-secret-build-metadata",
+			TLS:           recordsink.SQLTLSEncrypted,
+			ElapsedMS:     19,
+		}, nil
+	}
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/test", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("probe status=%d: %s", response.Code, response.Body)
+	}
+	if captured.DSN != sqlTestDSN || captured.MySQLTLS.CAFile != sqlTestCAPath ||
+		captured.MySQLTLS.ServerName != sqlTestServerName || captured.ConnectTimeout != 3*time.Second {
+		t.Fatalf("probe did not receive protected server configuration: %#v", captured)
+	}
+	if value, found := responseContainsAny(response, sqlTestDSN, "super-secret-password", sqlTestCAPath, sqlTestServerName, "secret-build-metadata"); found {
+		t.Fatalf("probe exposed protected value %q: %s", value, response.Body)
+	}
+	var probePayload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&probePayload); err != nil {
+		t.Fatalf("decode probe response: %v", err)
+	}
+	if !probePayload.Success || probePayload.Diagnostic.Probe == nil ||
+		probePayload.Diagnostic.Probe.Vendor != "mariadb" ||
+		probePayload.Diagnostic.Probe.TLS != recordsink.SQLTLSEncrypted {
+		t.Fatalf("unexpected safe probe response: %#v", probePayload)
+	}
+
+	rawFailure := fmt.Sprintf("dial %s with CA %s failed: raw-driver-secret", sqlTestDSN, sqlTestCAPath)
+	server.sqlOperations.probe = func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error) {
+		return recordsink.SQLProbeResult{}, errors.New(rawFailure)
+	}
+	failed := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/test", nil))
+	if failed.Code != http.StatusBadGateway {
+		t.Fatalf("failed probe status=%d, want 502: %s", failed.Code, failed.Body)
+	}
+	if value, found := responseContainsAny(failed, sqlTestDSN, "super-secret-password", sqlTestCAPath, sqlTestServerName, "raw-driver-secret"); found {
+		t.Fatalf("failure exposed protected value %q: %s", value, failed.Body)
+	}
+
+	last := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/last-result", nil))
+	if last.Code != http.StatusOK {
+		t.Fatalf("last result status=%d: %s", last.Code, last.Body)
+	}
+	if value, found := responseContainsAny(last, sqlTestDSN, "super-secret-password", sqlTestCAPath, sqlTestServerName, "raw-driver-secret"); found {
+		t.Fatalf("last result exposed protected value %q: %s", value, last.Body)
+	}
+	var lastPayload struct {
+		Available  bool                   `json:"available"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(last.Body).Decode(&lastPayload); err != nil {
+		t.Fatalf("decode last result: %v", err)
+	}
+	if !lastPayload.Available || lastPayload.Diagnostic.Status != "failed" ||
+		lastPayload.Diagnostic.Failure == nil ||
+		lastPayload.Diagnostic.Failure.Code != string(recordsink.SQLFailureUnknown) {
+		t.Fatalf("unexpected last result: %#v", lastPayload)
+	}
+}
+
+func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	confirmationToken := recordsink.SoftDeleteConfirmationTokenPrefix + strings.Repeat("a", 64)
+	var (
+		mu       sync.Mutex
+		calls    int
+		options  []recordsink.SQLOptions
+		rowCodes [][]string
+	)
+	server.sqlOperations.sync = func(_ context.Context, option recordsink.SQLOptions, rows []map[string]interface{}) (recordsink.SQLResult, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		options = append(options, option)
+		codes := make([]string, 0, len(rows))
+		for _, row := range rows {
+			codes = append(codes, fmt.Sprint(row["Code"]))
+		}
+		sort.Strings(codes)
+		rowCodes = append(rowCodes, codes)
+		result := recordsink.SQLResult{
+			Inserted:       len(rows),
+			ElapsedMS:      -7,
+			DryRun:         !option.DryRun,
+			Reconciliation: recordsink.ReconciliationMode("unsafe-value"),
+			ReconciliationEvidence: &recordsink.SQLReconciliationEvidence{
+				SourceRows:           len(rows),
+				TargetRows:           3,
+				MissingRows:          1,
+				WouldSoftDelete:      1,
+				PartialSourceRisk:    true,
+				ConfirmationRequired: true,
+				ApplyAllowed:         true,
+			},
+		}
+		if option.DryRun {
+			result.ReconciliationEvidence.ConfirmationToken = confirmationToken
+			return result, nil
+		}
+		if option.ReconciliationToken == "" {
+			result.ReconciliationEvidence.ApplyAllowed = false
+			result.ReconciliationEvidence.GuardCode = recordsink.ReconciliationGuardPreviewRequired
+			return result, &recordsink.ReconciliationGuardError{Code: recordsink.ReconciliationGuardPreviewRequired}
+		}
+		return result, nil
+	}
+
+	preview := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if preview.Code != http.StatusOK {
+		t.Fatalf("preview status=%d: %s", preview.Code, preview.Body)
+	}
+	var previewPayload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(preview.Body).Decode(&previewPayload); err != nil {
+		t.Fatalf("decode preview: %v", err)
+	}
+	if !previewPayload.Success || previewPayload.Diagnostic.Operation != "preview" ||
+		previewPayload.Diagnostic.Result == nil || !previewPayload.Diagnostic.Result.DryRun ||
+		previewPayload.Diagnostic.Result.Reconciliation != recordsink.SoftDeleteMissing ||
+		previewPayload.Diagnostic.Result.Inserted != 2 || previewPayload.Diagnostic.Result.ElapsedMS != 0 {
+		t.Fatalf("unexpected preview diagnostic: %#v", previewPayload)
+	}
+	evidence := previewPayload.Diagnostic.Result.ReconciliationEvidence
+	if evidence == nil || evidence.ConfirmationToken != confirmationToken ||
+		!evidence.ConfirmationRequired || !evidence.ApplyAllowed ||
+		evidence.SourceRows != 2 || evidence.TargetRows != 3 ||
+		evidence.MissingRows != 1 || evidence.WouldSoftDelete != 1 ||
+		!evidence.PartialSourceRisk {
+		t.Fatalf("preview omitted safe reconciliation evidence: %#v", evidence)
+	}
+
+	rejectedRequests := []struct {
+		name        string
+		contentType string
+		body        []byte
+		wantStatus  int
+	}{
+		{"missing content type", "", []byte(`{"confirm":"manual_sync"}`), http.StatusUnsupportedMediaType},
+		{"missing confirmation", "application/json", []byte(`{}`), http.StatusBadRequest},
+		{"wrong confirmation", "application/json", []byte(`{"confirm":"yes"}`), http.StatusBadRequest},
+		{"unknown field", "application/json", []byte(`{"confirm":"manual_sync","dsn":"forbidden"}`), http.StatusBadRequest},
+		{"malformed reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":"sha256:not-a-valid-plan"}`), http.StatusBadRequest},
+		{"uppercase reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":"sha256:` + strings.Repeat("A", 64) + `"}`), http.StatusBadRequest},
+		{"padded reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":" ` + confirmationToken + `"}`), http.StatusBadRequest},
+		{"multiple objects", "application/json", []byte(`{"confirm":"manual_sync"} {}`), http.StatusBadRequest},
+		{"oversized", "application/json", []byte(`{"confirm":"manual_sync","padding":"` + strings.Repeat("x", maximumSQLRequestBytes) + `"}`), http.StatusBadRequest},
+	}
+	for _, test := range rejectedRequests {
+		t.Run(test.name, func(t *testing.T) {
+			request := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", test.body)
+			if test.contentType != "" {
+				request.Header.Set("Content-Type", test.contentType)
+			}
+			response := serveSQLRequest(server, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status=%d, want %d: %s", response.Code, test.wantStatus, response.Body)
+			}
+		})
+	}
+	mu.Lock()
+	if calls != 1 {
+		t.Fatalf("sync called %d times before confirmation, want preview only", calls)
+	}
+	mu.Unlock()
+
+	missingTokenRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", []byte(`{"confirm":"manual_sync"}`))
+	missingTokenRequest.Header.Set("Content-Type", "application/json")
+	missingToken := serveSQLRequest(server, missingTokenRequest)
+	if missingToken.Code != http.StatusConflict {
+		t.Fatalf("soft-delete sync without preview token status=%d, want 409: %s", missingToken.Code, missingToken.Body)
+	}
+	var missingTokenPayload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(missingToken.Body).Decode(&missingTokenPayload); err != nil {
+		t.Fatalf("decode missing-token guard: %v", err)
+	}
+	if missingTokenPayload.Success || missingTokenPayload.Diagnostic.Failure == nil ||
+		missingTokenPayload.Diagnostic.Failure.Code != string(recordsink.SQLFailureReconciliation) ||
+		missingTokenPayload.Diagnostic.Failure.Reason != recordsink.ReconciliationGuardPreviewRequired ||
+		missingTokenPayload.Diagnostic.Result == nil ||
+		missingTokenPayload.Diagnostic.Result.ReconciliationEvidence == nil ||
+		missingTokenPayload.Diagnostic.Result.ReconciliationEvidence.ConfirmationToken != "" {
+		t.Fatalf("missing-token guard was unsafe or incomplete: %#v", missingTokenPayload)
+	}
+
+	confirmedBody := []byte(fmt.Sprintf(`{"confirm":"manual_sync","reconciliation_token":%q}`, confirmationToken))
+	confirmedRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", confirmedBody)
+	confirmedRequest.Header.Set("Content-Type", "application/json; charset=utf-8")
+	confirmed := serveSQLRequest(server, confirmedRequest)
+	if confirmed.Code != http.StatusOK {
+		t.Fatalf("confirmed sync status=%d: %s", confirmed.Code, confirmed.Body)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 3 || len(options) != 3 || !options[0].DryRun || options[1].DryRun || options[2].DryRun {
+		t.Fatalf("unexpected SQL sink calls/options: calls=%d options=%#v", calls, options)
+	}
+	for index, option := range options {
+		if option.DSN != sqlTestDSN || option.Table != "products" || option.KeyField != "Code" ||
+			option.Batch != 2 || option.Reconciliation != recordsink.SoftDeleteMissing ||
+			option.MySQLTLS.CAFile != sqlTestCAPath || option.MySQLTLS.ServerName != sqlTestServerName {
+			t.Fatalf("sink option[%d] did not use shared protected configuration: %#v", index, option)
+		}
+	}
+	if options[0].ReconciliationToken != "" || options[1].ReconciliationToken != "" ||
+		options[2].ReconciliationToken != confirmationToken {
+		t.Fatalf("preview token was not passed only to the confirmed apply: %#v", options)
+	}
+	wantCodes := []string{"001", "002"}
+	for index, codes := range rowCodes {
+		if fmt.Sprint(codes) != fmt.Sprint(wantCodes) {
+			t.Fatalf("sink call[%d] codes=%v, want %v", index, codes, wantCodes)
+		}
+	}
+	if value, found := responseContainsAny(confirmed, sqlTestDSN, "super-secret-password", sqlTestCAPath, sqlTestServerName); found {
+		t.Fatalf("sync exposed protected value %q: %s", value, confirmed.Body)
+	}
+}
+
+func TestSQLTargetFailedSyncCannotReportPartialSuccessOrRawError(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	invalidEvidenceToken := "sha256:must-not-cross-the-http-boundary"
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		return recordsink.SQLResult{
+			Inserted:  1,
+			Updated:   1,
+			Unchanged: -1,
+			Deleted:   9,
+			Failed:    -1,
+			ElapsedMS: -1,
+			ReconciliationEvidence: &recordsink.SQLReconciliationEvidence{
+				SourceRows:           -3,
+				ProtectedRows:        -2,
+				TargetRows:           -1,
+				ConfirmationRequired: true,
+				ApplyAllowed:         true,
+				ConfirmationToken:    invalidEvidenceToken,
+				GuardCode:            recordsink.ReconciliationGuardCode("raw-internal-guard"),
+			},
+		}, errors.New("raw driver error at " + sqlTestDSN)
+	}
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if response.Code != http.StatusBadGateway {
+		t.Fatalf("failed sync status=%d, want 502: %s", response.Code, response.Body)
+	}
+	if value, found := responseContainsAny(response, sqlTestDSN, "super-secret-password", "raw driver error", invalidEvidenceToken, "raw-internal-guard"); found {
+		t.Fatalf("sync failure exposed protected value %q: %s", value, response.Body)
+	}
+	var payload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode failed sync: %v", err)
+	}
+	result := payload.Diagnostic.Result
+	if payload.Success || result == nil || result.Inserted != 0 || result.Updated != 0 ||
+		result.Unchanged != 0 || result.Deleted != 0 || result.Failed != 2 ||
+		result.ElapsedMS != 0 || !result.DryRun || result.Reconciliation != recordsink.SoftDeleteMissing {
+		t.Fatalf("failed sync exposed partial-looking result: %#v", payload)
+	}
+	evidence := result.ReconciliationEvidence
+	if evidence == nil || evidence.SourceRows != 0 || evidence.ProtectedRows != 0 ||
+		evidence.TargetRows != 0 || evidence.ApplyAllowed || evidence.ConfirmationToken != "" ||
+		evidence.GuardCode != recordsink.ReconciliationGuardUnknown {
+		t.Fatalf("failed sync exposed unsafe reconciliation evidence: %#v", evidence)
+	}
+}
+
+func TestSQLTargetBlocksBrowserHardDeleteAndIrrelevantTokens(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	calls := 0
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		calls++
+		return recordsink.SQLResult{}, nil
+	}
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Export.Reconciliation = string(recordsink.DeleteMissing)
+	}); err != nil {
+		t.Fatalf("set hard-delete mode: %v", err)
+	}
+	hardDeleteRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", []byte(`{"confirm":"manual_sync"}`))
+	hardDeleteRequest.Header.Set("Content-Type", "application/json")
+	hardDelete := serveSQLRequest(server, hardDeleteRequest)
+	if hardDelete.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("hard-delete sync status=%d, want 422: %s", hardDelete.Code, hardDelete.Body)
+	}
+	if calls != 0 {
+		t.Fatalf("browser hard-delete request reached the SQL sink %d times", calls)
+	}
+
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Export.Reconciliation = string(recordsink.UpsertOnly)
+	}); err != nil {
+		t.Fatalf("set upsert-only mode: %v", err)
+	}
+	token := recordsink.SoftDeleteConfirmationTokenPrefix + strings.Repeat("b", 64)
+	unexpectedTokenBody := []byte(fmt.Sprintf(`{"confirm":"manual_sync","reconciliation_token":%q}`, token))
+	unexpectedTokenRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", unexpectedTokenBody)
+	unexpectedTokenRequest.Header.Set("Content-Type", "application/json")
+	unexpectedToken := serveSQLRequest(server, unexpectedTokenRequest)
+	if unexpectedToken.Code != http.StatusBadRequest {
+		t.Fatalf("upsert with irrelevant token status=%d, want 400: %s", unexpectedToken.Code, unexpectedToken.Body)
+	}
+	if calls != 0 {
+		t.Fatalf("irrelevant preview token reached the SQL sink %d times", calls)
+	}
+}
+
+func TestSQLOperationsSerializeMutatingAndProbeRequests(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	syncEntered := make(chan struct{})
+	releaseSync := make(chan struct{})
+	probeEntered := make(chan struct{})
+	server.sqlOperations.sync = func(ctx context.Context, _ recordsink.SQLOptions, rows []map[string]interface{}) (recordsink.SQLResult, error) {
+		close(syncEntered)
+		select {
+		case <-releaseSync:
+			return recordsink.SQLResult{Inserted: len(rows)}, nil
+		case <-ctx.Done():
+			return recordsink.SQLResult{}, ctx.Err()
+		}
+	}
+	server.sqlOperations.probe = func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error) {
+		close(probeEntered)
+		return recordsink.SQLProbeResult{Connected: true, Driver: "mysql"}, nil
+	}
+
+	previewDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		previewDone <- serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	}()
+	select {
+	case <-syncEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("preview did not enter the SQL sink")
+	}
+
+	statusResponse := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil))
+	var status sqlTargetStatus
+	if statusResponse.Code != http.StatusOK {
+		t.Fatalf("busy status endpoint=%d: %s", statusResponse.Code, statusResponse.Body)
+	}
+	if err := json.NewDecoder(statusResponse.Body).Decode(&status); err != nil {
+		t.Fatalf("decode busy status: %v", err)
+	}
+	if !status.Busy {
+		t.Fatalf("status did not report active SQL operation: %#v", status)
+	}
+
+	probeDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		probeDone <- serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/test", nil))
+	}()
+	select {
+	case <-probeEntered:
+		t.Fatal("probe entered while preview held the serialized operation permit")
+	case <-time.After(150 * time.Millisecond):
+	}
+	close(releaseSync)
+
+	select {
+	case response := <-previewDone:
+		if response.Code != http.StatusOK {
+			t.Fatalf("preview status=%d: %s", response.Code, response.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("preview did not complete")
+	}
+	select {
+	case <-probeEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not enter after preview released the operation permit")
+	}
+	select {
+	case response := <-probeDone:
+		if response.Code != http.StatusOK {
+			t.Fatalf("probe status=%d: %s", response.Code, response.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not complete")
+	}
+}
+
+func TestSQLTargetSourceFailureAndRouteMethodsAreSafe(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	server.dataSourceMu.Lock()
+	source := server.dataSource
+	server.dataSource = nil
+	server.dataSourceMu.Unlock()
+	t.Cleanup(func() {
+		server.dataSourceMu.Lock()
+		server.dataSource = source
+		server.dataSourceMu.Unlock()
+	})
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("source failure status=%d, want 503: %s", response.Code, response.Body)
+	}
+	if strings.Contains(response.Body.String(), "data source is not initialized") {
+		t.Fatalf("source failure exposed internal error: %s", response.Body)
+	}
+
+	methodResponse := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodDelete, "/api/sql-target/status", nil))
+	if methodResponse.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("unexpected method status=%d, want 405: %s", methodResponse.Code, methodResponse.Body)
+	}
+}

--- a/pkg/server/sql_operations_test.go
+++ b/pkg/server/sql_operations_test.go
@@ -43,6 +43,15 @@ type legacySQLTestSource struct {
 	rawCalls int
 }
 
+type sqlFingerprintCancelValue struct {
+	cancel context.CancelFunc
+}
+
+func (value sqlFingerprintCancelValue) String() string {
+	value.cancel()
+	return "private-fingerprint-value"
+}
+
 func (source *legacySQLTestSource) GetRecords() ([]map[string]interface{}, error) {
 	return source.GetRawRecords()
 }
@@ -1293,6 +1302,54 @@ func TestSQLSourcePreparationCancellationDoesNotWedgeOperations(t *testing.T) {
 	cancelImmediately()
 	if _, err := server.RecordResultContext(cancelled); !errors.Is(err, context.Canceled) {
 		t.Fatalf("pre-cancelled RecordResultContext error=%v, want context.Canceled", err)
+	}
+}
+
+func TestSQLSourceFingerprintCancellationDoesNotReachSink(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	request := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil)
+	requestContext, cancel := context.WithCancel(request.Context())
+	defer cancel()
+	request = request.WithContext(requestContext)
+
+	server.sqlOperations.records = func(context.Context) (recordpipe.Result, error) {
+		return recordpipe.Result{
+			Rows: []map[string]interface{}{{
+				"Code":  "A",
+				"value": sqlFingerprintCancelValue{cancel: cancel},
+			}},
+			KeyField: "Code",
+		}, nil
+	}
+	sinkCalls := 0
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		sinkCalls++
+		return recordsink.SQLResult{}, nil
+	}
+
+	response := serveSQLRequest(server, request)
+	if response.Code != http.StatusRequestTimeout {
+		t.Fatalf("fingerprint cancellation status=%d, want 408: %s", response.Code, response.Body)
+	}
+	var payload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode fingerprint cancellation: %v", err)
+	}
+	failure := payload.Diagnostic.Failure
+	if payload.Success || payload.Diagnostic.Status != "failed" ||
+		failure == nil ||
+		failure.Code != string(recordsink.SQLFailureCancelled) ||
+		failure.Stage != "source" ||
+		failure.Retryable ||
+		sinkCalls != 0 {
+		t.Fatalf("unsafe fingerprint cancellation diagnostic=%#v sinkCalls=%d", payload, sinkCalls)
+	}
+	if strings.Contains(response.Body.String(), "private-fingerprint-value") {
+		t.Fatalf("fingerprint cancellation exposed source value: %s", response.Body)
 	}
 }
 

--- a/pkg/server/sql_operations_test.go
+++ b/pkg/server/sql_operations_test.go
@@ -3,9 +3,11 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +19,7 @@ import (
 	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
 	"github.com/atomicdeploy/patris-export/pkg/recordsink"
 )
 
@@ -34,6 +37,27 @@ type sqlTestCredentials struct {
 	host   string
 	cookie *http.Cookie
 	csrf   string
+}
+
+type legacySQLTestSource struct {
+	rawCalls int
+}
+
+func (source *legacySQLTestSource) GetRecords() ([]map[string]interface{}, error) {
+	return source.GetRawRecords()
+}
+
+func (source *legacySQLTestSource) GetRawRecords() ([]map[string]interface{}, error) {
+	source.rawCalls++
+	return []map[string]interface{}{{"Code": "legacy"}}, nil
+}
+
+func (source *legacySQLTestSource) GetPath() string {
+	return "legacy.json"
+}
+
+func (source *legacySQLTestSource) Close() error {
+	return nil
 }
 
 func newSQLOperationsTestServer(t *testing.T) *Server {
@@ -91,8 +115,8 @@ func createSQLTestSession(t *testing.T, server *Server, remote bool) sqlTestCred
 	request := httptest.NewRequest(http.MethodPost, credentials.origin+"/api/sql-target/session", nil)
 	request.RemoteAddr = remoteAddress
 	request.Header.Set("Origin", credentials.origin)
-	if remote {
-		request.Header.Set(sqlOperatorTokenHeader, sqlTestOperatorToken)
+	if server.sqlOperations.operatorToken != "" {
+		request.Header.Set(sqlOperatorTokenHeader, server.sqlOperations.operatorToken)
 	}
 	response := httptest.NewRecorder()
 	server.router.ServeHTTP(response, request)
@@ -149,18 +173,37 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 		target     string
 		origin     []string
 		remoteAddr string
+		configured string
 		token      string
+		headers    map[string]string
 		wantStatus int
 	}{
 		{
-			name:       "loopback bootstrap",
+			name:       "configured loopback requires token",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			configured: sqlTestOperatorToken,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "configured loopback accepts exact token",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			configured: sqlTestOperatorToken,
+			token:      sqlTestOperatorToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "unconfigured direct loopback bootstrap",
 			target:     "http://127.0.0.1:18080/api/sql-target/session",
 			origin:     []string{"http://127.0.0.1:18080"},
 			remoteAddr: "127.0.0.1:41000",
 			wantStatus: http.StatusOK,
 		},
 		{
-			name:       "localhost bootstrap",
+			name:       "unconfigured direct localhost bootstrap",
 			target:     "http://localhost:18080/api/sql-target/session",
 			origin:     []string{"http://localhost:18080"},
 			remoteAddr: "[::1]:41000",
@@ -171,6 +214,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "http://patris.example/api/sql-target/session",
 			origin:     []string{"http://patris.example"},
 			remoteAddr: "127.0.0.1:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestOperatorToken,
 			wantStatus: http.StatusForbidden,
 		},
@@ -179,6 +223,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "http://patris.example/api/sql-target/session",
 			origin:     []string{"http://patris.example"},
 			remoteAddr: "203.0.113.19:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestOperatorToken,
 			wantStatus: http.StatusForbidden,
 		},
@@ -187,6 +232,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "https://patris.example/api/sql-target/session",
 			origin:     []string{"https://patris.example"},
 			remoteAddr: "203.0.113.19:41000",
+			configured: sqlTestOperatorToken,
 			wantStatus: http.StatusForbidden,
 		},
 		{
@@ -194,6 +240,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "https://patris.example/api/sql-target/session",
 			origin:     []string{"https://patris.example"},
 			remoteAddr: "203.0.113.19:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestEdgeToken,
 			wantStatus: http.StatusForbidden,
 		},
@@ -202,6 +249,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "https://patris.example/api/sql-target/session",
 			origin:     []string{"https://patris.example"},
 			remoteAddr: "203.0.113.19:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestOperatorToken,
 			wantStatus: http.StatusOK,
 		},
@@ -210,15 +258,46 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			target:     "http://127.0.0.1:18080/api/sql-target/session",
 			origin:     []string{"https://patris.example"},
 			remoteAddr: "127.0.0.1:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestOperatorToken,
+			headers: map[string]string{
+				"X-Forwarded-Proto": "https",
+				"X-Forwarded-Host":  "patris.example",
+			},
 			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "proxy marker disables tokenless rewritten loopback",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			headers:    map[string]string{"X-Forwarded-For": "203.0.113.19"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "standard Forwarded marker disables tokenless rewritten loopback",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			headers:    map[string]string{"Forwarded": "for=203.0.113.19;proto=http"},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "nonstandard X-Forwarded marker disables tokenless rewritten loopback",
+			target:     "http://127.0.0.1:18080/api/sql-target/session",
+			origin:     []string{"http://127.0.0.1:18080"},
+			remoteAddr: "127.0.0.1:41000",
+			headers:    map[string]string{"X-Forwarded-Prefix": "/patris"},
+			wantStatus: http.StatusForbidden,
 		},
 		{
 			name:       "untrusted peer cannot spoof forwarded TLS",
 			target:     "http://patris.example/api/sql-target/session",
 			origin:     []string{"https://patris.example"},
 			remoteAddr: "203.0.113.19:41000",
+			configured: sqlTestOperatorToken,
 			token:      sqlTestOperatorToken,
+			headers:    map[string]string{"X-Forwarded-Proto": "https"},
 			wantStatus: http.StatusForbidden,
 		},
 		{
@@ -258,6 +337,7 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			server.sqlOperations.operatorToken = test.configured
 			request := httptest.NewRequest(http.MethodPost, test.target, nil)
 			request.RemoteAddr = test.remoteAddr
 			for _, origin := range test.origin {
@@ -266,12 +346,8 @@ func TestSQLOperatorSessionRequiresExactOriginAndDedicatedAuthorization(t *testi
 			if test.token != "" {
 				request.Header.Set(sqlOperatorTokenHeader, test.token)
 			}
-			if test.name == "trusted loopback reverse proxy" {
-				request.Header.Set("X-Forwarded-Proto", "https")
-				request.Header.Set("X-Forwarded-Host", "patris.example")
-			}
-			if test.name == "untrusted peer cannot spoof forwarded TLS" {
-				request.Header.Set("X-Forwarded-Proto", "https")
+			for name, value := range test.headers {
+				request.Header.Set(name, value)
 			}
 			response := serveSQLRequest(server, request)
 			if response.Code != test.wantStatus {
@@ -425,6 +501,120 @@ func TestSQLTargetStatusIsUsefulAndSecretFree(t *testing.T) {
 	}
 }
 
+func TestSQLPreviewGrantCannotOutliveOrReappearAfterSessionRevoke(t *testing.T) {
+	state := newSQLOperationsState()
+	now := time.Now().UTC().Truncate(time.Second)
+	state.now = func() time.Time { return now }
+	sessionID, _, expiresAt, err := state.createSession("http://127.0.0.1:18080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionHash := sha256.Sum256([]byte(sessionID))
+	grant := sqlIssuedPreviewGrant{
+		grantHash:   sha256.Sum256([]byte(strings.Repeat("g", 43))),
+		sessionHash: sessionHash,
+		expiresAt:   expiresAt,
+	}
+	if !state.issuePreviewGrant(grant) {
+		t.Fatal("active session could not issue preview grant")
+	}
+	state.revokeSession(sessionID)
+	if got := state.takePreviewGrant(); got != nil {
+		t.Fatal("revoked session retained preview grant")
+	}
+	if state.issuePreviewGrant(grant) {
+		t.Fatal("revoked session reissued preview grant")
+	}
+}
+
+func TestSQLTargetRequiresExplicitMySQLTableAndSafeMode(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Convert.Table = ""
+		cfg.Export.MySQLTable = ""
+		cfg.Export.SQLiteTable = "sqlite_only_must_not_be_selected"
+	}); err != nil {
+		t.Fatalf("configure table fallback: %v", err)
+	}
+	credentials := createSQLTestSession(t, server, false)
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("fallback status endpoint=%d: %s", response.Code, response.Body)
+	}
+	var status sqlTargetStatus
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		t.Fatalf("decode fallback status: %v", err)
+	}
+	if status.TableConfigured {
+		t.Fatalf("status treated an implicit or SQLite-only table as configured: %#v", status)
+	}
+	sourceCalls := 0
+	sinkCalls := 0
+	server.sqlOperations.records = func(context.Context) (recordpipe.Result, error) {
+		sourceCalls++
+		return recordpipe.Result{}, nil
+	}
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		sinkCalls++
+		return recordsink.SQLResult{}, nil
+	}
+	preview := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if preview.Code != http.StatusUnprocessableEntity || !strings.Contains(preview.Body.String(), "target_table_required") {
+		t.Fatalf("implicit-table preview status=%d, want safe 422: %s", preview.Code, preview.Body)
+	}
+	syncRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", []byte(`{"confirm":"manual_sync"}`))
+	syncRequest.Header.Set("Content-Type", "application/json")
+	syncResponse := serveSQLRequest(server, syncRequest)
+	if syncResponse.Code != http.StatusUnprocessableEntity || !strings.Contains(syncResponse.Body.String(), "target_table_required") {
+		t.Fatalf("implicit-table sync status=%d, want safe 422: %s", syncResponse.Code, syncResponse.Body)
+	}
+	if sourceCalls != 0 || sinkCalls != 0 {
+		t.Fatalf("implicit target reached source=%d or sink=%d", sourceCalls, sinkCalls)
+	}
+
+	for _, malformedTable := range []string{
+		"!!!",
+		"sales.products",
+		"1products",
+		"_products",
+		"products_",
+		strings.Repeat("a", 65),
+	} {
+		if err := server.config.Update(func(cfg *appconfig.Config) {
+			cfg.Convert.Table = malformedTable
+			cfg.Export.MySQLTable = ""
+		}); err != nil {
+			t.Fatalf("configure malformed table %q: %v", malformedTable, err)
+		}
+		response = serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/status", nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("malformed-table %q status endpoint=%d: %s", malformedTable, response.Code, response.Body)
+		}
+		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+			t.Fatalf("decode malformed-table %q status: %v", malformedTable, err)
+		}
+		if status.TableConfigured {
+			t.Fatalf("status treated malformed table %q as configured: %#v", malformedTable, status)
+		}
+		preview = serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+		if preview.Code != http.StatusUnprocessableEntity || !strings.Contains(preview.Body.String(), "target_table_invalid") {
+			t.Fatalf("malformed-table %q preview status=%d, want safe 422: %s", malformedTable, preview.Code, preview.Body)
+		}
+		syncRequest = newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", []byte(`{"confirm":"manual_sync"}`))
+		syncRequest.Header.Set("Content-Type", "application/json")
+		syncResponse = serveSQLRequest(server, syncRequest)
+		if syncResponse.Code != http.StatusUnprocessableEntity || !strings.Contains(syncResponse.Body.String(), "target_table_invalid") {
+			t.Fatalf("malformed-table %q sync status=%d, want safe 422: %s", malformedTable, syncResponse.Code, syncResponse.Body)
+		}
+		if sourceCalls != 0 || sinkCalls != 0 {
+			t.Fatalf("malformed target %q reached source=%d or sink=%d", malformedTable, sourceCalls, sinkCalls)
+		}
+	}
+	if mode := safeSQLReconciliationMode(recordsink.ReconciliationMode("future_or_corrupt_mode")); mode != recordsink.UpsertOnly {
+		t.Fatalf("unknown reconciliation mode=%q, want safe %q", mode, recordsink.UpsertOnly)
+	}
+}
+
 func TestSQLTargetProbeAndLastResultRedactTargetAndDriverErrors(t *testing.T) {
 	server := newSQLOperationsTestServer(t)
 	credentials := createSQLTestSession(t, server, false)
@@ -562,6 +752,12 @@ func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
 		previewPayload.Diagnostic.Result.Inserted != 2 || previewPayload.Diagnostic.Result.ElapsedMS != 0 {
 		t.Fatalf("unexpected preview diagnostic: %#v", previewPayload)
 	}
+	previewGrant := previewPayload.Diagnostic.PreviewGrant
+	if !validSQLPreviewGrant(previewGrant) ||
+		previewPayload.Diagnostic.PreviewGrantExpiresAt == nil ||
+		!previewPayload.Diagnostic.PreviewGrantExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("preview omitted its short-lived one-time grant: %#v", previewPayload.Diagnostic)
+	}
 	evidence := previewPayload.Diagnostic.Result.ReconciliationEvidence
 	if evidence == nil || evidence.ConfirmationToken != confirmationToken ||
 		!evidence.ConfirmationRequired || !evidence.ApplyAllowed ||
@@ -569,6 +765,33 @@ func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
 		evidence.MissingRows != 1 || evidence.WouldSoftDelete != 1 ||
 		!evidence.PartialSourceRisk {
 		t.Fatalf("preview omitted safe reconciliation evidence: %#v", evidence)
+	}
+	lastPreview := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodGet, "/api/sql-target/last-result", nil))
+	if lastPreview.Code != http.StatusOK {
+		t.Fatalf("cached preview status=%d: %s", lastPreview.Code, lastPreview.Body)
+	}
+	if strings.Contains(lastPreview.Body.String(), confirmationToken) ||
+		strings.Contains(lastPreview.Body.String(), previewGrant) ||
+		strings.Contains(lastPreview.Body.String(), `"preview_grant"`) {
+		t.Fatalf("cached preview replayed a direct-response authorization token: %s", lastPreview.Body)
+	}
+	var cachedPreviewPayload struct {
+		Available  bool                   `json:"available"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(lastPreview.Body).Decode(&cachedPreviewPayload); err != nil {
+		t.Fatalf("decode cached preview: %v", err)
+	}
+	cachedEvidence := cachedPreviewPayload.Diagnostic.Result.ReconciliationEvidence
+	if !cachedPreviewPayload.Available || cachedEvidence == nil ||
+		cachedPreviewPayload.Diagnostic.PreviewGrant != "" ||
+		cachedPreviewPayload.Diagnostic.PreviewGrantExpiresAt != nil ||
+		cachedEvidence.ConfirmationToken != "" || cachedEvidence.SourceRows != evidence.SourceRows ||
+		cachedEvidence.TargetRows != evidence.TargetRows || cachedEvidence.MissingRows != evidence.MissingRows ||
+		cachedEvidence.WouldSoftDelete != evidence.WouldSoftDelete ||
+		cachedEvidence.ApplyAllowed ||
+		cachedEvidence.GuardCode != recordsink.ReconciliationGuardPreviewRequired {
+		t.Fatalf("cached preview lost safe evidence or retained its token: %#v", cachedPreviewPayload)
 	}
 
 	rejectedRequests := []struct {
@@ -581,6 +804,7 @@ func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
 		{"missing confirmation", "application/json", []byte(`{}`), http.StatusBadRequest},
 		{"wrong confirmation", "application/json", []byte(`{"confirm":"yes"}`), http.StatusBadRequest},
 		{"unknown field", "application/json", []byte(`{"confirm":"manual_sync","dsn":"forbidden"}`), http.StatusBadRequest},
+		{"malformed preview grant", "application/json", []byte(`{"confirm":"manual_sync","preview_grant":"not-base64url"}`), http.StatusBadRequest},
 		{"malformed reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":"sha256:not-a-valid-plan"}`), http.StatusBadRequest},
 		{"uppercase reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":"sha256:` + strings.Repeat("A", 64) + `"}`), http.StatusBadRequest},
 		{"padded reconciliation token", "application/json", []byte(`{"confirm":"manual_sync","reconciliation_token":" ` + confirmationToken + `"}`), http.StatusBadRequest},
@@ -627,17 +851,72 @@ func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
 		t.Fatalf("missing-token guard was unsafe or incomplete: %#v", missingTokenPayload)
 	}
 
-	confirmedBody := []byte(fmt.Sprintf(`{"confirm":"manual_sync","reconciliation_token":%q}`, confirmationToken))
+	refreshedPreview := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if refreshedPreview.Code != http.StatusOK {
+		t.Fatalf("refreshed preview status=%d: %s", refreshedPreview.Code, refreshedPreview.Body)
+	}
+	var refreshedPayload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(refreshedPreview.Body).Decode(&refreshedPayload); err != nil {
+		t.Fatalf("decode refreshed preview: %v", err)
+	}
+	refreshedGrant := refreshedPayload.Diagnostic.PreviewGrant
+	if !refreshedPayload.Success || !validSQLPreviewGrant(refreshedGrant) {
+		t.Fatalf("refreshed preview omitted grant: %#v", refreshedPayload)
+	}
+	grantWithoutPlanBody := []byte(fmt.Sprintf(
+		`{"confirm":"manual_sync","preview_grant":%q}`,
+		refreshedGrant,
+	))
+	grantWithoutPlanRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", grantWithoutPlanBody)
+	grantWithoutPlanRequest.Header.Set("Content-Type", "application/json")
+	grantWithoutPlan := serveSQLRequest(server, grantWithoutPlanRequest)
+	if grantWithoutPlan.Code != http.StatusConflict ||
+		!strings.Contains(grantWithoutPlan.Body.String(), string(recordsink.ReconciliationGuardPreviewRequired)) {
+		t.Fatalf("soft-delete grant without exact-plan token status=%d, want 409: %s", grantWithoutPlan.Code, grantWithoutPlan.Body)
+	}
+
+	finalPreview := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if finalPreview.Code != http.StatusOK {
+		t.Fatalf("final preview status=%d: %s", finalPreview.Code, finalPreview.Body)
+	}
+	var finalPreviewPayload struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(finalPreview.Body).Decode(&finalPreviewPayload); err != nil {
+		t.Fatalf("decode final preview: %v", err)
+	}
+	finalGrant := finalPreviewPayload.Diagnostic.PreviewGrant
+	if !finalPreviewPayload.Success || !validSQLPreviewGrant(finalGrant) {
+		t.Fatalf("final preview omitted grant: %#v", finalPreviewPayload)
+	}
+
+	confirmedBody := []byte(fmt.Sprintf(
+		`{"confirm":"manual_sync","preview_grant":%q,"reconciliation_token":%q}`,
+		finalGrant,
+		confirmationToken,
+	))
 	confirmedRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", confirmedBody)
 	confirmedRequest.Header.Set("Content-Type", "application/json; charset=utf-8")
 	confirmed := serveSQLRequest(server, confirmedRequest)
 	if confirmed.Code != http.StatusOK {
 		t.Fatalf("confirmed sync status=%d: %s", confirmed.Code, confirmed.Body)
 	}
+	replayedRequest := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", confirmedBody)
+	replayedRequest.Header.Set("Content-Type", "application/json")
+	replayed := serveSQLRequest(server, replayedRequest)
+	if replayed.Code != http.StatusConflict ||
+		!strings.Contains(replayed.Body.String(), string(recordsink.ReconciliationGuardPreviewRequired)) {
+		t.Fatalf("replayed grant status=%d, want generic preview-required 409: %s", replayed.Code, replayed.Body)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	if calls != 3 || len(options) != 3 || !options[0].DryRun || options[1].DryRun || options[2].DryRun {
+	if calls != 4 || len(options) != 4 ||
+		!options[0].DryRun || !options[1].DryRun || !options[2].DryRun || options[3].DryRun {
 		t.Fatalf("unexpected SQL sink calls/options: calls=%d options=%#v", calls, options)
 	}
 	for index, option := range options {
@@ -648,7 +927,7 @@ func TestSQLTargetPreviewAndConfirmedSyncUseCanonicalSharedSink(t *testing.T) {
 		}
 	}
 	if options[0].ReconciliationToken != "" || options[1].ReconciliationToken != "" ||
-		options[2].ReconciliationToken != confirmationToken {
+		options[2].ReconciliationToken != "" || options[3].ReconciliationToken != confirmationToken {
 		t.Fatalf("preview token was not passed only to the confirmed apply: %#v", options)
 	}
 	wantCodes := []string{"001", "002"}
@@ -751,6 +1030,305 @@ func TestSQLTargetBlocksBrowserHardDeleteAndIrrelevantTokens(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("irrelevant preview token reached the SQL sink %d times", calls)
+	}
+}
+
+func TestSQLTargetUpsertGrantIsOneTimeSessionConfigSourceAndExpiryBound(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	server.sqlOperations.now = func() time.Time { return now }
+	firstSession := createSQLTestSession(t, server, false)
+	secondSession := createSQLTestSession(t, server, false)
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Export.Reconciliation = string(recordsink.UpsertOnly)
+	}); err != nil {
+		t.Fatalf("set upsert-only mode: %v", err)
+	}
+
+	var sourceValue interface{} = "alpha"
+	server.sqlOperations.records = func(context.Context) (recordpipe.Result, error) {
+		return recordpipe.Result{
+			Rows:     []map[string]interface{}{{"Code": "001", "Name": sourceValue}},
+			KeyField: "Code",
+			Raw:      true,
+		}, nil
+	}
+	sinkCalls := 0
+	server.sqlOperations.sync = func(_ context.Context, options recordsink.SQLOptions, rows []map[string]interface{}) (recordsink.SQLResult, error) {
+		sinkCalls++
+		return recordsink.SQLResult{Inserted: len(rows), DryRun: options.DryRun}, nil
+	}
+
+	preview := func(t *testing.T) string {
+		t.Helper()
+		response := serveSQLRequest(server, newAuthenticatedSQLRequest(firstSession, http.MethodPost, "/api/sql-target/preview", nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("upsert preview status=%d: %s", response.Code, response.Body)
+		}
+		var payload struct {
+			Success    bool                   `json:"success"`
+			Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+		}
+		if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode upsert preview: %v", err)
+		}
+		if !payload.Success || !validSQLPreviewGrant(payload.Diagnostic.PreviewGrant) ||
+			payload.Diagnostic.PreviewGrantExpiresAt == nil {
+			t.Fatalf("upsert preview omitted grant: %#v", payload)
+		}
+		return payload.Diagnostic.PreviewGrant
+	}
+	apply := func(credentials sqlTestCredentials, grant string) *httptest.ResponseRecorder {
+		body := []byte(fmt.Sprintf(`{"confirm":"manual_sync","preview_grant":%q}`, grant))
+		request := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/sync", body)
+		request.Header.Set("Content-Type", "application/json")
+		return serveSQLRequest(server, request)
+	}
+	assertPreviewRequired := func(label string, response *httptest.ResponseRecorder) {
+		if response.Code != http.StatusConflict ||
+			!strings.Contains(response.Body.String(), string(recordsink.ReconciliationGuardPreviewRequired)) {
+			t.Fatalf("%s status=%d, want generic preview-required 409: %s", label, response.Code, response.Body)
+		}
+		if value, found := responseContainsAny(response, sqlTestDSN, "super-secret-password", sqlTestCAPath); found {
+			t.Fatalf("%s exposed protected value %q: %s", label, value, response.Body)
+		}
+	}
+
+	firstGrant := preview(t)
+	assertPreviewRequired("missing grant", apply(firstSession, ""))
+
+	configGrant := preview(t)
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Export.MySQLDSN = "other_user:other-secret@tcp(second-db.internal:3306)/patris"
+	}); err != nil {
+		t.Fatalf("switch target DSN: %v", err)
+	}
+	assertPreviewRequired("target switch", apply(firstSession, configGrant))
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.Export.MySQLDSN = sqlTestDSN
+	}); err != nil {
+		t.Fatalf("restore target DSN: %v", err)
+	}
+
+	sourceGrant := preview(t)
+	sourceValue = "changed-after-preview"
+	assertPreviewRequired("source drift", apply(firstSession, sourceGrant))
+
+	sourceValue = int64(1)
+	typeGrant := preview(t)
+	sourceValue = float64(1)
+	assertPreviewRequired("source type drift", apply(firstSession, typeGrant))
+
+	sessionGrant := preview(t)
+	assertPreviewRequired("session switch", apply(secondSession, sessionGrant))
+
+	expiredGrant := preview(t)
+	now = now.Add(sqlPreviewGrantTTL + time.Second)
+	assertPreviewRequired("expired grant", apply(firstSession, expiredGrant))
+
+	validGrant := preview(t)
+	applied := apply(firstSession, validGrant)
+	if applied.Code != http.StatusOK {
+		t.Fatalf("fresh bound upsert grant status=%d: %s", applied.Code, applied.Body)
+	}
+	assertPreviewRequired("replayed grant", apply(firstSession, validGrant))
+
+	// Seven previews and one authorized apply reach the sink. Every rejected apply
+	// is blocked before the sink.
+	if sinkCalls != 8 {
+		t.Fatalf("sink calls=%d, want 8 preview/apply calls", sinkCalls)
+	}
+	if firstGrant == configGrant {
+		t.Fatal("independent previews reused an opaque grant")
+	}
+}
+
+func TestSQLTargetSlowSyncBodyDoesNotHoldOperationPermit(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	probeEntered := make(chan struct{})
+	server.sqlOperations.probe = func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error) {
+		close(probeEntered)
+		return recordsink.SQLProbeResult{Connected: true, Driver: "mysql"}, nil
+	}
+
+	reader, writer := io.Pipe()
+	request := httptest.NewRequest(http.MethodPost, credentials.origin+"/api/sql-target/sync", reader)
+	request.Header.Set("Origin", credentials.origin)
+	request.Header.Set(sqlCSRFHeader, credentials.csrf)
+	request.Header.Set("Content-Type", "application/json")
+	request.AddCookie(credentials.cookie)
+	syncDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { syncDone <- serveSQLRequest(server, request) }()
+
+	select {
+	case response := <-syncDone:
+		t.Fatalf("partial sync body unexpectedly completed: status=%d body=%s", response.Code, response.Body)
+	case <-time.After(100 * time.Millisecond):
+	}
+	probeDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		probeDone <- serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/test", nil))
+	}()
+	select {
+	case <-probeEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("slow sync body held the global SQL operation permit")
+	}
+	select {
+	case response := <-probeDone:
+		if response.Code != http.StatusOK {
+			t.Fatalf("probe failed beside slow sync body: status=%d body=%s", response.Code, response.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not complete beside slow sync body")
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close partial request body: %v", err)
+	}
+	select {
+	case response := <-syncDone:
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("partial sync body status=%d, want 400: %s", response.Code, response.Body)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("partial sync body did not finish after EOF")
+	}
+}
+
+func TestSQLSourcePreparationCancellationDoesNotWedgeOperations(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	sourceEntered := make(chan struct{})
+	sourceExited := make(chan struct{})
+	probeEntered := make(chan struct{})
+	sinkCalls := 0
+	server.sqlOperations.records = func(ctx context.Context) (recordpipe.Result, error) {
+		close(sourceEntered)
+		<-ctx.Done()
+		close(sourceExited)
+		return recordpipe.Result{}, ctx.Err()
+	}
+	server.sqlOperations.probe = func(context.Context, recordsink.SQLOptions) (recordsink.SQLProbeResult, error) {
+		close(probeEntered)
+		return recordsink.SQLProbeResult{Connected: true, Driver: "mysql"}, nil
+	}
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		sinkCalls++
+		return recordsink.SQLResult{}, nil
+	}
+
+	request := newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil)
+	requestContext, cancel := context.WithTimeout(request.Context(), 250*time.Millisecond)
+	defer cancel()
+	request = request.WithContext(requestContext)
+	previewDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() { previewDone <- serveSQLRequest(server, request) }()
+	select {
+	case <-sourceEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("source preparation did not start")
+	}
+
+	probeDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		probeDone <- serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/test", nil))
+	}()
+	select {
+	case <-probeEntered:
+		t.Fatal("probe overlapped source preparation while the serialized permit was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	var preview *httptest.ResponseRecorder
+	select {
+	case preview = <-previewDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled source preparation did not return promptly")
+	}
+	select {
+	case <-sourceExited:
+	default:
+		t.Fatal("handler returned before the context-aware source exited")
+	}
+	select {
+	case <-probeEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not enter after the cancelled source released the operation permit")
+	}
+	select {
+	case probe := <-probeDone:
+		if probe.Code != http.StatusOK {
+			t.Fatalf("probe failed after source cancellation: status=%d body=%s", probe.Code, probe.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe did not complete after source cancellation")
+	}
+	if preview.Code != http.StatusGatewayTimeout {
+		t.Fatalf("cancelled source status=%d, want 504: %s", preview.Code, preview.Body)
+	}
+	var failed struct {
+		Success    bool                   `json:"success"`
+		Diagnostic sqlOperationDiagnostic `json:"diagnostic"`
+	}
+	if err := json.NewDecoder(preview.Body).Decode(&failed); err != nil {
+		t.Fatalf("decode cancelled source response: %v", err)
+	}
+	if failed.Success || failed.Diagnostic.Failure == nil ||
+		failed.Diagnostic.Failure.Code != string(recordsink.SQLFailureTimeout) ||
+		failed.Diagnostic.Failure.Stage != "source" || sinkCalls != 0 {
+		t.Fatalf("cancelled source reached sink or returned unsafe diagnostic: %#v sinkCalls=%d", failed, sinkCalls)
+	}
+
+	server.sqlOperations.records = func(ctx context.Context) (recordpipe.Result, error) {
+		return server.RecordResultContext(ctx)
+	}
+	second := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if second.Code != http.StatusOK || sinkCalls != 1 {
+		t.Fatalf("operation permit was not reusable: status=%d sinkCalls=%d body=%s", second.Code, sinkCalls, second.Body)
+	}
+
+	cancelled, cancelImmediately := context.WithCancel(context.Background())
+	cancelImmediately()
+	if _, err := server.RecordResultContext(cancelled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-cancelled RecordResultContext error=%v, want context.Canceled", err)
+	}
+}
+
+func TestSQLSourcePreparationRejectsLegacyUnboundedDataSource(t *testing.T) {
+	server := newSQLOperationsTestServer(t)
+	credentials := createSQLTestSession(t, server, false)
+	legacy := &legacySQLTestSource{}
+	server.dataSourceMu.Lock()
+	original := server.dataSource
+	server.dataSource = legacy
+	server.dataSourceMu.Unlock()
+	t.Cleanup(func() {
+		server.dataSourceMu.Lock()
+		server.dataSource = original
+		server.dataSourceMu.Unlock()
+	})
+	sinkCalls := 0
+	server.sqlOperations.sync = func(context.Context, recordsink.SQLOptions, []map[string]interface{}) (recordsink.SQLResult, error) {
+		sinkCalls++
+		return recordsink.SQLResult{}, nil
+	}
+
+	response := serveSQLRequest(server, newAuthenticatedSQLRequest(credentials, http.MethodPost, "/api/sql-target/preview", nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("legacy source status=%d, want 503: %s", response.Code, response.Body)
+	}
+	if legacy.rawCalls != 0 || sinkCalls != 0 {
+		t.Fatalf("bounded SQL request used legacy source calls=%d sink=%d", legacy.rawCalls, sinkCalls)
+	}
+	if strings.Contains(response.Body.String(), "bounded record reads") {
+		t.Fatalf("legacy source response exposed internal detail: %s", response.Body)
+	}
+
+	result, err := server.RecordResultContext(context.Background())
+	if err != nil || len(result.Rows) != 1 || legacy.rawCalls != 1 {
+		t.Fatalf("legacy Background compatibility failed: rows=%d calls=%d err=%v", len(result.Rows), legacy.rawCalls, err)
 	}
 }
 


### PR DESCRIPTION
## Outcome

Completes the protected SQL-target operations backend for #6 without exposing database credentials or permitting unreviewed destructive writes.

- adds a short-lived same-origin operator session with HttpOnly/SameSite cookie, CSRF binding, dedicated operator credential, and fail-closed proxy/origin handling
- adds redacted target status, bounded connection test, dry-run preview, one-time preview grants, manual sync, safe last-result diagnostics, and logout
- binds every apply to the exact session, protected target configuration, canonical typed source projection, and (for soft-delete) exact reconciliation plan
- consumes authorization before every apply outcome; browser hard-delete remains unavailable
- makes source acquisition, projection, hashing, SQL preprocessing, file replacement, watcher shutdown, and database I/O deadline-aware
- preserves legacy deterministic revision/reconciliation digest bytes and existing CLI/watch compatibility

## Verification

- independent exact-head security/correctness review: CLEAN
- `go test -count=1 ./...`
- `go vet ./...`
- focused race tests across server, recordsink, appconfig, datasource, filecopy, paradox, converter, recordmap, recordpipe, and canonical packages
- deterministic digest compatibility, cancellation, TTL, replay, session/config/source binding, proxy/origin, redaction, and no-sink-on-timeout regressions
- `git diff --check`
- credential-pattern scan across all changed files

No production database was used or mutated. The issue remains open with `review: pending-owner-approval` until the owner reviews the completed backend and UI.