### PR TITLE
Use neutral product code labels in customer outputs

### DIFF
--- a/docs/EXCEL-EXPORT.md
+++ b/docs/EXCEL-EXPORT.md
@@ -13,6 +13,15 @@ English workbooks remain left-to-right unless RTL is explicitly requested.
 `column_labels` can still override individual headings. Machine keys in the
 JSON, CSV, SQL, and API contracts are unchanged.
 
+The public product identity heading is `Product Code` in English and `کد کالا`
+in Persian. The Web table and its browser-generated CSV use the same localized
+heading. Existing presentation settings containing the old defaults `Code` or
+`کد`, or the deprecated branded labels `Patris Code` or `کد پاتریس`, are
+rendered with the neutral localized heading. Other custom labels remain
+authoritative. This is presentation-only: the canonical `product_code` key,
+the legacy `Code` input alias, and machine-oriented HTTP/API CSV headers remain
+compatible.
+
 Structured `warehouse_stock` is expanded into deterministic numeric columns,
 for example `Warehouse Stock 2` and `Warehouse Stock 10` (or their Persian
 equivalents), rather than being serialized into one object cell.

--- a/pkg/recordsink/xlsx_labels.go
+++ b/pkg/recordsink/xlsx_labels.go
@@ -15,7 +15,7 @@ type xlsxLocalizedLabel struct {
 // schema. Machine keys remain in the JSON/CSV/API contract; Excel receives
 // readable headings without changing or duplicating the transformed values.
 var xlsxColumnLabels = map[string]xlsxLocalizedLabel{
-	"product_code":                   {English: "Code", Persian: "کد"},
+	"product_code":                   {English: "Product Code", Persian: "کد کالا"},
 	"name":                           {English: "Name", Persian: "نام"},
 	"category_code":                  {English: "Category Code", Persian: "کد دسته‌بندی"},
 	"part_number":                    {English: "Part Number", Persian: "پارت نامبر"},
@@ -43,6 +43,15 @@ var xlsxColumnLabels = map[string]xlsxLocalizedLabel{
 	"source_updated_at":              {English: "Source Updated", Persian: "آخرین به‌روزرسانی منبع"},
 	"warnings":                       {English: "Warnings", Persian: "هشدارها"},
 	"record_hash":                    {English: "Record Hash", Persian: "هش رکورد"},
+}
+
+var defaultXLSXProductCodeLabels = map[string]struct{}{
+	"code":         {},
+	"product code": {},
+	"patris code":  {},
+	"کد":           {},
+	"کد کالا":      {},
+	"کد پاتریس":    {},
 }
 
 func xlsxHeaderLabel(field, warehouseID, language string, configured map[string]string) string {
@@ -91,6 +100,9 @@ func configuredXLSXLabel(field, language string, configured map[string]string) s
 		if value == "" || strings.EqualFold(value, field) {
 			return ""
 		}
+		if field == "product_code" && isDefaultXLSXProductCodeLabel(value) {
+			return ""
+		}
 		// Default English UI labels must not override the built-in Persian
 		// workbook vocabulary when xlsx_language=fa/auto+fa.
 		if language == "fa" {
@@ -104,6 +116,30 @@ func configuredXLSXLabel(field, language string, configured map[string]string) s
 		return value
 	}
 	return ""
+}
+
+func isDefaultXLSXProductCodeLabel(value string) bool {
+	normalized := strings.NewReplacer(
+		"ي", "ی",
+		"ى", "ی",
+		"ك", "ک",
+		"\u200c", " ",
+		"\u200d", " ",
+		"\u200e", "",
+		"\u200f", "",
+		"\u202a", "",
+		"\u202b", "",
+		"\u202c", "",
+		"\u202d", "",
+		"\u202e", "",
+		"\u2066", "",
+		"\u2067", "",
+		"\u2068", "",
+		"\u2069", "",
+	).Replace(value)
+	normalized = strings.ToLower(strings.Join(strings.Fields(normalized), " "))
+	_, exists := defaultXLSXProductCodeLabels[normalized]
+	return exists
 }
 
 // configuredXLSXAliasValue gives the canonical machine key deterministic

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -58,17 +58,17 @@ func TestCanonicalXLSXRoundTripPreservesTypesLayoutAndMetadata(t *testing.T) {
 	if err != nil || len(recordRows) != 2 {
 		t.Fatalf("records rows = %#v, err=%v", recordRows, err)
 	}
-	wantHeaders := []string{"Code", "Name", "Foreign Price", "Weight (g)", "Shipping Price/kg", "Shipping Currency", "Profit Margin (%)", "IRT per CNY", "Final Price (IRT)", "Warnings"}
+	wantHeaders := []string{"Product Code", "Name", "Foreign Price", "Weight (g)", "Shipping Price/kg", "Shipping Currency", "Profit Margin (%)", "IRT per CNY", "Final Price (IRT)", "Warnings"}
 	if strings.Join(recordRows[0], "|") != strings.Join(wantHeaders, "|") {
 		t.Fatalf("canonical column order = %v, want %v", recordRows[0], wantHeaders)
 	}
 	columns := headerColumns(recordRows[0])
-	assertXLSXCell(t, book, "Records", cellAt(columns, "Code", 2), "00113007045", excelize.CellTypeSharedString)
+	assertXLSXCell(t, book, "Records", cellAt(columns, "Product Code", 2), "00113007045", excelize.CellTypeSharedString)
 	assertXLSXCell(t, book, "Records", cellAt(columns, "Name", 2), "ماژول آزمون", excelize.CellTypeSharedString)
 	assertXLSXCell(t, book, "Records", cellAt(columns, "Foreign Price", 2), "24.5", excelize.CellTypeNumber)
 	assertXLSXCell(t, book, "Records", cellAt(columns, "Final Price (IRT)", 2), "2009410", excelize.CellTypeNumber)
 
-	codeStyle := styleForCell(t, book, "Records", cellAt(columns, "Code", 2))
+	codeStyle := styleForCell(t, book, "Records", cellAt(columns, "Product Code", 2))
 	if codeStyle.CustomNumFmt == nil || *codeStyle.CustomNumFmt != "@" {
 		t.Fatalf("Code style = %+v, want text format", codeStyle)
 	}
@@ -175,14 +175,14 @@ func TestFormulaXLSXLocalizesHeadersSplitsWarehousesAndCalculates(t *testing.T) 
 		t.Fatalf("records rows = %#v, err=%v", recordRows, err)
 	}
 	wantHeaders := []string{
-		"کد", "نام", "موجودی انبار ۲", "موجودی انبار ۱۰", "قیمت ارزی", "وزن (گرم)",
+		"کد کالا", "نام", "موجودی انبار ۲", "موجودی انبار ۱۰", "قیمت ارزی", "وزن (گرم)",
 		"هزینه حمل/کیلوگرم", "ارز هزینه حمل", "حاشیه سود (%)", "نرخ ریال به یوان", "قیمت نهایی (ریال)",
 	}
 	if strings.Join(recordRows[0], "|") != strings.Join(wantHeaders, "|") {
 		t.Fatalf("localized columns = %v, want %v", recordRows[0], wantHeaders)
 	}
 	columns := headerColumns(recordRows[0])
-	assertXLSXCell(t, book, "Records", cellAt(columns, "کد", 2), "001", excelize.CellTypeSharedString)
+	assertXLSXCell(t, book, "Records", cellAt(columns, "کد کالا", 2), "001", excelize.CellTypeSharedString)
 	assertXLSXCell(t, book, "Records", cellAt(columns, "موجودی انبار ۲", 2), "1", excelize.CellTypeNumber)
 	assertXLSXCell(t, book, "Records", cellAt(columns, "موجودی انبار ۱۰", 2), "3", excelize.CellTypeNumber)
 
@@ -334,6 +334,29 @@ func TestConfiguredXLSXLabelUsesDeterministicCanonicalAliasPrecedence(t *testing
 	configured[" product_code "] = "Trimmed Canonical Code"
 	if got := configuredXLSXLabel("product_code", "en", configured); got != "Trimmed Canonical Code" {
 		t.Fatalf("trimmed canonical label = %q", got)
+	}
+}
+
+func TestConfiguredXLSXProductCodeLabelsMigrateToNeutralLocalizedOutput(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		language   string
+		configured map[string]string
+		want       string
+	}{
+		{name: "English deprecated brand", language: "en", configured: map[string]string{"product_code": "Patris Code"}, want: "Product Code"},
+		{name: "Persian deprecated brand", language: "fa", configured: map[string]string{"Code": "کد پاتریس"}, want: "کد کالا"},
+		{name: "English Persian brand", language: "en", configured: map[string]string{"Code": "کد‌پاتریس"}, want: "Product Code"},
+		{name: "Persian English brand", language: "fa", configured: map[string]string{"product_code": "  PATRIS   CODE  "}, want: "کد کالا"},
+		{name: "English legacy default", language: "en", configured: map[string]string{"Code": "Code"}, want: "Product Code"},
+		{name: "Persian legacy default", language: "fa", configured: map[string]string{"product_code": "کد"}, want: "کد کالا"},
+		{name: "Custom label remains authoritative", language: "en", configured: map[string]string{"Code": "Customer SKU"}, want: "Customer SKU"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := xlsxHeaderLabel("product_code", "", test.language, test.configured); got != test.want {
+				t.Fatalf("xlsxHeaderLabel() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -802,14 +802,14 @@ func TestCanonicalKalaParityAcrossRESTCSVXLSXAndWebSocket(t *testing.T) {
 	for index, header := range formulaRows[0] {
 		formulaColumns[header] = index + 1
 	}
-	for _, required := range []string{"کد", "قیمت ارزی", "وزن (گرم)", "هزینه حمل/کیلوگرم", "ارز هزینه حمل", "حاشیه سود (%)", "نرخ ریال به یوان", "قیمت نهایی (ریال)"} {
+	for _, required := range []string{"کد کالا", "قیمت ارزی", "وزن (گرم)", "هزینه حمل/کیلوگرم", "ارز هزینه حمل", "حاشیه سود (%)", "نرخ ریال به یوان", "قیمت نهایی (ریال)"} {
 		if formulaColumns[required] == 0 {
 			t.Fatalf("formula XLSX missing Persian header %q: %v", required, formulaRows[0])
 		}
 	}
 	formulaRow := 0
 	for index, row := range formulaRows[1:] {
-		codeColumn := formulaColumns["کد"] - 1
+		codeColumn := formulaColumns["کد کالا"] - 1
 		if len(row) > codeColumn && row[codeColumn] == "102001011" {
 			formulaRow = index + 2
 			break
@@ -1039,13 +1039,13 @@ func assertHumanXLSXCanonicalFixture(t *testing.T, rows [][]string) {
 	for index, field := range rows[0] {
 		columns[field] = index
 	}
-	for _, required := range []string{"Code", "Foreign Price", "Weight (g)", "Total Stock", "Final Price (IRT)", "Record Hash"} {
+	for _, required := range []string{"Product Code", "Foreign Price", "Weight (g)", "Total Stock", "Final Price (IRT)", "Record Hash"} {
 		if _, exists := columns[required]; !exists {
 			t.Fatalf("XLSX missing human-readable column %s: %v", required, rows[0])
 		}
 	}
 	for _, row := range rows[1:] {
-		if len(row) <= columns["Code"] || row[columns["Code"]] != "102001011" {
+		if len(row) <= columns["Product Code"] || row[columns["Product Code"]] != "102001011" {
 			continue
 		}
 		for field, expected := range map[string]string{"Foreign Price": "2.75", "Weight (g)": "1.84", "Total Stock": "20", "Final Price (IRT)": "111999"} {

--- a/web/src/table-ux.js
+++ b/web/src/table-ux.js
@@ -4,7 +4,7 @@ export const COLUMN_RESIZE_STEP = 12;
 export const WAREHOUSE_FIELD_PREFIX = 'warehouse_stock::';
 
 const COLUMN_LABELS = Object.freeze({
-    product_code: Object.freeze({ en: 'Code', fa: 'کد' }),
+    product_code: Object.freeze({ en: 'Product Code', fa: 'کد کالا' }),
     category_code: Object.freeze({ en: 'Category Code', fa: 'کد دسته‌بندی' }),
     name: Object.freeze({ en: 'Name', fa: 'نام' }),
     part_number: Object.freeze({ en: 'Part Number', fa: 'پارت نامبر' }),
@@ -49,6 +49,15 @@ const COLUMN_LABELS = Object.freeze({
 
 const LEGACY_DEFAULT_COLUMN_LABELS = new Set([
     'anbar', 'code', 'name', 'stock', 'warehouse', 'warehouse stock'
+]);
+
+const PRODUCT_CODE_DEFAULT_LABELS = new Set([
+    'code',
+    'product code',
+    'patris code',
+    'کد',
+    'کد کالا',
+    'کد پاتریس'
 ]);
 
 export const ROW_ICON_NAMES = [
@@ -1612,9 +1621,23 @@ export function localizedColumnLabel(field, language = 'en', configuredLabel = '
     const humanized = humanizeColumnKey(source);
     const configuredIsGenerated = configured.localeCompare(source, undefined, { sensitivity: 'base' }) === 0
         || configured.localeCompare(humanized, undefined, { sensitivity: 'base' }) === 0;
-    if (configured && !configuredIsGenerated && !LEGACY_DEFAULT_COLUMN_LABELS.has(configured.toLowerCase())) return configured;
+    const configuredIsDefault = LEGACY_DEFAULT_COLUMN_LABELS.has(configured.toLowerCase())
+        || (canonical === 'product_code' && PRODUCT_CODE_DEFAULT_LABELS.has(normalizedPresentationLabel(configured)));
+    if (configured && !configuredIsGenerated && !configuredIsDefault) return configured;
     if (COLUMN_LABELS[canonical]) return COLUMN_LABELS[canonical][locale];
     return humanized;
+}
+
+function normalizedPresentationLabel(value) {
+    return String(value || '')
+        .normalize('NFKC')
+        .replace(/[يى]/g, 'ی')
+        .replace(/ك/g, 'ک')
+        .replace(/[\u200c\u200d]/g, ' ')
+        .replace(/[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toLocaleLowerCase('en-US');
 }
 
 function humanizeColumnKey(field) {

--- a/web/test/table-ux.test.mjs
+++ b/web/test/table-ux.test.mjs
@@ -290,12 +290,19 @@ test('shared grid schema expands canonical and legacy warehouse stock into indep
 });
 
 test('known column keys use human localized labels and custom labels remain authoritative', () => {
+    assert.equal(localizedColumnLabel('product_code', 'en'), 'Product Code');
+    assert.equal(localizedColumnLabel('product_code', 'fa'), 'کد کالا');
     assert.equal(localizedColumnLabel('part_number', 'en'), 'Part Number');
     assert.equal(localizedColumnLabel('part_number', 'fa'), 'پارت نامبر');
     assert.equal(localizedColumnLabel('final_price', 'fa'), 'قیمت نهایی (تومان)');
     assert.equal(localizedColumnLabel('some_machine_key', 'en'), 'Some Machine Key');
     assert.equal(localizedColumnLabel('name', 'fa', 'Marketing title'), 'Marketing title');
-    assert.equal(localizedColumnLabel('Code', 'fa', 'Code'), 'کد');
+    assert.equal(localizedColumnLabel('Code', 'fa', 'Code'), 'کد کالا');
+    assert.equal(localizedColumnLabel('Code', 'en', 'Patris Code'), 'Product Code');
+    assert.equal(localizedColumnLabel('product_code', 'fa', 'Patris Code'), 'کد کالا');
+    assert.equal(localizedColumnLabel('Code', 'en', 'کد پاتریس'), 'Product Code');
+    assert.equal(localizedColumnLabel('product_code', 'fa', 'کد‌پاتریس'), 'کد کالا');
+    assert.equal(localizedColumnLabel('product_code', 'en', 'Customer SKU'), 'Customer SKU');
     assert.equal(localizedColumnLabel('FOROSH', 'en', 'FOROSH'), 'Sale Price');
     assert.equal(localizedColumnLabel('FOROSH', 'fa', 'FOROSH'), 'قیمت فروش');
     assert.equal(localizedColumnLabel('Sefaresh', 'fa', 'Sefaresh'), 'حد سفارش');


### PR DESCRIPTION
## What changed

- Present the canonical `product_code` column as `Product Code` in English and `کد کالا` in Persian.
- Apply the same localized heading to the Web table, browser-generated CSV, and XLSX workbooks.
- Migrate generated/default presentation labels including `Code`, `کد`, `Patris Code`, and `کد پاتریس` to the neutral localized heading.
- Preserve explicitly customized labels.
- Keep the internal `product_code` schema key and accepted legacy `Code` input alias unchanged.

## Why

Customer-facing product identity must use neutral catalog terminology without leaking an internal Patris label. Existing saved UI/export settings can retain older generated labels, so the presentation layer needs a compatibility migration rather than a schema rename.

## Validation

- `npm test` — 74/74 passing
- `npm run build` — passing
- `go test ./pkg/recordsink ./pkg/server` — passing with the deployed dynamic pxlib runtime before the unrelated #206/#208 base advances
- `go test ./...` — passing before the unrelated #206/#208 base advances
- `git diff --check` — passing on the exact head
- GitHub release CI will rerun the full Go/Web/build/package matrix against the exact rebased head

Part of #202.
