### PR TITLE
Bound and parallelize Digitalogic pricing prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- Digitalogic assignment prefetch now uses a configurable, bounded worker pool
+  with deterministic page-order validation; its 60-second default HTTP timeout
+  is bounded to 80 seconds so canonical requests retain an 85-second ceiling.
 - Canonical JSON, CSV, HTTP, spreadsheet, SQL, and outbound-update rows now share a sparse field boundary: never-received values are omitted while explicitly received nulls remain null.
 - Product-sync is now one living standard with strict current-field decoding; obsolete aliases and compatibility branches are rejected.
 - Shipping integration uses the paired `shipping_price_per_kg` and `shipping_price_per_kg_currency` fields; users must select uppercase `CNY` or `IRR` for every configured method.
@@ -54,6 +57,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A terminal Digitalogic assignment-page failure now cancels in-flight sibling
+  requests, commits no partial assignments, and emits only typed secret-safe
+  diagnostics.
 - Browser configuration responses, initial WebSocket snapshots, and config
   update events no longer expose the MySQL DSN or protected TLS paths/names;
   browser saves preserve the server-side values and ignore client-supplied

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -111,16 +111,23 @@ Digitalogic mode reads, but does not mutate:
   result.
 
 Canonical transform collects unique, non-quarantined Codes before its normal
-per-record resolution, prefetches them in bounded request-order chunks, and
-stores results in the existing bounded assignment LRU. A transform-scoped
-result barrier also retains only that run's unique Codes and releases each
-outcome as the row resolves, so a deliberately small `max_entries` cannot evict
-current-run successes or diagnostics and recreate single-Code N+1 requests. It
-does not create a second pricing client or transformation path. With the
-default `batch_size: 500` and `max_entries: 2048`, a cold 1,002-Code catalog
-performs exactly three batch POSTs plus one catalog GET, and performs zero
-single-Code requests. Duplicate source Codes remain quarantined before
-prefetch.
+per-record resolution, divides them into deterministic request-order pages,
+and prefetches those pages with a bounded worker pool. The default
+`batch_concurrency: 2` permits two batch requests at once and the hard maximum
+is four. Results may arrive out of order, but they are validated and merged in
+their original page order before entering the existing bounded assignment LRU.
+A terminal page failure cancels its in-flight siblings and fails the entire
+prefetch closed without exposing remote response bodies.
+
+A transform-scoped result barrier also retains only that run's unique Codes
+and releases each outcome as the row resolves, so a deliberately small
+`max_entries` cannot evict current-run successes or diagnostics and recreate
+single-Code N+1 requests. It does not create a second pricing client or
+transformation path. With the default `batch_size: 500`,
+`batch_concurrency: 2`, and `max_entries: 2048`, a cold 1,002-Code catalog
+performs exactly three batch POSTs plus one catalog GET, performs at most two
+batch POSTs concurrently, and performs zero single-Code requests. Duplicate
+source Codes remain quarantined before prefetch.
 
 All chunks are staged before one atomic cache commit. Every chunk must carry
 the same non-empty default-markup revision and the same schema, configured
@@ -152,9 +159,10 @@ stored in the Patris config:
         "bearer_token_env": "DIGITALOGIC_PRICING_READ_TOKEN",
         "batch_assignment_path": "integration/pricing-assignments/batch",
         "batch_size": 500,
+        "batch_concurrency": 2,
         "fresh_for": "5m",
         "max_stale": "1h",
-        "timeout": "15s",
+        "timeout": "60s",
         "max_entries": 2048,
         "max_concurrency": 8,
         "max_response_bytes": 2097152
@@ -166,16 +174,28 @@ stored in the Patris config:
 
 ```powershell
 $env:DIGITALOGIC_PRICING_READ_TOKEN = "..."
-$env:PATRIS_EXPORT_PRICING_TIMEOUT = "15s"
+$env:PATRIS_EXPORT_PRICING_TIMEOUT = "60s"
 $env:PATRIS_EXPORT_PRICING_BATCH_SIZE = "500"
+$env:PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY = "2"
 patris-export serve C:\Patris\data4\kala.db
 ```
 
