### PR TITLE
Add privacy-safe recent-sales aggregate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The standalone home and character-map routes now share the viewer's complete
   English/Persian translation runtime, embedded Vazirmatn font, persisted
   language preference, RTL/LTR layout, and localized accessible controls.
+- An authenticated recent-sales endpoint now projects a separately configured
+  supported source into a deterministic, paged product-level aggregate while
+  excluding customer, order, payment, and delivery details; its source/auth
+  profile stays server-side across browser config reads and writes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -608,6 +608,14 @@ same table controls through its Products/Categories switch. Products include
 their explicit `category_code`; reserved accounting and service rows appear in
 `excluded_codes` and are never exposed as products.
 
+`GET /api/recent-sales` is a separate authenticated, read-only product-level
+aggregate feed. It requires explicit RFC3339 `from` and `to` bounds, bounded
+paging, a dedicated bearer credential stored only in an environment variable,
+and a separately configured supported sales source. It returns only product
+code, sold quantity, sale frequency, last-sold time, and stable
+source/window/page metadata. It explicitly refuses `kala.db` and the primary
+product database. See [Recent-sales aggregate API](docs/RECENT-SALES-API.md).
+
 `POST /api/refresh` forces the same source snapshot refresh used by the Web UI,
 WebSocket, IPC, and embedded-library `refresh` command. This gives desktop and
 remote clients one consistent manual-refresh operation.

--- a/docs/RECENT-SALES-API.md
+++ b/docs/RECENT-SALES-API.md
@@ -1,0 +1,157 @@
+# Privacy-safe recent-sales aggregate API
+
+`GET /api/recent-sales` is an authenticated, read-only enrichment feed for
+product-level sales recency and frequency. It never returns source rows or
+order/customer fields.
+
+## Authentication
+
+The endpoint requires an `Authorization: Bearer ...` header. The secret is read
+only from the environment variable named by `recent_sales.token_env`; it is not
+stored in the config file or returned by any API. The default variable name is
+`PATRIS_EXPORT_RECENT_SALES_TOKEN`.
+
+The complete recent-sales source/auth profile is server-side configuration. It
+is redacted from browser/WebSocket config payloads and preserved if the browser
+saves unrelated UI settings.
+
+If the feature is enabled but the configured variable is missing or shorter
+than 16 characters, the endpoint fails closed with HTTP 503. Missing or invalid
+credentials return HTTP 401. Query-string credentials are not supported.
+
+## Supported source profile
+
+The source must be a separate local `.json` or Paradox `.db` file supported by
+the existing datasource abstraction. The primary product database and every
+file named `kala.db` are explicitly refused. Remote URLs are also refused so
+the service can hash and verify one stable local snapshot before and after the
+read.
+
+No sales database schema is assumed. Configure the exact field names:
+
+```json
+{
+  "recent_sales": {
+    "enabled": true,
+    "source": "C:/Patris/integration/sales-events.json",
+    "source_id": "office-sales",
+    "token_env": "PATRIS_EXPORT_RECENT_SALES_TOKEN",
+    "product_code_field": "product_code",
+    "quantity_field": "quantity",
+    "sold_at_field": "sold_at",
+    "event_id_field": "sale_event_id",
+    "max_window": "2160h",
+    "max_page_size": 500,
+    "max_source_rows": 1000000,
+    "max_source_mb": 256
+  }
+}
+```
+
+The equivalent operational environment overrides are:
+
+```text
+PATRIS_EXPORT_RECENT_SALES_ENABLED=true
+PATRIS_EXPORT_RECENT_SALES_SOURCE=C:\Patris\integration\sales-events.json
+PATRIS_EXPORT_RECENT_SALES_SOURCE_ID=office-sales
+PATRIS_EXPORT_RECENT_SALES_TOKEN_ENV=PATRIS_EXPORT_RECENT_SALES_TOKEN
+PATRIS_EXPORT_RECENT_SALES_PRODUCT_CODE_FIELD=product_code
+PATRIS_EXPORT_RECENT_SALES_QUANTITY_FIELD=quantity
+PATRIS_EXPORT_RECENT_SALES_SOLD_AT_FIELD=sold_at
+PATRIS_EXPORT_RECENT_SALES_EVENT_ID_FIELD=sale_event_id
+PATRIS_EXPORT_RECENT_SALES_MAX_WINDOW=2160h
+PATRIS_EXPORT_RECENT_SALES_MAX_PAGE_SIZE=500
+PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_ROWS=1000000
+PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_MB=256
+```
+
+Each source row must contain:
+
+- an exact non-empty textual product code (JSON sources must quote it, which
+  preserves leading zeroes);
+- a positive finite sold quantity;
+- an RFC3339 sale timestamp;
+- a stable event/line identifier used only for deduplication.
+
+Identical duplicate event identifiers count once. Conflicting duplicates fail
+the whole request closed. Other source fields are ignored and cannot cross the
+response boundary. Prefer a pre-sanitized integration source even though the
+response projector also uses a closed allowlist.
+
+## Request
+
+Both time bounds are required. The window is inclusive at `from` and exclusive
+at `to`, then normalized to UTC:
+
+```powershell
+$headers = @{ Authorization = "Bearer $env:PATRIS_EXPORT_RECENT_SALES_TOKEN" }
+Invoke-RestMethod `
+  -Headers $headers `
+  -Uri 'http://127.0.0.1:18080/api/recent-sales?from=2026-07-01T00%3A00%3A00Z&to=2026-07-08T00%3A00%3A00Z&page=1&page_size=100'
+```
+
+Allowed query parameters are only:
+
+- `from`: required RFC3339 timestamp;
+- `to`: required RFC3339 timestamp;
+- `page`: optional positive integer, default `1`, maximum `1000000`;
+- `page_size`: optional positive integer, default `100`, maximum `500` or the
+  lower configured bound.
+
+The default maximum window is 90 days. Configuration can reduce it or raise it
+only as far as 365 days. Source ingestion is independently bounded by row count
+and file size; defaults are 1,000,000 rows and 256 MiB, and the hard file-size
+ceiling is 1 GiB.
+
+## Response
+
+The media type is
+`application/vnd.patris.recent-sales-aggregate+json`.
+Product aggregates are byte-sorted by `product_code` before paging:
+
+```json
+{
+  "schema": "patris.recent-sales-aggregate",
+  "version": 1,
+  "source": {
+    "id": "office-sales",
+    "dataset": "sales-events.json",
+    "revision": "sha256:..."
+  },
+  "window": {
+    "from": "2026-07-01T00:00:00Z",
+    "to": "2026-07-08T00:00:00Z"
+  },
+  "page": {
+    "number": 1,
+    "size": 100,
+    "total_items": 2,
+    "total_pages": 1
+  },
+  "sales": [
+    {
+      "product_code": "113006048",
+      "sold_quantity": 4,
+      "sale_frequency": 3,
+      "last_sold_at": "2026-07-07T10:20:00Z"
+    }
+  ]
+}
+```
+
+The `sales` object has exactly four fields. Customer identity/contact/address,
+invoice or payment details, discounts, destinations, source event identifiers,
+and all other order-level data are excluded. `sale_frequency` is the count of
+unique configured event/line identifiers for that product inside the window.
+
+`testdata/recent-sales-config.synthetic.json` and
+`testdata/recent-sales-events.synthetic.json` provide a credential-free,
+non-production profile for isolated build/API probes. Supply the bearer value
+only through `PATRIS_EXPORT_RECENT_SALES_TOKEN`.
+
+## Current source limitation
+
+The application does not discover or infer a live sales table. An operator must
+configure a separately supported source and its exact field mapping. This is
+intentional: guessing a schema or deriving sales from `kala.db` would violate
+the privacy and product-identity boundary.

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/canonical"
+	"github.com/atomicdeploy/patris-export/pkg/recentsales"
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 	"github.com/atomicdeploy/patris-export/pkg/updateout"
 	"github.com/fsnotify/fsnotify"
