### PR TITLE
fix: use valid scheduled task runlevel

### DIFF
--- a/scripts/windows/Install-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Install-PatrisExportScheduledTask.ps1
@@ -61,7 +61,7 @@ switch ($Action) {
             -RestartCount 999 `
             -RestartInterval (New-TimeSpan -Minutes 1) `
             -StartWhenAvailable
-        $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel LeastPrivilege
+        $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
         $task = New-ScheduledTask -Action $taskAction -Trigger $trigger -Settings $settings -Principal $principal
         Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -InputObject $task -Force | Out-Null
         Write-Host "Installed scheduled task: $TaskPath$TaskName"


### PR DESCRIPTION
## What changed
- Replaces the invalid ScheduledTasks `RunLevel` value `LeastPrivilege` with the documented least-privileged value `Limited`.

## Why
`New-ScheduledTaskPrincipal` accepts `Limited` or `Highest` on this host. The previous value prevented the live scheduled task from being installed after the #206 rebuild.

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows\Install-PatrisExportScheduledTask.ps1 -Action Status`
- `git diff --check`

Closes #207