-`PATRIS_EXPORT_PRICING_TIMEOUT` and `PATRIS_EXPORT_PRICING_BATCH_SIZE` override
-the same normalized Digitalogic provider used by file configuration. Batch
-size is capped at the endpoint maximum of 500. The 15-second timeout
-default leaves headroom for a production 500-Code response without changing
-the bounded request count or enabling single-Code fallback.
+`PATRIS_EXPORT_PRICING_TIMEOUT`, `PATRIS_EXPORT_PRICING_BATCH_SIZE`, and
+`PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY` override the same normalized
+Digitalogic provider used by file configuration. Batch size is capped at the
+endpoint maximum of 500 and concurrency is capped at four. The HTTP timeout
+defaults to 60 seconds and is normalized to the inclusive range from 100
+milliseconds through 80 seconds. Canonical HTTP routes add at most five
+seconds of cooperative-cancellation grace to a normalized Digitalogic timeout,
+so the configured pricing phase retains an 85-second hard request ceiling.
+For a 939-Code projection, the default settings issue two 500-or-smaller pages
+concurrently instead of waiting for them sequentially.
+
+Transport completion is separate from catalog completeness. Digitalogic must
+still assign a shipping method to the intended product rows and configure a
+global or product-specific percentage markup before those rows can expose a
+final price. Missing assignments remain explicit fail-closed warnings; Patris
+does not invent shipping or markup defaults.
 
 Only HTTPS is accepted remotely; plain HTTP is limited to loopback. Provider
 paths must stay relative and on the configured origin, redirects are refused,

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -823,6 +823,11 @@ func ApplyEnv(cfg *Config) {
 			cfg.Canonical.Pricing.Digitalogic.BatchSize = batch
 		}
 	}
+	if value := os.Getenv("PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY"); strings.TrimSpace(value) != "" {
+		if workers, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
+			cfg.Canonical.Pricing.Digitalogic.BatchConcurrency = workers
+		}
+	}
 	if value := os.Getenv("PATRIS_EXPORT_RECENT_SALES_ENABLED"); strings.TrimSpace(value) != "" {
 		cfg.RecentSales.Enabled = parseBool(value, cfg.RecentSales.Enabled)
 	}

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -391,6 +391,7 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_PRICING_MAX_STALE", "30m")
 	t.Setenv("PATRIS_EXPORT_PRICING_TIMEOUT", "20s")
 	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_SIZE", "250")
+	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY", "3")
 	t.Setenv("DIGITALOGIC_KEY", "must-not-be-copied")
 	t.Setenv("DIGITALOGIC_SECRET", "must-not-be-copied")
 	t.Setenv("DIGITALOGIC_PRICING_READ_TOKEN", "must-not-be-copied-bearer")