@@ -39,6 +40,7 @@ type Config struct {
 	Convert       ConvertConfig          `json:"convert" yaml:"convert" toml:"convert"`
 	Transform     recordmap.Config       `json:"transform" yaml:"transform" toml:"transform"`
 	Canonical     canonical.Config       `json:"canonical" yaml:"canonical" toml:"canonical"`
+	RecentSales   recentsales.Config     `json:"recent_sales" yaml:"recent_sales" toml:"recent_sales"`
 	Export        ExportConfig           `json:"export" yaml:"export" toml:"export"`
 	SendUpdates   updateout.Config       `json:"send_updates" yaml:"send_updates" toml:"send_updates"`
 	Edge          EdgeConfig             `json:"edge" yaml:"edge" toml:"edge"`
@@ -207,7 +209,8 @@ func Default() Config {
 			XLSXMode:            "precalculated",
 			XLSXZebraRows:       true,
 		},
-		Canonical: canonical.DefaultConfig(),
+		Canonical:   canonical.DefaultConfig(),
+		RecentSales: recentsales.DefaultConfig(),
 		SendUpdates: updateout.Config{
 			Method:        "POST",
 			Format:        "json",
@@ -820,6 +823,48 @@ func ApplyEnv(cfg *Config) {
 			cfg.Canonical.Pricing.Digitalogic.BatchSize = batch
 		}
 	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_ENABLED"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.Enabled = parseBool(value, cfg.RecentSales.Enabled)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_SOURCE"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.Source = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_SOURCE_ID"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.SourceID = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_TOKEN_ENV"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.TokenEnv = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_PRODUCT_CODE_FIELD"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.ProductCodeField = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_QUANTITY_FIELD"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.QuantityField = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_SOLD_AT_FIELD"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.SoldAtField = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_EVENT_ID_FIELD"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.EventIDField = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_MAX_WINDOW"); strings.TrimSpace(value) != "" {
+		cfg.RecentSales.MaxWindow = strings.TrimSpace(value)
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_MAX_PAGE_SIZE"); strings.TrimSpace(value) != "" {
+		if maxPageSize, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+			cfg.RecentSales.MaxPageSize = maxPageSize
+		}
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_ROWS"); strings.TrimSpace(value) != "" {
+		if maxRows, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+			cfg.RecentSales.MaxSourceRows = maxRows
+		}
+	}
+	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_MB"); strings.TrimSpace(value) != "" {
+		if maxMB, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil {
+			cfg.RecentSales.MaxSourceMB = maxMB
+		}
+	}
 	for _, key := range []string{"PATRIS_EXPORT_TEMP_DIR", "PATRIS_EXPORT_TMPDIR"} {
 		if value := os.Getenv(key); strings.TrimSpace(value) != "" {
 			cfg.Runtime.TempDir = strings.TrimSpace(value)
@@ -1067,6 +1112,7 @@ func normalize(cfg *Config) {
 		cfg.Export.Reconciliation = "upsert_only"
 	}
 	cfg.Canonical = canonical.NormalizeConfig(cfg.Canonical)
+	cfg.RecentSales = recentsales.NormalizeConfig(cfg.RecentSales)
 	cfg.SendUpdates = updateout.Normalize(cfg.SendUpdates)
 	cfg.Edge.TargetURL = strings.TrimRight(strings.TrimSpace(cfg.Edge.TargetURL), "/")
 	cfg.Edge.Token = strings.TrimSpace(cfg.Edge.Token)

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
+	"github.com/atomicdeploy/patris-export/pkg/recentsales"
 )
 
 func TestLoadFilesLayersJSONYAMLTOML(t *testing.T) {
@@ -425,6 +426,52 @@ func TestApplyEnvBoundsDigitalogicPricingBatchSizeAndTimeout(t *testing.T) {
 	}
 	if digitalogic.BatchSize != 500 {
 		t.Fatalf("batch size was not bounded to the remote contract maximum: %+v", digitalogic)
+	}
+}
+
+func TestRecentSalesConfigUsesEnvironmentReferencesWithoutPersistingSecrets(t *testing.T) {
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_ENABLED", "true")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_SOURCE", " C:/safe/sales-events.json ")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_SOURCE_ID", " office-sales ")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_TOKEN_ENV", "OFFICE_RECENT_SALES_TOKEN")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_PRODUCT_CODE_FIELD", "Code")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_QUANTITY_FIELD", "Tedad")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_SOLD_AT_FIELD", "SoldAt")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_EVENT_ID_FIELD", "LineID")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_MAX_WINDOW", "10000h")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_MAX_PAGE_SIZE", "900")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_ROWS", "2000000")
+	t.Setenv("PATRIS_EXPORT_RECENT_SALES_MAX_SOURCE_MB", "2000")
+	t.Setenv("OFFICE_RECENT_SALES_TOKEN", "must-never-enter-config")
+
+	cfg := Default()
+	ApplyEnv(&cfg)
+	recent := cfg.RecentSales
+	if !recent.Enabled || recent.Source != "C:/safe/sales-events.json" || recent.SourceID != "office-sales" ||
+		recent.TokenEnv != "OFFICE_RECENT_SALES_TOKEN" || recent.ProductCodeField != "Code" ||
+		recent.QuantityField != "Tedad" || recent.SoldAtField != "SoldAt" || recent.EventIDField != "LineID" {
+		t.Fatalf("recent-sales environment references were not applied: %+v", recent)
+	}
+	if recent.MaxWindow != (365*24*time.Hour).String() || recent.MaxPageSize != 500 ||
+		recent.MaxSourceRows != 1_000_000 || recent.MaxSourceMB != 1024 {
+		t.Fatalf("recent-sales safety limits were not bounded: %+v", recent)
+	}
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "must-never-enter-config") {
+		t.Fatalf("recent-sales credential value entered config: %s", encoded)
+	}
+}
+
+func TestRecentSalesDefaultsFailClosed(t *testing.T) {
+	cfg := Default()
+	if cfg.RecentSales.Enabled || cfg.RecentSales.Source != "" ||
+		cfg.RecentSales.TokenEnv != recentsales.DefaultTokenEnv ||
+		cfg.RecentSales.MaxPageSize != 500 || cfg.RecentSales.MaxSourceRows != 1_000_000 ||
+		cfg.RecentSales.MaxSourceMB != 256 {
+		t.Fatalf("unsafe recent-sales defaults: %+v", cfg.RecentSales)
 	}
 }
 

