### PR TITLE
Prevent initial pricing projection from blocking startup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,6 +74,9 @@ type Server struct {
 	catalogProviderKey   string
 	catalogProviderMu    sync.Mutex
 	sqlOperations        *sqlOperationsState
+	backgroundCtx        context.Context
+	backgroundCancel     context.CancelFunc
+	backgroundWG         sync.WaitGroup
 }
 
 type Options struct {
@@ -144,6 +147,7 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 		return nil, fmt.Errorf("failed to create data source: %w", err)
 	}
 
+	backgroundCtx, backgroundCancel := context.WithCancel(context.Background())
 	s := &Server{
 		router:           mux.NewRouter(),
 		dbPath:           dbPath,
@@ -152,6 +156,8 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 		wsClients:        make(map[*websocket.Conn]*sync.Mutex),
 		eventSubscribers: make(map[chan map[string]interface{}]struct{}),
 		sqlOperations:    newSQLOperationsState(),
+		backgroundCtx:    backgroundCtx,
+		backgroundCancel: backgroundCancel,
 		useTempFile:      copyBeforeRead,
 		config:           options.Config,
 		version:          options.Version,
@@ -191,6 +197,8 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 			s.broadcastConfig(cfg)
 		})
 		if err != nil {
+			backgroundCancel()
+			_ = ds.Close()
 			return nil, fmt.Errorf("failed to watch config: %w", err)
 		}
 		s.configWatcher = w
@@ -1504,9 +1512,12 @@ func (s *Server) broadcastUpdate() {
 	go s.broadcastProcessInfo()
 }
 
-func (s *Server) dispatchInitialUpdate() {
-	result, err := s.RecordResult()
+func (s *Server) dispatchInitialUpdate(ctx context.Context) {
+	result, err := s.RecordResultContext(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		log.Printf("Failed to prepare initial send update payload: %v", err)
 		return
 	}
@@ -1520,6 +1531,14 @@ func (s *Server) dispatchInitialUpdate() {
 		Contract:         result.SyncEnvelope(nil),
 		SnapshotContract: result.SyncEnvelope(nil),
 	})
+}
+
+func (s *Server) dispatchInitialUpdateAsync() {
+	s.backgroundWG.Add(1)
+	go func() {
+		defer s.backgroundWG.Done()
+		s.dispatchInitialUpdate(s.backgroundCtx)
+	}()
 }
 
 func (s *Server) dispatchUpdateEvent(event updateout.Event) {
@@ -2318,7 +2337,7 @@ func (s *Server) StartWatching(debounceDuration time.Duration) error {
 			return fmt.Errorf("failed to poll URL: %w", err)
 		}
 		log.Printf("👀 Polling remote source: %s (interval: %v)", dbPath, pollInterval)
-		s.dispatchInitialUpdate()
+		s.dispatchInitialUpdateAsync()
 		return nil
 	}
 
@@ -2338,13 +2357,17 @@ func (s *Server) StartWatching(debounceDuration time.Duration) error {
 	}
 	log.Printf("👀 Watching %s file: %s", fileType, filepath.Base(dbPath))
 