@@ -401,7 +402,7 @@ func TestApplyEnvConfiguresDigitalogicWithoutStoringCredentials(t *testing.T) {
 	if cfg.Canonical.Pricing.Mode != "digitalogic" || digitalogic.BaseURL != "https://digitalogic.example/wp-json/digitalogic" {
 		t.Fatalf("Digitalogic pricing provider was not selected: %+v", cfg.Canonical.Pricing)
 	}
-	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.BearerTokenEnv != "DIGITALOGIC_PRICING_READ_TOKEN" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" || digitalogic.Timeout != "20s" || digitalogic.BatchSize != 250 {
+	if digitalogic.UsernameEnv != "DIGITALOGIC_KEY" || digitalogic.PasswordEnv != "DIGITALOGIC_SECRET" || digitalogic.BearerTokenEnv != "DIGITALOGIC_PRICING_READ_TOKEN" || digitalogic.FreshFor != "2m" || digitalogic.MaxStale != "30m" || digitalogic.Timeout != "20s" || digitalogic.BatchSize != 250 || digitalogic.BatchConcurrency != 3 {
 		t.Fatalf("Digitalogic provider environment references were not normalized: %+v", digitalogic)
 	}
 	encoded, err := json.Marshal(cfg)
@@ -417,15 +418,27 @@ func TestApplyEnvBoundsDigitalogicPricingBatchSizeAndTimeout(t *testing.T) {
 	t.Setenv("PATRIS_EXPORT_DIGITALOGIC_URL", "https://digitalogic.example/wp-json/digitalogic/")
 	t.Setenv("PATRIS_EXPORT_PRICING_TIMEOUT", "not-a-duration")
 	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_SIZE", "501")
+	t.Setenv("PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY", "99")
 
 	cfg := Default()
 	ApplyEnv(&cfg)
 	digitalogic := cfg.Canonical.Pricing.Digitalogic
-	if digitalogic.Timeout != "15s" {
+	if digitalogic.Timeout != "1m0s" {
 		t.Fatalf("invalid timeout did not normalize to the safe default: %+v", digitalogic)
 	}
 	if digitalogic.BatchSize != 500 {
 		t.Fatalf("batch size was not bounded to the remote contract maximum: %+v", digitalogic)
+	}
+	if digitalogic.BatchConcurrency != 4 {
+		t.Fatalf("batch concurrency was not bounded to the safe maximum: %+v", digitalogic)
+	}
+
+	t.Setenv("PATRIS_EXPORT_PRICING_TIMEOUT", "24h")
+	cfg = Default()
+	ApplyEnv(&cfg)
+	digitalogic = cfg.Canonical.Pricing.Digitalogic
+	if digitalogic.Timeout != "1m20s" {
+		t.Fatalf("large timeout was not bounded to the hard maximum: %+v", digitalogic)
 	}
 }
 

--- a/pkg/pricingcatalog/catalog.go
+++ b/pkg/pricingcatalog/catalog.go
@@ -12,19 +12,23 @@ import (
 )
 
 const (
-	ModeNone           = "none"
-	ModeStatic         = "static"
-	ModeDigitalogic    = "digitalogic"
-	CurrencyCNY        = "CNY"
-	CurrencyIRR        = "IRR"
-	defaultFreshFor    = 5 * time.Minute
-	defaultMaxStale    = time.Hour
-	defaultTimeout     = 15 * time.Second
-	defaultMaxEntries  = 2048
-	defaultMaxBytes    = int64(2 << 20)
-	defaultConcurrency = 8
-	defaultBatchSize   = 500
-	maximumBatchSize   = 500
+	ModeNone            = "none"
+	ModeStatic          = "static"
+	ModeDigitalogic     = "digitalogic"
+	CurrencyCNY         = "CNY"
+	CurrencyIRR         = "IRR"
+	defaultFreshFor     = 5 * time.Minute
+	defaultMaxStale     = time.Hour
+	defaultTimeout      = 60 * time.Second
+	minimumTimeout      = 100 * time.Millisecond
+	maximumTimeout      = 80 * time.Second
+	defaultMaxEntries   = 2048
+	defaultMaxBytes     = int64(2 << 20)
+	defaultConcurrency  = 8
+	defaultBatchSize    = 500
+	maximumBatchSize    = 500
+	defaultBatchWorkers = 2
+	maximumBatchWorkers = 4
 )
 
 // Config selects a replaceable pricing-catalog provider. Static is suitable
@@ -52,6 +56,7 @@ type DigitalogicConfig struct {
 	AssignmentPath      string `json:"assignment_path,omitempty" yaml:"assignment_path,omitempty" toml:"assignment_path,omitempty"`
 	BatchAssignmentPath string `json:"batch_assignment_path,omitempty" yaml:"batch_assignment_path,omitempty" toml:"batch_assignment_path,omitempty"`
 	BatchSize           int    `json:"batch_size,omitempty" yaml:"batch_size,omitempty" toml:"batch_size,omitempty"`
+	BatchConcurrency    int    `json:"batch_concurrency,omitempty" yaml:"batch_concurrency,omitempty" toml:"batch_concurrency,omitempty"`
 	UsernameEnv         string `json:"username_env,omitempty" yaml:"username_env,omitempty" toml:"username_env,omitempty"`
 	PasswordEnv         string `json:"password_env,omitempty" yaml:"password_env,omitempty" toml:"password_env,omitempty"`
 	BearerTokenEnv      string `json:"bearer_token_env,omitempty" yaml:"bearer_token_env,omitempty" toml:"bearer_token_env,omitempty"`
@@ -159,15 +164,26 @@ func Normalize(cfg Config) Config {
 	if d.BatchSize > maximumBatchSize {
 		d.BatchSize = maximumBatchSize
 	}
+	if d.BatchConcurrency <= 0 {
+		d.BatchConcurrency = defaultBatchWorkers
+	}
+	if d.BatchConcurrency > maximumBatchWorkers {
+		d.BatchConcurrency = maximumBatchWorkers
+	}
 	if parseDuration(d.FreshFor, 0) <= 0 {
 		d.FreshFor = defaultFreshFor.String()
 	}
 	if parseDuration(d.MaxStale, 0) <= 0 {
 		d.MaxStale = defaultMaxStale.String()
 	}
-	if parseDuration(d.Timeout, 0) <= 0 {
-		d.Timeout = defaultTimeout.String()
+	timeout := parseDuration(d.Timeout, defaultTimeout)
+	if timeout < minimumTimeout {
+		timeout = minimumTimeout
 	}
+	if timeout > maximumTimeout {
+		timeout = maximumTimeout
+	}
+	d.Timeout = timeout.String()
 	if d.MaxEntries <= 0 {
 		d.MaxEntries = defaultMaxEntries
 	}

--- a/pkg/pricingcatalog/catalog_test.go
+++ b/pkg/pricingcatalog/catalog_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -708,14 +709,14 @@ func TestHTTPProviderRejectsInvalidBatchDecimalsAndMissingDefaultRevision(t *tes
 }
 
 func TestHTTPProviderCommitsChunksAtomicallyAfterDefaultRevisionAgreement(t *testing.T) {
-	var batchRequests, singleRequests int
+	var batchRequests, singleRequests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/integration/catalog":
 			fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","revision":"r1","currency":{"local":"IRT","cny_to_local":1,"cny_to_irt":1},"pricing":{"formula_id":"landed_price"},"shipping_methods":[{"id":"air","price_per_kg":1,"currency":"CNY"}]}}`)
 		case "/integration/pricing-assignments/batch":
-			batchRequests++
+			batchRequests.Add(1)
 			var request struct {
 				Codes []string `json:"codes"`
 			}
@@ -741,7 +742,7 @@ func TestHTTPProviderCommitsChunksAtomicallyAfterDefaultRevisionAgreement(t *tes
 				}},
 			}})
 		default:
-			singleRequests++
+			singleRequests.Add(1)
 		}
 	}))
 	defer server.Close()