--- a/pkg/recentsales/contract.go
+++ b/pkg/recentsales/contract.go
@@ -1,0 +1,219 @@
+package recentsales
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaName           = "patris.recent-sales-aggregate"
+	SchemaVersion        = 1
+	MediaType            = "application/vnd.patris.recent-sales-aggregate+json"
+	DefaultTokenEnv      = "PATRIS_EXPORT_RECENT_SALES_TOKEN"
+	defaultMaxWindow     = 90 * 24 * time.Hour
+	maxAllowedWindow     = 365 * 24 * time.Hour
+	defaultMaxPageSize   = 500
+	defaultMaxSourceRows = 1_000_000
+	defaultMaxSourceMB   = int64(256)
+	maxAllowedSourceMB   = int64(1024)
+	maxPageNumber        = 1_000_000
+)
+
+// Config defines a fail-closed source profile for the recent-sales aggregate
+// feed. TokenEnv names an environment variable; credential values are never
+// stored in application configuration or returned by the API.
+type Config struct {
+	Enabled          bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
+	Source           string `json:"source" yaml:"source" toml:"source"`
+	SourceID         string `json:"source_id" yaml:"source_id" toml:"source_id"`
+	TokenEnv         string `json:"token_env" yaml:"token_env" toml:"token_env"`
+	ProductCodeField string `json:"product_code_field" yaml:"product_code_field" toml:"product_code_field"`
+	QuantityField    string `json:"quantity_field" yaml:"quantity_field" toml:"quantity_field"`
+	SoldAtField      string `json:"sold_at_field" yaml:"sold_at_field" toml:"sold_at_field"`
+	EventIDField     string `json:"event_id_field" yaml:"event_id_field" toml:"event_id_field"`
+	MaxWindow        string `json:"max_window" yaml:"max_window" toml:"max_window"`
+	MaxPageSize      int    `json:"max_page_size" yaml:"max_page_size" toml:"max_page_size"`
+	MaxSourceRows    int    `json:"max_source_rows" yaml:"max_source_rows" toml:"max_source_rows"`
+	MaxSourceMB      int64  `json:"max_source_mb" yaml:"max_source_mb" toml:"max_source_mb"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		SourceID:         "sales",
+		TokenEnv:         DefaultTokenEnv,
+		ProductCodeField: "product_code",
+		QuantityField:    "quantity",
+		SoldAtField:      "sold_at",
+		EventIDField:     "sale_event_id",
+		MaxWindow:        defaultMaxWindow.String(),
+		MaxPageSize:      defaultMaxPageSize,
+		MaxSourceRows:    defaultMaxSourceRows,
+		MaxSourceMB:      defaultMaxSourceMB,
+	}
+}
+
+func NormalizeConfig(cfg Config) Config {
+	defaults := DefaultConfig()
+	cfg.Source = strings.TrimSpace(cfg.Source)
+	cfg.SourceID = strings.TrimSpace(cfg.SourceID)
+	if cfg.SourceID == "" {
+		cfg.SourceID = defaults.SourceID
+	}
+	cfg.TokenEnv = strings.TrimSpace(cfg.TokenEnv)
+	if cfg.TokenEnv == "" {
+		cfg.TokenEnv = defaults.TokenEnv
+	}
+	cfg.ProductCodeField = normalizedField(cfg.ProductCodeField, defaults.ProductCodeField)
+	cfg.QuantityField = normalizedField(cfg.QuantityField, defaults.QuantityField)
+	cfg.SoldAtField = normalizedField(cfg.SoldAtField, defaults.SoldAtField)
+	cfg.EventIDField = normalizedField(cfg.EventIDField, defaults.EventIDField)
+	cfg.MaxWindow = normalizeDuration(cfg.MaxWindow, defaultMaxWindow, time.Hour, maxAllowedWindow).String()
+	if cfg.MaxPageSize <= 0 {
+		cfg.MaxPageSize = defaults.MaxPageSize
+	} else if cfg.MaxPageSize > defaultMaxPageSize {
+		cfg.MaxPageSize = defaultMaxPageSize
+	}
+	if cfg.MaxSourceRows <= 0 {
+		cfg.MaxSourceRows = defaults.MaxSourceRows
+	} else if cfg.MaxSourceRows > defaultMaxSourceRows {
+		cfg.MaxSourceRows = defaultMaxSourceRows
+	}
+	if cfg.MaxSourceMB <= 0 {
+		cfg.MaxSourceMB = defaults.MaxSourceMB
+	} else if cfg.MaxSourceMB > maxAllowedSourceMB {
+		cfg.MaxSourceMB = maxAllowedSourceMB
+	}
+	return cfg
+}
+
+func normalizedField(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func normalizeDuration(value string, fallback, minimum, maximum time.Duration) time.Duration {
+	parsed, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		parsed = fallback
+	}
+	if parsed < minimum {
+		parsed = minimum
+	}
+	if parsed > maximum {
+		parsed = maximum
+	}
+	return parsed
+}
+
+type Query struct {
+	From     time.Time
+	To       time.Time
+	Page     int
+	PageSize int
+}
+
+// ParseQuery validates an explicit, deterministic [from,to) window. Requiring
+// both bounds prevents a changing server clock from silently changing a
+// nightly operator's source window.
+func ParseQuery(values url.Values, cfg Config) (Query, error) {
+	cfg = NormalizeConfig(cfg)
+	for key, supplied := range values {
+		switch key {
+		case "from", "to", "page", "page_size":
+		default:
+			return Query{}, fmt.Errorf("unsupported query parameter %q", key)
+		}
+		if len(supplied) != 1 {
+			return Query{}, fmt.Errorf("query parameter %q must be supplied exactly once", key)
+		}
+	}
+	from, err := parseRequiredTimestamp("from", values.Get("from"))
+	if err != nil {
+		return Query{}, err
+	}
+	to, err := parseRequiredTimestamp("to", values.Get("to"))
+	if err != nil {
+		return Query{}, err
+	}
+	if !from.Before(to) {
+		return Query{}, fmt.Errorf("from must be before to")
+	}
+	maxWindow, _ := time.ParseDuration(cfg.MaxWindow)
+	if to.Sub(from) > maxWindow {
+		return Query{}, fmt.Errorf("requested window exceeds maximum %s", cfg.MaxWindow)
+	}
+	page, err := boundedPositiveInt("page", values.Get("page"), 1, maxPageNumber)
+	if err != nil {
+		return Query{}, err
+	}
+	pageSize, err := boundedPositiveInt("page_size", values.Get("page_size"), min(100, cfg.MaxPageSize), cfg.MaxPageSize)
+	if err != nil {
+		return Query{}, err
+	}
+	return Query{From: from.UTC(), To: to.UTC(), Page: page, PageSize: pageSize}, nil
+}
+
+func parseRequiredTimestamp(name, value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("%s is required", name)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s must be an RFC3339 timestamp", name)
+	}
+	return parsed.UTC(), nil
+}
+
+func boundedPositiveInt(name, value string, fallback, maximum int) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 || parsed > maximum {
+		return 0, fmt.Errorf("%s must be between 1 and %d", name, maximum)
+	}
+	return parsed, nil
+}
+
+type Envelope struct {
+	Schema  string      `json:"schema"`
+	Version int         `json:"version"`
+	Source  Source      `json:"source"`
+	Window  Window      `json:"window"`
+	Page    Page        `json:"page"`
+	Sales   []Aggregate `json:"sales"`
+}
+
+type Source struct {
+	ID       string `json:"id"`
+	Dataset  string `json:"dataset"`
+	Revision string `json:"revision"`
+}
+
+type Window struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+type Page struct {
+	Number     int `json:"number"`
+	Size       int `json:"size"`
+	TotalItems int `json:"total_items"`
+	TotalPages int `json:"total_pages"`
+}
+
+// Aggregate is deliberately closed to the four allowed product-level facts.
+type Aggregate struct {
+	ProductCode   string    `json:"product_code"`
+	SoldQuantity  float64   `json:"sold_quantity"`
+	SaleFrequency int       `json:"sale_frequency"`
+	LastSoldAt    time.Time `json:"last_sold_at"`
+}

--- a/pkg/recentsales/contract_test.go
+++ b/pkg/recentsales/contract_test.go
@@ -1,0 +1,232 @@
+package recentsales
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseQueryRequiresBoundedDeterministicWindowAndPaging(t *testing.T) {
+	cfg := DefaultConfig()
+	valid := url.Values{
+		"from":      {"2026-07-01T00:00:00Z"},
+		"to":        {"2026-07-08T00:00:00Z"},
+		"page":      {"2"},
+		"page_size": {"25"},
+	}
+	query, err := ParseQuery(valid, cfg)
+	if err != nil {
+		t.Fatalf("ParseQuery valid request: %v", err)
+	}
+	if query.Page != 2 || query.PageSize != 25 || query.From.Location() != time.UTC || query.To.Location() != time.UTC {
+		t.Fatalf("unexpected normalized query: %+v", query)
+	}
+
+	tests := []struct {
+		name   string
+		values url.Values
+	}{
+		{"missing from", url.Values{"to": {"2026-07-08T00:00:00Z"}}},
+		{"missing to", url.Values{"from": {"2026-07-01T00:00:00Z"}}},
+		{"bad timestamp", url.Values{"from": {"2026-07-01"}, "to": {"2026-07-08T00:00:00Z"}}},
+		{"reversed", url.Values{"from": {"2026-07-08T00:00:00Z"}, "to": {"2026-07-01T00:00:00Z"}}},
+		{"too wide", url.Values{"from": {"2026-01-01T00:00:00Z"}, "to": {"2026-07-08T00:00:00Z"}}},
+		{"page zero", url.Values{"from": {"2026-07-01T00:00:00Z"}, "to": {"2026-07-08T00:00:00Z"}, "page": {"0"}}},
+		{"page size too large", url.Values{"from": {"2026-07-01T00:00:00Z"}, "to": {"2026-07-08T00:00:00Z"}, "page_size": {"501"}}},
+		{"unknown parameter", url.Values{"from": {"2026-07-01T00:00:00Z"}, "to": {"2026-07-08T00:00:00Z"}, "customer": {"x"}}},
+		{"duplicate parameter", url.Values{"from": {"2026-07-01T00:00:00Z", "2026-07-02T00:00:00Z"}, "to": {"2026-07-08T00:00:00Z"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseQuery(test.values, cfg); err == nil {
+				t.Fatal("invalid query was accepted")
+			}
+		})
+	}
+}
+
+func TestLoadAggregatesDeduplicatesOrdersAndReturnsClosedPrivacyShape(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "sales-events.json")
+	rows := []map[string]interface{}{
+		{
+			"sale_event_id": "event-3", "product_code": "B-20", "quantity": 1.25,
+			"sold_at": "2026-07-03T10:00:00+03:30", "customer_name": "must-not-cross",
+			"address": "must-not-cross", "invoice_id": "must-not-cross", "payment": "must-not-cross",
+			"discount": "must-not-cross", "destination": "must-not-cross",
+		},
+		{
+			"sale_event_id": "event-1", "product_code": "A-10", "quantity": 2,
+			"sold_at": "2026-07-02T00:00:00Z", "customer_contact": "must-not-cross",
+		},
+		{
+			"sale_event_id": "event-2", "product_code": "A-10", "quantity": 3.5,
+			"sold_at": "2026-07-04T00:00:00Z", "order_id": "must-not-cross",
+		},
+		// Exact duplicate event rows are counted once.
+		{
+			"sale_event_id": "event-2", "product_code": "A-10", "quantity": 3.5,
+			"sold_at": "2026-07-04T00:00:00Z", "order_id": "different-private-value",
+		},
+		// This event is outside the requested [from,to) window.
+		{
+			"sale_event_id": "event-4", "product_code": "A-10", "quantity": 99,
+			"sold_at": "2026-06-30T23:59:59Z",
+		},
+	}
+	writeJSONFixture(t, source, rows)
+
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	cfg.Source = source
+	cfg.SourceID = "office-sales"
+	query := Query{
+		From:     mustTime(t, "2026-07-01T00:00:00Z"),
+		To:       mustTime(t, "2026-07-08T00:00:00Z"),
+		Page:     1,
+		PageSize: 100,
+	}
+	got, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.json"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Schema != SchemaName || got.Version != SchemaVersion || got.Source.ID != "office-sales" ||
+		got.Source.Dataset != "sales-events.json" || !strings.HasPrefix(got.Source.Revision, "sha256:") {
+		t.Fatalf("unexpected contract metadata: %+v", got)
+	}
+	want := []Aggregate{
+		{ProductCode: "A-10", SoldQuantity: 5.5, SaleFrequency: 2, LastSoldAt: mustTime(t, "2026-07-04T00:00:00Z")},
+		{ProductCode: "B-20", SoldQuantity: 1.25, SaleFrequency: 1, LastSoldAt: mustTime(t, "2026-07-03T06:30:00Z")},
+	}
+	if !reflect.DeepEqual(got.Sales, want) {
+		t.Fatalf("aggregates differ:\n got: %#v\nwant: %#v", got.Sales, want)
+	}
+	if got.Page.Number != 1 || got.Page.Size != 100 || got.Page.TotalItems != 2 || got.Page.TotalPages != 1 {
+		t.Fatalf("unexpected page metadata: %+v", got.Page)
+	}
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := string(body)
+	for _, forbidden := range []string{
+		"must-not-cross", "different-private-value", "customer", "contact", "address",
+		"invoice", "payment", "discount", "destination", "order_id", "sale_event_id",
+	} {
+		if strings.Contains(encoded, forbidden) {
+			t.Fatalf("response leaked forbidden source data %q: %s", forbidden, encoded)
+		}
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if gotKeys := sortedKeys(decoded); !reflect.DeepEqual(gotKeys, []string{"page", "sales", "schema", "source", "version", "window"}) {
+		t.Fatalf("top-level response shape is not closed: %v", gotKeys)
+	}
+	sales, ok := decoded["sales"].([]interface{})
+	if !ok || len(sales) != 2 {
+		t.Fatalf("unexpected sales payload: %#v", decoded["sales"])
+	}
+	if gotKeys := sortedKeys(sales[0].(map[string]interface{})); !reflect.DeepEqual(gotKeys, []string{"last_sold_at", "product_code", "sale_frequency", "sold_quantity"}) {
+		t.Fatalf("aggregate response shape is not closed: %v", gotKeys)
+	}
+
+	again, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.json"))
+	if err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if !reflect.DeepEqual(got, again) {
+		t.Fatalf("same source and window did not produce deterministic output")
+	}
+}
+
+func TestLoadPaginatesAfterDeterministicProductOrdering(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "sales.json")
+	writeJSONFixture(t, source, []map[string]interface{}{
+		{"sale_event_id": "3", "product_code": "C", "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+		{"sale_event_id": "1", "product_code": "A", "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+		{"sale_event_id": "2", "product_code": "B", "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+	})
+	cfg := DefaultConfig()
+	cfg.Source = source
+	got, err := Load(context.Background(), cfg, Query{
+		From: mustTime(t, "2026-07-01T00:00:00Z"), To: mustTime(t, "2026-07-03T00:00:00Z"),
+		Page: 2, PageSize: 1,
+	}, filepath.Join(dir, "products.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sales) != 1 || got.Sales[0].ProductCode != "B" || got.Page.TotalItems != 3 || got.Page.TotalPages != 3 {
+		t.Fatalf("unexpected deterministic second page: %+v", got)
+	}
+}
+
+func TestLoadFailsClosedForConflictingDuplicateAndProductDatabase(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "sales.json")
+	writeJSONFixture(t, source, []map[string]interface{}{
+		{"sale_event_id": "same", "product_code": "A", "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+		{"sale_event_id": "same", "product_code": "B", "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+	})
+	cfg := DefaultConfig()
+	cfg.Source = source
+	query := Query{From: mustTime(t, "2026-07-01T00:00:00Z"), To: mustTime(t, "2026-07-03T00:00:00Z"), Page: 1, PageSize: 100}
+	if _, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.db")); err == nil || !strings.Contains(err.Error(), "conflicting duplicate") {
+		t.Fatalf("conflicting duplicate did not fail closed: %v", err)
+	}
+
+	writeJSONFixture(t, source, []map[string]interface{}{
+		{"sale_event_id": "numeric-code", "product_code": 113006048, "quantity": 1, "sold_at": "2026-07-02T00:00:00Z"},
+	})
+	if _, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.db")); err == nil || !strings.Contains(err.Error(), "invalid product_code") {
+		t.Fatalf("lossy numeric JSON product code was accepted: %v", err)
+	}
+
+	cfg.Source = filepath.Join(dir, "kala.db")
+	if _, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.db")); err == nil || !strings.Contains(err.Error(), "kala.db") {
+		t.Fatalf("kala.db was accepted as sales source: %v", err)
+	}
+
+	cfg.Source = filepath.Join(dir, "products.db")
+	if _, err := Load(context.Background(), cfg, query, filepath.Join(dir, "products.db")); err == nil || !strings.Contains(err.Error(), "primary product database") {
+		t.Fatalf("primary product database was accepted as sales source: %v", err)
+	}
+}
+
+func writeJSONFixture(t *testing.T, path string, value interface{}) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed.UTC()
+}
+
+func sortedKeys(value map[string]interface{}) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/pkg/recentsales/source.go
+++ b/pkg/recentsales/source.go
@@ -1,0 +1,326 @@
+package recentsales
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/atomicdeploy/patris-export/pkg/converter"
+	"github.com/atomicdeploy/patris-export/pkg/datasource"
+)
+
+var ErrSourceChanged = errors.New("recent-sales source changed while it was being read")
+
+type saleEvent struct {
+	ProductCode string
+	Quantity    float64
+	SoldAt      time.Time
+}
+
+// Load reads a separately configured sales source through the existing
+// datasource abstraction. It explicitly rejects the primary product database:
+// this contract is not an excuse to infer sales from kala.db.
+func Load(ctx context.Context, cfg Config, query Query, primaryDatabase string) (Envelope, error) {
+	cfg = NormalizeConfig(cfg)
+	if err := validateQuery(query, cfg); err != nil {
+		return Envelope{}, err
+	}
+	if err := validateSource(cfg.Source, primaryDatabase); err != nil {
+		return Envelope{}, err
+	}
+	info, err := os.Stat(cfg.Source)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("stat recent-sales source: %w", err)
+	}
+	maxSourceBytes := cfg.MaxSourceMB * 1024 * 1024
+	if info.Size() > maxSourceBytes {
+		return Envelope{}, fmt.Errorf("recent-sales source is %d bytes; maximum is %d", info.Size(), maxSourceBytes)
+	}
+	before, err := sourceRevision(ctx, cfg.Source)
+	if err != nil {
+		return Envelope{}, err
+	}
+	ds, err := datasource.NewDataSource(cfg.Source, converter.DefaultCharMapping(), true)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("open recent-sales source: %w", err)
+	}
+	defer ds.Close()
+	contextSource, ok := ds.(datasource.ContextDataSource)
+	if !ok {
+		return Envelope{}, fmt.Errorf("recent-sales source does not support bounded reads")
+	}
+	rows, err := contextSource.GetRawRecordsContext(ctx)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("read recent-sales source: %w", err)
+	}
+	if len(rows) > cfg.MaxSourceRows {
+		return Envelope{}, fmt.Errorf("recent-sales source has %d rows; maximum is %d", len(rows), cfg.MaxSourceRows)
+	}
+	after, err := sourceRevision(ctx, cfg.Source)
+	if err != nil {
+		return Envelope{}, err
+	}
+	if before != after {
+		return Envelope{}, ErrSourceChanged
+	}
+	aggregates, err := aggregateRows(ctx, cfg, query, rows)
+	if err != nil {
+		return Envelope{}, err
+	}
+	totalItems := len(aggregates)
+	totalPages := 0
+	if totalItems > 0 {
+		totalPages = (totalItems + query.PageSize - 1) / query.PageSize
+	}
+	start := (query.Page - 1) * query.PageSize
+	if start > totalItems {
+		start = totalItems
+	}
+	end := min(start+query.PageSize, totalItems)
+	pageRows := append([]Aggregate(nil), aggregates[start:end]...)
+	if pageRows == nil {
+		pageRows = []Aggregate{}
+	}
+	return Envelope{
+		Schema:  SchemaName,
+		Version: SchemaVersion,
+		Source: Source{
+			ID:       cfg.SourceID,
+			Dataset:  filepath.Base(cfg.Source),
+			Revision: before,
+		},
+		Window: Window{From: query.From.UTC(), To: query.To.UTC()},
+		Page: Page{
+			Number:     query.Page,
+			Size:       query.PageSize,
+			TotalItems: totalItems,
+			TotalPages: totalPages,
+		},
+		Sales: pageRows,
+	}, nil
+}
+
+func validateQuery(query Query, cfg Config) error {
+	if query.Page <= 0 || query.Page > maxPageNumber {
+		return fmt.Errorf("page must be between 1 and %d", maxPageNumber)
+	}
+	if query.PageSize <= 0 || query.PageSize > cfg.MaxPageSize {
+		return fmt.Errorf("page_size must be between 1 and %d", cfg.MaxPageSize)
+	}
+	if query.From.IsZero() || query.To.IsZero() || !query.From.Before(query.To) {
+		return fmt.Errorf("from must be before to")
+	}
+	maxWindow, _ := time.ParseDuration(cfg.MaxWindow)
+	if query.To.Sub(query.From) > maxWindow {
+		return fmt.Errorf("requested window exceeds maximum %s", cfg.MaxWindow)
+	}
+	return nil
+}
+
+func validateSource(source, primaryDatabase string) error {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return fmt.Errorf("recent-sales source is not configured")
+	}
+	if strings.Contains(source, "://") {
+		return fmt.Errorf("recent-sales source must be a local supported datasource")
+	}
+	if strings.EqualFold(filepath.Base(source), "kala.db") {
+		return fmt.Errorf("kala.db cannot be used as a recent-sales source")
+	}
+	sourceAbs, sourceErr := filepath.Abs(source)
+	primaryAbs, primaryErr := filepath.Abs(strings.TrimSpace(primaryDatabase))
+	if sourceErr == nil && primaryErr == nil && strings.EqualFold(filepath.Clean(sourceAbs), filepath.Clean(primaryAbs)) {
+		return fmt.Errorf("the primary product database cannot be used as a recent-sales source")
+	}
+	return nil
+}
+
+func sourceRevision(ctx context.Context, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open recent-sales source revision: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	reader := bufio.NewReaderSize(file, 64*1024)
+	buffer := make([]byte, 64*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		read, readErr := reader.Read(buffer)
+		if read > 0 {
+			if _, err := hash.Write(buffer[:read]); err != nil {
+				return "", err
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("hash recent-sales source: %w", readErr)
+		}
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func aggregateRows(ctx context.Context, cfg Config, query Query, rows []map[string]interface{}) ([]Aggregate, error) {
+	events := make(map[string]saleEvent, len(rows))
+	for index, row := range rows {
+		if index%128 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+		eventID, err := exactString(row[cfg.EventIDField])
+		if err != nil || eventID == "" {
+			return nil, fmt.Errorf("recent-sales row %d has invalid %s", index+1, cfg.EventIDField)
+		}
+		productCode, err := exactString(row[cfg.ProductCodeField])
+		if err != nil || productCode == "" {
+			return nil, fmt.Errorf("recent-sales row %d has invalid %s", index+1, cfg.ProductCodeField)
+		}
+		quantity, err := positiveNumber(row[cfg.QuantityField])
+		if err != nil {
+			return nil, fmt.Errorf("recent-sales row %d has invalid %s", index+1, cfg.QuantityField)
+		}
+		soldAt, err := timestamp(row[cfg.SoldAtField])
+		if err != nil {
+			return nil, fmt.Errorf("recent-sales row %d has invalid %s", index+1, cfg.SoldAtField)
+		}
+		event := saleEvent{ProductCode: productCode, Quantity: quantity, SoldAt: soldAt}
+		if existing, exists := events[eventID]; exists {
+			if existing != event {
+				return nil, fmt.Errorf("recent-sales source has conflicting duplicate event identifiers")
+			}
+			continue
+		}
+		events[eventID] = event
+	}
+
+	byProduct := make(map[string]Aggregate)
+	for _, event := range events {
+		if event.SoldAt.Before(query.From) || !event.SoldAt.Before(query.To) {
+			continue
+		}
+		aggregate := byProduct[event.ProductCode]
+		aggregate.ProductCode = event.ProductCode
+		aggregate.SoldQuantity += event.Quantity
+		aggregate.SaleFrequency++
+		if aggregate.LastSoldAt.IsZero() || event.SoldAt.After(aggregate.LastSoldAt) {
+			aggregate.LastSoldAt = event.SoldAt
+		}
+		byProduct[event.ProductCode] = aggregate
+	}
+	result := make([]Aggregate, 0, len(byProduct))
+	for _, aggregate := range byProduct {
+		result = append(result, aggregate)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ProductCode < result[j].ProductCode
+	})
+	return result, nil
+}
+
+func exactString(value interface{}) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed), nil
+	case json.Number:
+		return strings.TrimSpace(typed.String()), nil
+	case int:
+		return strconv.Itoa(typed), nil
+	case int8:
+		return strconv.FormatInt(int64(typed), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(typed), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(typed), 10), nil
+	case int64:
+		return strconv.FormatInt(typed, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(typed), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(typed), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(typed), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(typed), 10), nil
+	case uint64:
+		return strconv.FormatUint(typed, 10), nil
+	default:
+		return "", fmt.Errorf("unsupported exact identifier type %T", value)
+	}
+}
+
+func positiveNumber(value interface{}) (float64, error) {
+	var number float64
+	var err error
+	switch typed := value.(type) {
+	case json.Number:
+		number, err = typed.Float64()
+	case string:
+		number, err = strconv.ParseFloat(strings.TrimSpace(typed), 64)
+	case int:
+		number = float64(typed)
+	case int8:
+		number = float64(typed)
+	case int16:
+		number = float64(typed)
+	case int32:
+		number = float64(typed)
+	case int64:
+		number = float64(typed)
+	case uint:
+		number = float64(typed)
+	case uint8:
+		number = float64(typed)
+	case uint16:
+		number = float64(typed)
+	case uint32:
+		number = float64(typed)
+	case uint64:
+		number = float64(typed)
+	case float32:
+		number = float64(typed)
+	case float64:
+		number = typed
+	default:
+		return 0, fmt.Errorf("unsupported quantity type %T", value)
+	}
+	if err != nil || math.IsNaN(number) || math.IsInf(number, 0) || number <= 0 {
+		return 0, fmt.Errorf("quantity must be a positive finite number")
+	}
+	return number, nil
+}
+
+func timestamp(value interface{}) (time.Time, error) {
+	switch typed := value.(type) {
+	case time.Time:
+		if typed.IsZero() {
+			return time.Time{}, fmt.Errorf("timestamp is empty")
+		}
+		return typed.UTC(), nil
+	case string:
+		parsed, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(typed))
+		if err != nil {
+			return time.Time{}, err
+		}
+		return parsed.UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("unsupported timestamp type %T", value)
+	}
+}

--- a/pkg/server/recent_sales_test.go
+++ b/pkg/server/recent_sales_test.go
@@ -1,0 +1,269 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
+	"github.com/atomicdeploy/patris-export/pkg/converter"
+	"github.com/atomicdeploy/patris-export/pkg/recentsales"
+)
+
+const recentSalesTestToken = "recent-sales-test-token-32-bytes"
+
+func TestRecentSalesEndpointAuthenticatesBeforeReadingAndReturnsClosedAggregate(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "products.json")
+	if err := os.WriteFile(primary, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(dir, "sales.json")
+	rows := []map[string]interface{}{
+		{
+			"sale_event_id": "sale-2", "product_code": "B", "quantity": 1,
+			"sold_at": "2026-07-02T00:00:00Z", "customer_name": "private-customer",
+			"invoice_id": "private-invoice", "payment": "private-payment",
+		},
+		{
+			"sale_event_id": "sale-1", "product_code": "A", "quantity": 2.5,
+			"sold_at": "2026-07-03T00:00:00Z", "address": "private-address",
+			"discount": "private-discount", "destination": "private-destination",
+		},
+	}
+	writeServerJSON(t, source, rows)
+	manager := recentSalesConfigManager(t, dir, map[string]interface{}{
+		"enabled": true, "source": source, "source_id": "nightly-sales",
+	})
+	t.Setenv(recentsales.DefaultTokenEnv, recentSalesTestToken)
+	server, err := NewServerWithOptions(primary, converter.DefaultCharMapping(), Options{Config: manager}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	endpoint := "/api/recent-sales?from=2026-07-01T00%3A00%3A00Z&to=2026-07-08T00%3A00%3A00Z&page=1&page_size=100"
+	for _, test := range []struct {
+		name   string
+		header string
+		target string
+		status int
+	}{
+		{"missing bearer", "", endpoint, http.StatusUnauthorized},
+		{"wrong bearer", "Bearer wrong-token-that-is-long-enough", endpoint, http.StatusUnauthorized},
+		{"query token forbidden", "", endpoint + "&token=" + recentSalesTestToken, http.StatusUnauthorized},
+		{"malformed bearer", "Basic " + recentSalesTestToken, endpoint, http.StatusUnauthorized},
+		{"invalid query after auth", "Bearer " + recentSalesTestToken, "/api/recent-sales", http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, test.target, nil)
+			if test.header != "" {
+				request.Header.Set("Authorization", test.header)
+			}
+			response := httptest.NewRecorder()
+			server.Router().ServeHTTP(response, request)
+			if response.Code != test.status {
+				t.Fatalf("status=%d, want %d: %s", response.Code, test.status, response.Body)
+			}
+			if strings.Contains(response.Body.String(), source) || strings.Contains(response.Body.String(), recentSalesTestToken) {
+				t.Fatalf("error response leaked source path or token: %s", response.Body)
+			}
+		})
+	}
+
+	request := httptest.NewRequest(http.MethodGet, endpoint, nil)
+	request.Header.Set("Authorization", "Bearer "+recentSalesTestToken)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d: %s", response.Code, response.Body)
+	}
+	if got := response.Header().Get("Content-Type"); got != recentsales.MediaType {
+		t.Fatalf("content type=%q", got)
+	}
+	if got := response.Header().Get("Cache-Control"); got != "private, no-store" {
+		t.Fatalf("cache control=%q", got)
+	}
+	body := response.Body.String()
+	for _, forbidden := range []string{
+		"private-", "customer", "invoice", "payment", "address", "discount",
+		"destination", "sale_event_id", source, recentSalesTestToken,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("success response leaked %q: %s", forbidden, body)
+		}
+	}
+	var payload struct {
+		Schema string                  `json:"schema"`
+		Source recentsales.Source      `json:"source"`
+		Sales  []recentsales.Aggregate `json:"sales"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Schema != recentsales.SchemaName || payload.Source.ID != "nightly-sales" ||
+		len(payload.Sales) != 2 || payload.Sales[0].ProductCode != "A" || payload.Sales[1].ProductCode != "B" {
+		t.Fatalf("unexpected aggregate response: %+v", payload)
+	}
+}
+
+func TestRecentSalesEndpointFailsClosedWhenDisabledOrCredentialMissing(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "products.json")
+	if err := os.WriteFile(primary, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	disabledManager := recentSalesConfigManager(t, filepath.Join(dir, "disabled"), map[string]interface{}{"enabled": false})
+	disabled, err := NewServerWithOptions(primary, converter.DefaultCharMapping(), Options{Config: disabledManager}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = disabled.Close() })
+	response := serveRecentSalesRequest(disabled, "Bearer "+recentSalesTestToken)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("disabled status=%d, want 404: %s", response.Code, response.Body)
+	}
+
+	t.Setenv(recentsales.DefaultTokenEnv, "")
+	missingManager := recentSalesConfigManager(t, filepath.Join(dir, "missing"), map[string]interface{}{
+		"enabled": true, "source": filepath.Join(dir, "not-read.json"),
+	})
+	missing, err := NewServerWithOptions(primary, converter.DefaultCharMapping(), Options{Config: missingManager}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = missing.Close() })
+	response = serveRecentSalesRequest(missing, "Bearer "+recentSalesTestToken)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("missing credential status=%d, want 503: %s", response.Code, response.Body)
+	}
+	if strings.Contains(response.Body.String(), "not-read.json") || strings.Contains(response.Body.String(), recentsales.DefaultTokenEnv) {
+		t.Fatalf("missing credential response disclosed configuration: %s", response.Body)
+	}
+}
+
+func TestBrowserConfigRedactsAndPreservesRecentSalesProfile(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "products.json")
+	if err := os.WriteFile(primary, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := recentSalesConfigManager(t, dir, map[string]interface{}{
+		"enabled": true, "source": "C:/protected/private-sales-source.json",
+		"source_id": "protected-source-id", "token_env": "PROTECTED_RECENT_SALES_TOKEN",
+		"product_code_field": "ProtectedCode", "quantity_field": "ProtectedQuantity",
+		"sold_at_field": "ProtectedTime", "event_id_field": "ProtectedEvent",
+	})
+	server, err := NewServerWithOptions(primary, converter.DefaultCharMapping(), Options{Config: manager}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	assertRedacted := func(body string) {
+		t.Helper()
+		for _, forbidden := range []string{
+			"private-sales-source", "protected-source-id", "PROTECTED_RECENT_SALES_TOKEN",
+			"ProtectedCode", "ProtectedQuantity", "ProtectedTime", "ProtectedEvent",
+		} {
+			if strings.Contains(body, forbidden) {
+				t.Fatalf("browser config exposed protected recent-sales profile %q: %s", forbidden, body)
+			}
+		}
+	}
+	get := httptest.NewRecorder()
+	server.Router().ServeHTTP(get, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET config status=%d: %s", get.Code, get.Body)
+	}
+	assertRedacted(get.Body.String())
+
+	clientConfig := browserConfig(manager.Get())
+	clientConfig.UI.Theme = "dark"
+	clientConfig.RecentSales = recentsales.Config{
+		Enabled: true, Source: "C:/attacker/replacement.json",
+		SourceID: "attacker", TokenEnv: "ATTACKER_TOKEN",
+	}
+	body, err := json.Marshal(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	put := httptest.NewRecorder()
+	server.Router().ServeHTTP(put, httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(string(body))))
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT config status=%d: %s", put.Code, put.Body)
+	}
+	assertRedacted(put.Body.String())
+	got := manager.Get()
+	if got.UI.Theme != "dark" || got.RecentSales.Source != "C:/protected/private-sales-source.json" ||
+		got.RecentSales.SourceID != "protected-source-id" || got.RecentSales.TokenEnv != "PROTECTED_RECENT_SALES_TOKEN" ||
+		got.RecentSales.ProductCodeField != "ProtectedCode" || got.RecentSales.QuantityField != "ProtectedQuantity" ||
+		got.RecentSales.SoldAtField != "ProtectedTime" || got.RecentSales.EventIDField != "ProtectedEvent" {
+		t.Fatalf("browser save changed protected recent-sales profile: %+v", got.RecentSales)
+	}
+}
+
+func TestBearerTokenAuthorizedUsesStrictReusableHTTPBoundary(t *testing.T) {
+	tests := []struct {
+		header string
+		want   bool
+	}{
+		{"Bearer " + recentSalesTestToken, true},
+		{"bearer " + recentSalesTestToken, true},
+		{"Bearer wrong", false},
+		{"Basic " + recentSalesTestToken, false},
+		{"Bearer " + recentSalesTestToken + " extra", false},
+		{"", false},
+	}
+	for _, test := range tests {
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		request.Header.Set("Authorization", test.header)
+		if got := bearerTokenAuthorized(request, recentSalesTestToken); got != test.want {
+			t.Fatalf("header %q authorized=%t, want %t", test.header, got, test.want)
+		}
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Add("Authorization", "Bearer "+recentSalesTestToken)
+	request.Header.Add("Authorization", "Bearer "+recentSalesTestToken)
+	if bearerTokenAuthorized(request, recentSalesTestToken) {
+		t.Fatal("duplicate Authorization headers were accepted")
+	}
+}
+
+func recentSalesConfigManager(t *testing.T, dir string, recentSales map[string]interface{}) *appconfig.Manager {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "patris-export.json")
+	writeServerJSON(t, path, map[string]interface{}{"recent_sales": recentSales})
+	manager, err := appconfig.LoadFiles([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manager
+}
+
+func writeServerJSON(t *testing.T, path string, value interface{}) {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func serveRecentSalesRequest(server *Server, authorization string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodGet, "/api/recent-sales?from=2026-07-01T00%3A00%3A00Z&to=2026-07-08T00%3A00%3A00Z", nil)
+	request.Header.Set("Authorization", authorization)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	return response
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/atomicdeploy/patris-export/pkg/paradox"
 	"github.com/atomicdeploy/patris-export/pkg/pricingcatalog"
 	"github.com/atomicdeploy/patris-export/pkg/processmon"
+	"github.com/atomicdeploy/patris-export/pkg/recentsales"
 	"github.com/atomicdeploy/patris-export/pkg/recorddiff"
 	"github.com/atomicdeploy/patris-export/pkg/recordmap"
 	"github.com/atomicdeploy/patris-export/pkg/recordpipe"
@@ -218,6 +220,7 @@ func (s *Server) setupRoutes() {
 	s.router.HandleFunc("/api/records.{format:json|csv|xlsx}", s.handleGetRecords).Methods("GET")
 	s.router.HandleFunc("/api/categories", s.handleGetCategories).Methods("GET")
 	s.router.HandleFunc("/api/product-sync", s.handleGetProductSyncContract).Methods("GET")
+	s.router.HandleFunc("/api/recent-sales", s.handleGetRecentSales).Methods("GET")
 	s.router.HandleFunc("/api/info", s.handleGetInfo).Methods("GET")
 	s.router.HandleFunc("/api/app", s.handleGetApp).Methods("GET")
 	s.router.HandleFunc("/api/charmap", s.handleGetCharmap).Methods("GET")
@@ -389,6 +392,7 @@ func browserConfig(cfg appconfig.Config) appconfig.Config {
 	cfg.Export.MySQLDSN = ""
 	cfg.Export.MySQLTLSCAFile = ""
 	cfg.Export.MySQLTLSServerName = ""
+	cfg.RecentSales = recentsales.Config{}
 	return cfg
 }
 
@@ -715,6 +719,62 @@ func canonicalRequestTimeout(cfg appconfig.Config) time.Duration {
 	return timeout
 }
 
+// handleGetRecentSales exposes only a privacy-safe product-level aggregate.
+// It authenticates before reading the separately configured source and never
+// serializes or returns source rows.
+func (s *Server) handleGetRecentSales(w http.ResponseWriter, r *http.Request) {
+	cfg := recentsales.DefaultConfig()
+	if s.config != nil {
+		cfg = s.config.Get().RecentSales
+	}
+	cfg = recentsales.NormalizeConfig(cfg)
+	if !cfg.Enabled {
+		writeRecentSalesError(w, http.StatusNotFound, "not_available", "Recent-sales aggregates are not available.")
+		return
+	}
+	token := strings.TrimSpace(os.Getenv(cfg.TokenEnv))
+	if len(token) < 16 {
+		writeRecentSalesError(w, http.StatusServiceUnavailable, "not_configured", "Recent-sales authentication is not configured.")
+		return
+	}
+	if !bearerTokenAuthorized(r, token) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="patris-export-recent-sales"`)
+		writeRecentSalesError(w, http.StatusUnauthorized, "unauthorized", "A valid bearer token is required.")
+		return
+	}
+	query, err := recentsales.ParseQuery(r.URL.Query(), cfg)
+	if err != nil {
+		writeRecentSalesError(w, http.StatusBadRequest, "invalid_query", err.Error())
+		return
+	}
+	envelope, err := recentsales.Load(r.Context(), cfg, query, s.currentDBPath())
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			writeRecentSalesError(w, http.StatusRequestTimeout, "request_cancelled", "The recent-sales request was cancelled.")
+			return
+		}
+		writeRecentSalesError(w, http.StatusServiceUnavailable, "source_unavailable", "The recent-sales aggregate source is unavailable.")
+		return
+	}
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("Content-Type", recentsales.MediaType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if err := json.NewEncoder(w).Encode(envelope); err != nil {
+		http.Error(w, "Failed to encode recent-sales aggregate.", http.StatusInternalServerError)
+	}
+}
+
+func writeRecentSalesError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	writeJSONStatus(w, status, map[string]interface{}{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
 func requestedRecordsFormat(r *http.Request) string {
 	if routeFormat, ok := mux.Vars(r)["format"]; ok {
 		return strings.ToLower(strings.TrimSpace(routeFormat))
@@ -975,10 +1035,12 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 	// The browser is not a connection-management surface. Preserve protected
 	// server-side connection material even if an old cache or crafted request
 	// includes replacement values.
-	protectedExport := s.config.Get().Export
+	protectedConfig := s.config.Get()
+	protectedExport := protectedConfig.Export
 	cfg.Export.MySQLDSN = protectedExport.MySQLDSN
 	cfg.Export.MySQLTLSCAFile = protectedExport.MySQLTLSCAFile
 	cfg.Export.MySQLTLSServerName = protectedExport.MySQLTLSServerName
+	cfg.RecentSales = protectedConfig.RecentSales
 	cfg, err := s.ReplaceConfig(cfg)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to save config: %v", err), http.StatusInternalServerError)
@@ -1880,12 +1942,27 @@ func (s *Server) edgeUploadAuthorized(r *http.Request) bool {
 	}
 	got := strings.TrimSpace(r.Header.Get("X-Patris-Edge-Token"))
 	if got == "" {
-		auth := strings.TrimSpace(r.Header.Get("Authorization"))
-		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
-			got = strings.TrimSpace(auth[len("Bearer "):])
-		}
+		return bearerTokenAuthorized(r, token)
 	}
-	return subtle.ConstantTimeCompare([]byte(got), []byte(token)) == 1
+	return secureTokenEqual(got, token)
+}
+
+func bearerTokenAuthorized(r *http.Request, token string) bool {
+	values := r.Header.Values("Authorization")
+	if len(values) != 1 {
+		return false
+	}
+	parts := strings.Fields(strings.TrimSpace(values[0]))
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return false
+	}
+	return secureTokenEqual(parts[1], token)
+}
+
+func secureTokenEqual(got, want string) bool {
+	gotHash := sha256.Sum256([]byte(got))
+	wantHash := sha256.Sum256([]byte(want))
+	return subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) == 1
 }
 
 func firstNonEmpty(values ...string) string {

--- a/testdata/recent-sales-config.synthetic.json
+++ b/testdata/recent-sales-config.synthetic.json
@@ -1,0 +1,16 @@
+{
+  "recent_sales": {
+    "enabled": true,
+    "source": "testdata/recent-sales-events.synthetic.json",
+    "source_id": "synthetic-sales",
+    "token_env": "PATRIS_EXPORT_RECENT_SALES_TOKEN",
+    "product_code_field": "product_code",
+    "quantity_field": "quantity",
+    "sold_at_field": "sold_at",
+    "event_id_field": "sale_event_id",
+    "max_window": "2160h",
+    "max_page_size": 100,
+    "max_source_rows": 1000,
+    "max_source_mb": 1
+  }
+}

--- a/testdata/recent-sales-events.synthetic.json
+++ b/testdata/recent-sales-events.synthetic.json
@@ -1,0 +1,20 @@
+[
+  {
+    "sale_event_id": "synthetic-sale-001",
+    "product_code": "113006048",
+    "quantity": 2,
+    "sold_at": "2026-07-20T08:00:00Z"
+  },
+  {
+    "sale_event_id": "synthetic-sale-002",
+    "product_code": "113006048",
+    "quantity": 1,
+    "sold_at": "2026-07-21T09:30:00Z"
+  },
+  {
+    "sale_event_id": "synthetic-sale-003",
+    "product_code": "113006049",
+    "quantity": 4,
+    "sold_at": "2026-07-22T11:15:00Z"
+  }
+]


### PR DESCRIPTION
Closes #210.

## Summary

- add authenticated `GET /api/recent-sales` with explicit bounded time-window
  and paging validation
- aggregate and deterministically sort exact product codes, sold quantity,
  unique sale frequency, and last-sold time
- deduplicate identical event/line identifiers and fail closed on conflicting
  duplicates
- emit a closed privacy allowlist that cannot serialize source rows or
  customer/order/payment/delivery fields
- add a separately configured local JSON/Paradox source profile through the
  existing datasource abstraction
- keep the complete recent-sales source/auth profile out of browser/WebSocket
  config payloads and preserve it across unrelated browser config saves
- refuse `kala.db`, the active primary product database, remote sources,
  oversized sources, and missing/weak credentials
- document the contract, environment-only credential, limits, source
  limitation, and synthetic probe profile

## Contract

Endpoint:

```text
GET /api/recent-sales?from=<RFC3339>&to=<RFC3339>&page=1&page_size=100
Authorization: Bearer <value from configured token environment variable>
```

Successful media type:

```text
application/vnd.patris.recent-sales-aggregate+json
```

Top-level schema:

```text
schema, version, source, window, page, sales
```

Each `sales` item has exactly:

```text
product_code, sold_quantity, sale_frequency, last_sold_at
```

`source.revision` is a SHA-256 digest verified before and after the supported
source read. The window is normalized to UTC and uses `[from,to)` semantics.
Results are byte-sorted by exact product code before paging.

The bearer secret is never stored in application configuration. Server-side
configuration stores only the environment-variable name, and the complete
recent-sales profile is redacted from browser/WebSocket config. Missing/short
credentials fail closed with 503; missing/invalid bearer authorization returns
401 before source access. Duplicate authorization headers and query-string
credentials are rejected.

## Source limitation

No live sales-table schema was found in this repository, and this change does
not guess one or query `kala.db`. An operator must configure a separate local
`.json` or Paradox `.db` datasource plus its exact product-code, quantity,
timestamp, and stable event-ID field names. JSON product codes must be quoted
so leading zeroes remain exact.

## Validation

- `npm --prefix web run build`
- `go test -count=1 -timeout=180s ./pkg/recentsales ./pkg/appconfig`
- `PATRIS_EXPORT_PXLIB_LIBRARY=<verified existing runtime DLL> go test -count=1 -timeout=300s ./pkg/server`
- `go vet ./pkg/recentsales ./pkg/appconfig ./pkg/server`
- `git diff --check`

All passed after rebasing onto `origin/main` at `2b4a847`.

Isolated source-only HTTP probe (no live database or production process):

```text
commit: 22e6cc8
/api/status: 200
/api/recent-sales without bearer: 401
/api/recent-sales with bearer: 200
content-type: application/vnd.patris.recent-sales-aggregate+json
schema: patris.recent-sales-aggregate
version: 1
source revision: sha256:38072d9c00aa60bb4fc258e02f5152273c37db58b9a186466872790b7af2b905
total_items: 2
item keys: last_sold_at,product_code,sale_frequency,sold_quantity
forbidden-data match: false
browser-config protected-profile match: false
```

The live Windows rebuild/probe remains intentionally coordinated by the parent
integration task after review/merge.