-	s.dispatchInitialUpdate()
+	s.dispatchInitialUpdateAsync()
 	return nil
 }
 
 // Close cleans up server resources
 func (s *Server) Close() error {
 	var firstErr error
+	if s.backgroundCancel != nil {
+		s.backgroundCancel()
+	}
+	s.backgroundWG.Wait()
 	if s.configWatcher != nil {
 		if err := s.configWatcher.Close(); err != nil && firstErr == nil {
 			firstErr = err

--- a/pkg/server/startup_timeout_test.go
+++ b/pkg/server/startup_timeout_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
+)
+
+type canonicalProjectionTestSource struct {
+	path string
+	rows []map[string]interface{}
+}
+
+func (source *canonicalProjectionTestSource) GetRecords() ([]map[string]interface{}, error) {
+	return source.GetRawRecords()
+}
+
+func (source *canonicalProjectionTestSource) GetRawRecords() ([]map[string]interface{}, error) {
+	return source.GetRawRecordsContext(context.Background())
+}
+
+func (source *canonicalProjectionTestSource) GetRawRecordsContext(ctx context.Context) ([]map[string]interface{}, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return source.rows, nil
+}
+
+func (source *canonicalProjectionTestSource) GetPath() string {
+	return source.path
+}
+
+func (source *canonicalProjectionTestSource) Close() error {
+	return nil
+}
+
+func TestStartWatchingDoesNotWaitForInitialDigitalogicProjection(t *testing.T) {
+	batchStarted := make(chan struct{})
+	releaseBatch := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/integration/catalog":
+			writeCanonicalProjectionCatalog(w)
+		case "/integration/pricing-assignments/batch":
+			startedOnce.Do(func() { close(batchStarted) })
+			select {
+			case <-r.Context().Done():
+			case <-releaseBatch:
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer remote.Close()
+	defer releaseOnce.Do(func() { close(releaseBatch) })
+
+	srv := newCanonicalProjectionTestServer(t, remote.URL, "5s")
+	startedAt := time.Now()
+	if err := srv.StartWatching(0); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("watch startup waited for initial pricing projection: %s", elapsed)
+	}
+
+	select {
+	case <-batchStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background initial pricing projection did not start")
+	}
+
+	appRequest := httptest.NewRequest(http.MethodGet, "/api/app", nil)
+	appRecorder := httptest.NewRecorder()
+	srv.router.ServeHTTP(appRecorder, appRequest)
+	if appRecorder.Code != http.StatusOK {
+		t.Fatalf("health-independent app endpoint status = %d: %s", appRecorder.Code, appRecorder.Body.String())
+	}
+
+	closeStartedAt := time.Now()
+	if err := srv.Close(); err != nil {
+		t.Fatalf("close server: %v", err)
+	}
+	if elapsed := time.Since(closeStartedAt); elapsed > time.Second {
+		t.Fatalf("server close did not cancel initial pricing projection: %s", elapsed)
+	}
+	releaseOnce.Do(func() { close(releaseBatch) })
+}
+
+func newCanonicalProjectionTestServer(t *testing.T, baseURL, timeout string) *Server {
+	t.Helper()
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	manager, err := appconfig.Load(configPath)
+	if err != nil {
+		t.Fatalf("create config manager: %v", err)
+	}
+	cfg := manager.Get()
+	cfg.Canonical.Pricing = pricingcatalog.Config{
+		Mode: pricingcatalog.ModeDigitalogic,
+		Digitalogic: pricingcatalog.DigitalogicConfig{
+			BaseURL:   baseURL,
+			BatchSize: 1,
+			Timeout:   timeout,
+		},
+	}
+	if err := manager.Replace(cfg); err != nil {
+		t.Fatalf("store test config: %v", err)
+	}
+
+	sourcePath := filepath.Join(tempDir, "source.json")
+	if err := os.WriteFile(sourcePath, []byte(`{}`), 0600); err != nil {
+		t.Fatalf("create bootstrap source: %v", err)
+	}
+	srv, err := NewServerWithOptions(sourcePath, nil, Options{Config: manager}, false)
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	kalaPath := filepath.Join(tempDir, "kala.db")
+	if err := os.WriteFile(kalaPath, nil, 0600); err != nil {
+		srv.Close()
+		t.Fatalf("create watched kala path: %v", err)
+	}
+	source := &canonicalProjectionTestSource{
+		path: kalaPath,
+		rows: []map[string]interface{}{{
+			"Code":   "102001011",
+			"Name":   "Test module",
+			"Serial": "SKU-1",
+			"Sharh1": "1 2 3 240",
+			"Sharh2": "100 g",
+			"ANBAR1": 1,
+		}},
+	}
+	srv.dataSourceMu.Lock()
+	bootstrap := srv.dataSource
+	srv.dataSource = source
+	srv.dbPath = kalaPath
+	srv.dataSourceMu.Unlock()
+	if err := bootstrap.Close(); err != nil {
+		srv.Close()
+		t.Fatalf("close bootstrap source: %v", err)
+	}
+	return srv
+}
+
+func writeCanonicalProjectionCatalog(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price"},"selected_warehouses":[],"shipping_methods":[{"id":"air","price_per_kg":120,"currency":"CNY"}]}}`)
+}


### PR DESCRIPTION
Part of #202.

## What changed

- Start the initial send/update projection in a tracked background task after the file or remote watcher is ready.
- Give that task a server-owned context so shutdown cancels a stalled Digitalogic pricing request.
- Wait for the tracked task during `Close`, preventing a background projection from racing resource teardown.
- Release the data source and background context if configuration watching fails during server construction.
- Add a deterministic stalled-pricing regression test proving watcher startup and `/api/app` remain responsive and shutdown cancels promptly.

## Integration with current `main`

This branch is rebased onto #206. It intentionally reuses #206's bounded canonical `/api/product-sync` and `/api/categories` request handling instead of introducing a second timeout implementation. The remaining change here is the startup lifecycle: canonical/pricing work no longer delays HTTP startup through the initial update path.

## Validation

- `go test ./pkg/server -count=1 -timeout 5m`: passed with the deployed dynamic `libpxlib.dll`.
- Focused stalled-pricing lifecycle test: passed.
- `git diff --check`: passed.

Issue #202 should remain open until the public terminology PR is merged and the merged Windows executable is rebuilt and probed against the live raw-viewer/canonical-product-sync configuration.