@@ -760,8 +761,8 @@ func TestHTTPProviderCommitsChunksAtomicallyAfterDefaultRevisionAgreement(t *tes
 			t.Fatalf("mixed default revisions did not fail atomically for %s: %+v", code, resolved)
 		}
 	}
-	if batchRequests != 2 || singleRequests != 0 {
-		t.Fatalf("mixed revision handling made unsafe requests: batch=%d single=%d", batchRequests, singleRequests)
+	if batchRequests.Load() != 2 || singleRequests.Load() != 0 {
+		t.Fatalf("mixed revision handling made unsafe requests: batch=%d single=%d", batchRequests.Load(), singleRequests.Load())
 	}
 }
 
@@ -1234,8 +1235,32 @@ func TestHTTPProviderConfiguredTimeoutAllowsSlowBatch(t *testing.T) {
 
 func TestDigitalogicProviderDefaultsLeaveProductionBatchHeadroom(t *testing.T) {
 	digitalogic := Normalize(Config{Mode: ModeDigitalogic}).Digitalogic
-	if digitalogic.Timeout != "15s" || digitalogic.BatchSize != 500 {
+	if digitalogic.Timeout != "1m0s" || digitalogic.BatchSize != 500 || digitalogic.BatchConcurrency != 2 {
 		t.Fatalf("unexpected production batch defaults: %+v", digitalogic)
+	}
+}
+
+func TestDigitalogicProviderBoundsTimeoutAndBatchConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     string
+		concurrency int
+		wantTimeout string
+		wantWorkers int
+	}{
+		{name: "invalid values use defaults", timeout: "not-a-duration", concurrency: 0, wantTimeout: "1m0s", wantWorkers: 2},
+		{name: "small positive timeout uses minimum", timeout: "1ms", concurrency: 1, wantTimeout: "100ms", wantWorkers: 1},
+		{name: "large values use hard caps", timeout: "24h", concurrency: 99, wantTimeout: "1m20s", wantWorkers: 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			digitalogic := Normalize(Config{Mode: ModeDigitalogic, Digitalogic: DigitalogicConfig{
+				Timeout: test.timeout, BatchConcurrency: test.concurrency,
+			}}).Digitalogic
+			if digitalogic.Timeout != test.wantTimeout || digitalogic.BatchConcurrency != test.wantWorkers {
+				t.Fatalf("normalized Digitalogic bounds = %+v, want timeout=%s workers=%d", digitalogic, test.wantTimeout, test.wantWorkers)
+			}
+		})
 	}
 }
 

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -116,6 +116,12 @@ type batchAssignmentResult struct {
 	allowSingle bool
 }
 
