### PR TITLE
fix(server): keep product-sync canonical in raw mode

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -282,6 +282,20 @@ func (s *Server) RecordResult() (recordpipe.Result, error) {
 // JSON reads promptly; native pxlib record extraction checks cancellation
 // immediately before and after its non-interruptible native call.
 func (s *Server) RecordResultContext(ctx context.Context) (recordpipe.Result, error) {
+	return s.recordResultContext(ctx, s.recordOptions())
+}
+
+// canonicalRecordResultContext prepares the configured canonical projection
+// independently from the viewer/export raw-mode preference. Raw mode controls
+// observational source rows; it must not disable the dedicated integration
+// contract for a dataset with an enabled canonical profile.
+func (s *Server) canonicalRecordResultContext(ctx context.Context) (recordpipe.Result, error) {
+	options := s.recordOptions()
+	options.Raw = false
+	return s.recordResultContext(ctx, options)
+}
+
+func (s *Server) recordResultContext(ctx context.Context, options recordpipe.Options) (recordpipe.Result, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -313,7 +327,7 @@ func (s *Server) RecordResultContext(ctx context.Context) (recordpipe.Result, er
 	if err := ctx.Err(); err != nil {
 		return recordpipe.Result{}, err
 	}
-	result := recordpipe.BuildContext(ctx, records, dbPath, s.recordOptions())
+	result := recordpipe.BuildContext(ctx, records, dbPath, options)
 	if err := ctx.Err(); err != nil {
 		return recordpipe.Result{}, err
 	}
@@ -642,8 +656,8 @@ func (s *Server) handleGetCategories(w http.ResponseWriter, _ *http.Request) {
 
 // handleGetProductSyncContract exposes the living integration envelope
 // without changing the long-standing row collection returned by /api/records.
-func (s *Server) handleGetProductSyncContract(w http.ResponseWriter, _ *http.Request) {
-	result, err := s.RecordResult()
+func (s *Server) handleGetProductSyncContract(w http.ResponseWriter, r *http.Request) {
+	result, err := s.canonicalRecordResultContext(r.Context())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to read records: %v", err), http.StatusInternalServerError)
 		return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -867,6 +867,73 @@ func TestCanonicalKalaParityAcrossRESTCSVXLSXAndWebSocket(t *testing.T) {
 	assertJSONEquivalent(t, "REST and WebSocket contract", restProduct, contractProduct)
 }
 
+func TestCanonicalProductSyncRemainsAvailableWithRawViewerMode(t *testing.T) {
+	fixtureConfig := filepath.Join("..", "..", "testdata", "canonical-static-config.json")
+	configData, err := os.ReadFile(fixtureConfig)
+	if err != nil {
+		t.Fatalf("read canonical fixture config: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "raw-canonical-config.json")
+	if err := os.WriteFile(configPath, configData, 0600); err != nil {
+		t.Fatalf("copy canonical fixture config: %v", err)
+	}
+	manager, err := appconfig.Load(configPath)
+	if err != nil {
+		t.Fatalf("load copied canonical fixture config: %v", err)
+	}
+	if err := manager.Update(func(cfg *appconfig.Config) {
+		cfg.Database.Raw = true
+		cfg.Convert.Raw = true
+	}); err != nil {
+		t.Fatalf("enable raw viewer mode: %v", err)
+	}
+
+	dbPath := filepath.Join("..", "..", "testdata", "kala.db")
+	srv, err := NewServerWithOptions(dbPath, nil, Options{Config: manager}, false)
+	if err != nil {
+		t.Fatalf("create raw canonical server: %v", err)
+	}
+	defer srv.Close()
+
+	recordsRecorder := httptest.NewRecorder()
+	srv.router.ServeHTTP(recordsRecorder, httptest.NewRequest(http.MethodGet, "/api/records", nil))
+	if recordsRecorder.Code != http.StatusOK {
+		t.Fatalf("raw records status = %d: %s", recordsRecorder.Code, recordsRecorder.Body.String())
+	}
+	var rawRecords map[string]map[string]interface{}
+	if err := json.NewDecoder(recordsRecorder.Body).Decode(&rawRecords); err != nil {
+		t.Fatalf("decode raw viewer rows: %v", err)
+	}
+	rawProduct, ok := rawRecords["102001011"]
+	if !ok {
+		t.Fatalf("raw viewer did not preserve Code-keyed KALA row")
+	}
+	if _, exists := rawProduct["Sharh1"]; !exists {
+		t.Fatalf("raw viewer row no longer exposes diagnostic source fields: %#v", rawProduct)
+	}
+	if _, exists := rawProduct["product_code"]; exists {
+		t.Fatalf("raw viewer row was unexpectedly canonicalized: %#v", rawProduct)
+	}
+
+	contractRecorder := httptest.NewRecorder()
+	srv.router.ServeHTTP(contractRecorder, httptest.NewRequest(http.MethodGet, "/api/product-sync", nil))
+	if contractRecorder.Code != http.StatusOK {
+		t.Fatalf("product-sync status = %d: %s", contractRecorder.Code, contractRecorder.Body.String())
+	}
+	if contentType := contractRecorder.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/vnd.patris.product-sync+json") {
+		t.Fatalf("unexpected product-sync content type %q", contentType)
+	}
+	var envelope canonical.Envelope
+	if err := json.NewDecoder(contractRecorder.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode canonical product-sync envelope: %v", err)
+	}
+	if envelope.Schema != canonical.ContractName || envelope.Source.Dataset != "kala.db" {
+		t.Fatalf("product-sync identity = %q/%q, want %q/kala.db", envelope.Schema, envelope.Source.Dataset, canonical.ContractName)
+	}
+	product := canonicalTypedProductByCode(t, envelope.Products, "102001011")
+	assertCanonicalFixtureValues(t, "raw-mode product-sync", product)
+}
+
 func assertJSONEquivalent(t *testing.T, source string, left, right interface{}) {
 	t.Helper()
 	leftJSON, err := json.Marshal(left)


### PR DESCRIPTION
Part of #202.

## What changed

- Build the dedicated `/api/product-sync` projection with canonical options even when viewer/export raw mode is enabled.
- Keep `/api/records` raw and unchanged for diagnostic consumers.
- Add a regression test proving the two contracts remain independent.

## Why

Raw mode is a viewer/export preference; it should not disable the dedicated integration contract for a dataset with an enabled canonical profile. This keeps standalone diagnostic rows unchanged while allowing explicitly requested integration clients to consume transformed data.

## Verified impact

- With explicit raw viewer mode, `/api/records` remains raw.
- `/api/product-sync` returns HTTP 200 with `application/vnd.patris.product-sync+json`.
- The isolated KALA proof returned 936 canonical products and 73 categories.
- Machine keys and the `patris.product-sync` schema remain backward-compatible.

The remaining live Digitalogic pricing/startup cancellation work and public `Product Code` / `کد کالا` presentation are tracked in #202 and will merge separately before the production rebuild.

## Validation

- `go test ./pkg/server -run TestCanonicalProductSyncRemainsAvailableWithRawViewerMode -count=1`
- `go test ./pkg/server ./pkg/recordpipe -count=1`
- clean Windows staging build, standard dynamic-pxlib variant
- all required GitHub checks passed, including Windows package and installer jobs