+type batchAssignmentFetch struct {
+	page      batchAssignmentPage
+	err       error
+	completed bool
+}
+
 type remoteStatusError struct {
 	status int
 }
@@ -136,6 +142,7 @@ var (
 	errCredentialUnavailable = errors.New("configured credential is unavailable")
 	errRequestTooLarge       = errors.New("request exceeds configured limit")
 	errResponseTooLarge      = errors.New("response exceeds configured limit")
+	errBatchPrefetchStopped  = errors.New("pricing assignment batch prefetch stopped before completion")
 )
 
 func (d *batchDecimal) UnmarshalJSON(data []byte) error {
@@ -306,36 +313,30 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) Provider {
 
 	pendingOutcomes := make(map[string]prefetchOutcome, len(pending))
 	var expectedDefault *batchDefaultMarkup
-	var batchErr error
-	for offset := 0; offset < len(pending); offset += p.config.BatchSize {
-		end := offset + p.config.BatchSize
-		if end > len(pending) {
-			end = len(pending)
-		}
-		chunk := pending[offset:end]
-		page, err := p.fetchAssignmentBatch(ctx, chunk)
-		if err != nil {
-			batchErr = err
-			break
-		}
-		if expectedDefault == nil {
-			copy := cloneBatchDefaultMarkup(page.defaultMarkup)
-			expectedDefault = &copy
-		} else if !equalBatchDefaultMarkup(*expectedDefault, page.defaultMarkup) {
-			batchErr = &contractError{reason: "default-markup contract changed between batch chunks"}
-			break
-		}
-		for _, result := range page.results {
-			if result.snapshot != nil {
-				snapshot := cloneAssignmentSnapshot(*result.snapshot)
-				snapshot.fetchedAt = now
-				pendingOutcomes[result.code] = prefetchOutcome{snapshot: &snapshot}
-				continue
+	pages, batchErr := p.fetchAssignmentPages(ctx, pending)
+	if batchErr == nil {
+		// Pages may complete out of order, but contract agreement and result
+		// materialization always follow original request-page order.
+		for _, page := range pages {
+			if expectedDefault == nil {
+				copy := cloneBatchDefaultMarkup(page.defaultMarkup)
+				expectedDefault = &copy
+			} else if !equalBatchDefaultMarkup(*expectedDefault, page.defaultMarkup) {
+				batchErr = &contractError{reason: "default-markup contract changed between batch chunks"}
+				break
 			}
-			diagnostic := prefetchDiagnostic{
-				warnings: normalizedStrings(result.warnings), fetchedAt: now, allowSingle: result.allowSingle,
+			for _, result := range page.results {
+				if result.snapshot != nil {
+					snapshot := cloneAssignmentSnapshot(*result.snapshot)
+					snapshot.fetchedAt = now
+					pendingOutcomes[result.code] = prefetchOutcome{snapshot: &snapshot}
+					continue
+				}
+				diagnostic := prefetchDiagnostic{
+					warnings: normalizedStrings(result.warnings), fetchedAt: now, allowSingle: result.allowSingle,
+				}
+				pendingOutcomes[result.code] = prefetchOutcome{diagnostic: &diagnostic}
 			}
-			pendingOutcomes[result.code] = prefetchOutcome{diagnostic: &diagnostic}
 		}
 	}
 
@@ -359,6 +360,100 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) Provider {
 		return p
 	}
 	return &prefetchedProvider{parent: p, run: &prefetchRun{outcomes: outcomes}}
+}
+
+// fetchAssignmentPages bounds concurrent page requests independently from
+// per-product materialization workers. A terminal page failure cancels sibling
+// requests, while the caller's context remains the authoritative cancellation
+// signal returned to the canonical transform.
+func (p *httpProvider) fetchAssignmentPages(ctx context.Context, codes []string) ([]batchAssignmentPage, error) {
+	if len(codes) == 0 {
+		return nil, nil
+	}
+	pageCount := (len(codes) + p.config.BatchSize - 1) / p.config.BatchSize
+	fetches := make([]batchAssignmentFetch, pageCount)
+	if pageCount == 1 {
+		page, err := p.fetchAssignmentBatch(ctx, codes)
+		if err != nil {
+			return nil, err
+		}
+		return []batchAssignmentPage{page}, nil
+	}
+
+	workers := p.config.BatchConcurrency
+	if workers > pageCount {
+		workers = pageCount
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	batchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	jobs := make(chan int, pageCount)
+	for index := 0; index < pageCount; index++ {
+		jobs <- index
+	}
+	close(jobs)
+
+	var wait sync.WaitGroup
+	var failureOnce sync.Once
+	var firstFailure error
+	wait.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			defer wait.Done()
+			for {
+				select {
+				case <-batchCtx.Done():
+					return
+				case index, ok := <-jobs:
+					if !ok {
+						return
+					}
+					offset := index * p.config.BatchSize
+					end := offset + p.config.BatchSize
+					if end > len(codes) {
+						end = len(codes)
+					}
+					page, err := p.fetchAssignmentBatch(batchCtx, codes[offset:end])
+					fetches[index] = batchAssignmentFetch{page: page, err: err, completed: true}
+					if err != nil {
+						failureOnce.Do(func() {
+							firstFailure = err
+							cancel()
+						})
+					}
+				}
+			}
+		}()
+	}
+	wait.Wait()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Prefer the lowest request-page terminal error when multiple pages finish
+	// together. Sibling context-cancellation errors never mask that cause.
+	for _, fetch := range fetches {
+		if fetch.completed && fetch.err != nil &&
+			!errors.Is(fetch.err, context.Canceled) &&
+			!errors.Is(fetch.err, context.DeadlineExceeded) {
+			return nil, fetch.err
+		}
+	}
+	if firstFailure != nil {
+		return nil, firstFailure
+	}
+
+	pages := make([]batchAssignmentPage, pageCount)
+	for index, fetch := range fetches {
+		if !fetch.completed {
+			return nil, errBatchPrefetchStopped
+		}
+		pages[index] = fetch.page
+	}
+	return pages, nil
 }
 
 func (p *httpProvider) Resolve(ctx context.Context, code string) Resolution {

--- a/pkg/pricingcatalog/prefetch_concurrency_test.go
+++ b/pkg/pricingcatalog/prefetch_concurrency_test.go
@@ -1,0 +1,266 @@
+package pricingcatalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHTTPProviderPrefetches939CodesConcurrentlyAndMergesDeterministically(t *testing.T) {
+	var batchRequests atomic.Int32
+	var activeRequests atomic.Int32
+	var maximumActive atomic.Int32
+	bothPagesStarted := make(chan struct{})
+	secondPageFinished := make(chan struct{})
+	completionOrder := make(chan string, 2)
+	var startedOnce sync.Once
+	var secondOnce sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/integration/catalog" {
+			writeConcurrentPricingCatalog(w)
+			return
+		}
+		if r.URL.Path != "/integration/pricing-assignments/batch" {
+			http.NotFound(w, r)
+			return
+		}
+
+		batchRequests.Add(1)
+		var request struct {
+			Codes []string `json:"codes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode batch request: %v", err)
+			return
+		}
+		active := activeRequests.Add(1)
+		defer activeRequests.Add(-1)
+		for {
+			previous := maximumActive.Load()
+			if active <= previous || maximumActive.CompareAndSwap(previous, active) {
+				break
+			}
+		}
+		if active >= 2 {
+			startedOnce.Do(func() { close(bothPagesStarted) })
+		}
+
+		page := "first"
+		if len(request.Codes) > 0 && request.Codes[0] == "P-0500" {
+			page = "second"
+		}
+		select {
+		case <-bothPagesStarted:
+		case <-r.Context().Done():
+			return
+		}
+		if page == "first" {
+			select {
+			case <-secondPageFinished:
+			case <-r.Context().Done():
+				return
+			}
+		}
+		writeConcurrentAssignmentPage(w, request.Codes)
+		completionOrder <- page
+		if page == "second" {
+			secondOnce.Do(func() { close(secondPageFinished) })
+		}
+	}))
+	defer server.Close()
+
+	codes := make([]string, 939)
+	for index := range codes {
+		codes[index] = fmt.Sprintf("P-%04d", index)
+	}
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: server.URL, BatchSize: 500, BatchConcurrency: 2, MaxEntries: 1,
+	}, server.Client(), time.Now)
+
+	startedAt := time.Now()
+	scoped := provider.Prefetch(context.Background(), codes)
+	if elapsed := time.Since(startedAt); elapsed >= time.Second {
+		t.Fatalf("synthetic 939-Code concurrent prefetch took %s", elapsed)
+	}
+	if got := batchRequests.Load(); got != 2 {
+		t.Fatalf("batch requests = %d, want two bounded pages", got)
+	}
+	if got := maximumActive.Load(); got != 2 {
+		t.Fatalf("maximum concurrent pages = %d, want 2", got)
+	}
+	if first, second := <-completionOrder, <-completionOrder; first != "second" || second != "first" {
+		t.Fatalf("test did not force out-of-order completion: %q then %q", first, second)
+	}
+	for _, code := range []string{"P-0000", "P-0499", "P-0500", "P-0938"} {
+		resolution := scoped.Resolve(context.Background(), code)
+		if resolution.MethodID != "air" || decimalText(resolution.MarkupPercent) != "30" {
+			t.Fatalf("request-order merge lost %s: %+v", code, resolution)
+		}
+	}
+}
+
+func TestHTTPProviderTerminalPageFailureCancelsSiblingAndRedactsDetails(t *testing.T) {
+	var batchStarted atomic.Int32
+	bothPagesStarted := make(chan struct{})
+	siblingCanceled := make(chan struct{})
+	var startedOnce sync.Once
+	var canceledOnce sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/integration/catalog" {
+			writeConcurrentPricingCatalog(w)
+			return
+		}
+		var request struct {
+			Codes []string `json:"codes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode batch request: %v", err)
+			return
+		}
+		if batchStarted.Add(1) == 2 {
+			startedOnce.Do(func() { close(bothPagesStarted) })
+		}
+		select {
+		case <-bothPagesStarted:
+		case <-r.Context().Done():
+			return
+		}
+		if request.Codes[0] == "A" {
+			http.Error(w, "https://private.invalid Authorization: Bearer super-secret product A", http.StatusInternalServerError)
+			return
+		}
+		<-r.Context().Done()
+		canceledOnce.Do(func() { close(siblingCanceled) })
+	}))
+	defer server.Close()
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: server.URL, BatchSize: 1, BatchConcurrency: 2, Timeout: "2s",
+	}, server.Client(), time.Now)
+	startedAt := time.Now()
+	scoped := provider.Prefetch(context.Background(), []string{"A", "B"})
+	if elapsed := time.Since(startedAt); elapsed >= time.Second {
+		t.Fatalf("terminal page failure did not cancel promptly: %s", elapsed)
+	}
+	select {
+	case <-siblingCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("sibling batch request did not observe cancellation")
+	}
+	for _, code := range []string{"A", "B"} {
+		resolution := scoped.Resolve(context.Background(), code)
+		if !contains(resolution.Warnings, "pricing_assignment_batch_http_failed") {
+			t.Fatalf("typed terminal warning missing for %s: %+v", code, resolution)
+		}
+		diagnostic := strings.Join(resolution.Warnings, " ")
+		for _, forbidden := range []string{"private.invalid", "super-secret", "Bearer", "product A"} {
+			if strings.Contains(diagnostic, forbidden) {
+				t.Fatalf("diagnostic exposed %q for %s: %q", forbidden, code, diagnostic)
+			}
+		}
+	}
+}
+
+func TestHTTPProviderConcurrentPrefetchHonorsCallerCancellation(t *testing.T) {
+	var batchStarted atomic.Int32
+	bothPagesStarted := make(chan struct{})
+	requestCanceled := make(chan struct{}, 2)
+	var startedOnce sync.Once
+
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/integration/catalog" {
+			body := `{"data":{"schema":"digitalogic.integration-catalog","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price"},"shipping_methods":[{"id":"air","price_per_kg":120,"currency":"CNY"}]}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    r,
+			}, nil
+		}
+		if batchStarted.Add(1) == 2 {
+			startedOnce.Do(func() { close(bothPagesStarted) })
+		}
+		<-r.Context().Done()
+		requestCanceled <- struct{}{}
+		return nil, r.Context().Err()
+	})}
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: "https://digitalogic.example", BatchSize: 1, BatchConcurrency: 2, Timeout: "2s",
+	}, client, time.Now)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		provider.Prefetch(ctx, []string{"A", "B"})
+		close(done)
+	}()
+	select {
+	case <-bothPagesStarted:
+	case <-time.After(time.Second):
+		t.Fatal("bounded page workers did not start")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("caller cancellation did not stop prefetch")
+	}
+	for index := 0; index < 2; index++ {
+		select {
+		case <-requestCanceled:
+		case <-time.After(time.Second):
+			t.Fatal("in-flight request did not observe caller cancellation")
+		}
+	}
+	provider.mu.Lock()
+	committed := len(provider.assignments)
+	provider.mu.Unlock()
+	if committed != 0 {
+		t.Fatalf("caller-canceled prefetch committed %d assignments", committed)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func writeConcurrentPricingCatalog(w http.ResponseWriter) {
+	fmt.Fprint(w, `{"data":{"schema":"digitalogic.integration-catalog","revision":"r1","currency":{"local":"IRT","cny_to_local":29000,"cny_to_irt":29000},"pricing":{"formula_id":"landed_price"},"shipping_methods":[{"id":"air","price_per_kg":120,"currency":"CNY"}]}}`)
+}
+
+func writeConcurrentAssignmentPage(w http.ResponseWriter, codes []string) {
+	results := make([]map[string]interface{}, 0, len(codes))
+	for _, code := range codes {
+		results = append(results, map[string]interface{}{
+			"code":   code,
+			"status": "ok",
+			"assignment": map[string]interface{}{
+				"code": code, "shipping_method_id": "air", "profit_percent": "30",
+				"profit_percent_source": "global_default", "pricing_warnings": []string{},
+			},
+		})
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+		"schema":          "digitalogic.pricing-assignment-batch",
+		"requested_count": len(codes), "resolved_count": len(codes), "error_count": 0, "maximum_codes": 500,
+		"default_percentage_markup": map[string]interface{}{
+			"schema": "digitalogic.default-percentage-markup", "configured": true, "type": "percentage",
+			"profit_percent": "30", "source": "global_default", "revision": "rev-30",
+		},
+		"results": results,
+	}})
+}


### PR DESCRIPTION
## Outcome

Makes the existing Digitalogic pricing provider complete large canonical prefetches within a bounded concurrent timeout, while retaining the maximum-500 remote contract, deterministic validation, and atomic fail-closed commit.

Closes #153 after merge.

## Design

- changes the normalized HTTP timeout default from 15s to 60s and bounds configured values to 100ms..80s;
- adds `batch_concurrency` / `PATRIS_EXPORT_PRICING_BATCH_CONCURRENCY`, default 2 and hard cap 4;
- fetches request-order pages with the bounded worker pool, then validates and merges them strictly in original page order;
- preserves the existing all-pages/default-markup agreement and commits no partial assignments;
- cancels siblings after the first terminal page failure and honors caller cancellation;
- exposes only existing typed machine warnings, never remote URLs, credentials, headers, response bodies, or product values;
- remains on the same provider/client/cache path and is compatible with merged PR #209 and current `main`.

The existing canonical route adds at most 5s cancellation grace, so a normalized 80s provider timeout retains an 85s request ceiling. The measured 939-Code shape produces two pages; with the default two workers, they no longer wait sequentially.

## Verification

- `go test ./pkg/pricingcatalog ./pkg/appconfig ./pkg/canonical ./pkg/server -count=1 -timeout 8m`
- `go test -race ./pkg/pricingcatalog -count=1 -timeout 6m`
- `go test ./... -count=1 -timeout 12m`
- `go vet -buildvcs=false ./...`
- `go build -buildvcs=false ./cmd/patris-export`
- `git diff --check`

New deterministic tests cover exactly 939 Codes with forced out-of-order page completion, bounded concurrency, atomic default-revision disagreement, prompt sibling cancellation, caller cancellation/no partial commit, secret-safe typed errors, and config/environment defaults and caps.

The source-only Windows build completed with SHA-256 `97D49A4C969C4BF890D1958D514D85D4F39057077F1C8F1811F8CE38AE80DE35`. It was not promoted or deployed in this implementation pass.

## Post-merge readback gate

Production catalog configuration was updated independently of this branch: 819/819 exact-coded products are expected to resolve `air_express`, 120 CNY/kg, and the global 30% markup. A post-merge rebuild must prove `/api/status` 200 and two stable `/api/product-sync` responses under 90s with the same source revision/counts, nonzero expected shipping/markup/final-price coverage, and no `pricing_assignment_batch_transport_failed`. Any legitimately unmatched rows must remain explicit warnings; Patris must not invent defaults.

Review status: pending explicit owner approval. No merge, production configuration change, service restart, or deployment is included here.