### PR TITLE
Fix scheduled-task credential refresh lifecycle

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -61,6 +61,10 @@ jobs:
       shell: cmd
       run: build.cmd --target windows-native --ci --no-assets
 
+    - name: Test scheduled-task environment bridge
+      shell: cmd
+      run: powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File .\scripts\windows\Test-ScheduledTaskEnvironmentBridge.ps1
+
     - name: Audit and test optional pxlib backends
       shell: pwsh
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,9 @@ jobs:
               "LICENSE",
               "NOTICE",
               "BUILD-MANIFEST.txt",
-              "BUILD-VARIANT.json"
+              "BUILD-VARIANT.json",
+              "Install-PatrisExportScheduledTask.ps1",
+              "Run-PatrisExportScheduledTask.ps1"
           )) {
               if (-not (Test-Path (Join-Path $appRoot $required))) {
                   throw "Packaged Windows download is missing $required."
@@ -334,6 +336,8 @@ jobs:
                   "libwinpthread-1.dll",
                   "README.md",
                   "INSTALL.md",
+                  "Install-PatrisExportScheduledTask.ps1",
+                  "Run-PatrisExportScheduledTask.ps1",
                   "BUILD-MANIFEST.txt",
                   "BUILD-VARIANT.json",
                   "LICENSE.txt",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   supported source into a deterministic, paged product-level aggregate while
   excluding customer, order, payment, and delivery details; its source/auth
   profile stays server-side across browser config reads and writes.
+- The Windows scheduled-task helper can import explicitly named current
+  user/machine environment values at process launch without storing credential
+  values in task XML, arguments, configuration, logs, or release artifacts.
 
 ### Changed
 

--- a/docs/INSTALL-BINARIES.md
+++ b/docs/INSTALL-BINARIES.md
@@ -32,6 +32,41 @@ The bundle also contains `patris-export.dll` and `patris-export.h` for
 embedding. Existing configuration remains external to the install directory
 and is not overwritten by extracting a newer release.
 
+### Task Scheduler and environment-backed credentials
+
+Windows Task Scheduler does not refresh an already-created task process from
+the current user's environment after a credential is added or rotated. Use the
+bundled installer helper to name each environment variable that Patris must
+re-read at launch:
+
+```powershell
+.\Install-PatrisExportScheduledTask.ps1 `
+  -Action Install `
+  -DbPath C:\Patris\data4\kala.db `
+  -Address 127.0.0.1:18080 `
+  -ImportEnvironmentVariable DIGITALOGIC_PRICING_INPUT_TOKEN `
+  -ExtraArgs @("--raw=false", "--watch=false") `
+  -Start
+```
+
+The task stores only the validated variable name. Its launcher reads the
+current user-scoped value, falls back to the machine scope, imports it into the
+child process, and fails closed if no non-empty value exists. The value is
+never written to the task XML, command line, Patris config, or launcher output.
+The helper uses the co-located `patris-export.exe` in a ZIP or installer
+deployment. Repository operators retain the existing
+`%USERPROFILE%\Desktop\AtomicDeploy\deploy` fallback and can select another
+location with `-DeploymentDirectory`.
+Re-run the install action when task arguments or imported variable names
+change; rotating the value itself requires only a task restart.
+The assisted uninstaller stops and removes the default task only when its
+action points to that installation. Remove a custom `-TaskName` or `-TaskPath`
+with the same helper before uninstalling.
+Assisted upgrades stop an owned running default task before replacing locked
+files and restart it after the new payload and registration metadata are in
+place. An unrecognized task or process aborts the operation without deleting a
+partial installation.
+
 ## Linux amd64
 
 1. Download `patris-export-vX.Y.Z-linux-amd64.tar.gz`.

--- a/installer/windows/patris-export.nsi
+++ b/installer/windows/patris-export.nsi
@@ -120,6 +120,7 @@ LangString CleanupWarning 1065 "این گزینه را فقط هنگام حذف 
 Var CleanupCheckbox
 Var RemoveUserData
 Var InitialInstallDirectory
+Var PatrisTaskWasRunning
 
 Function PatrisSetInstallDirectory
   ReadRegStr $0 SHCTX "${PRODUCT_REG_KEY}" "InstallLocation"
@@ -188,6 +189,19 @@ Section "!Patris Export application" SEC_CORE
   SetOutPath "$INSTDIR"
   SetOverwrite on
 
+  StrCpy $PatrisTaskWasRunning "0"
+  ${If} ${FileExists} "$INSTDIR\Install-PatrisExportScheduledTask.ps1"
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\Install-PatrisExportScheduledTask.ps1" -Action PrepareUpgrade -DeploymentDirectory "$INSTDIR" -RequireOwnedAction'
+    Pop $0
+    Pop $1
+    ${If} $0 == 10
+      StrCpy $PatrisTaskWasRunning "1"
+    ${ElseIf} $0 != 0
+      DetailPrint "Unable to prepare the owned Patris Export task for upgrade: exit $0"
+      Abort "Patris Export is still running. Stop its scheduled task and retry the upgrade."
+    ${EndIf}
+  ${EndIf}
+
   ; Remove optional files from an older installation. Selected sections below
   ; recreate them, while deselecting a component removes its previous copy.
   Delete "$INSTDIR\patris-export.dll"
@@ -201,6 +215,8 @@ Section "!Patris Export application" SEC_CORE
   File /oname=libwinpthread-1.dll "${PAYLOAD_DIR}\libwinpthread-1.dll"
   File /oname=README.md "${PAYLOAD_DIR}\README.md"
   File /oname=INSTALL.md "${PAYLOAD_DIR}\INSTALL.md"
+  File /oname=Install-PatrisExportScheduledTask.ps1 "${PAYLOAD_DIR}\Install-PatrisExportScheduledTask.ps1"
+  File /oname=Run-PatrisExportScheduledTask.ps1 "${PAYLOAD_DIR}\Run-PatrisExportScheduledTask.ps1"
   File /oname=BUILD-MANIFEST.txt "${PAYLOAD_DIR}\BUILD-MANIFEST.txt"
   !if /FileExists "${PAYLOAD_DIR}\BUILD-VARIANT.json"
     File /oname=BUILD-VARIANT.json "${PAYLOAD_DIR}\BUILD-VARIANT.json"
@@ -244,6 +260,16 @@ Section "!Patris Export application" SEC_CORE
   WriteRegDWORD SHCTX "${PRODUCT_UNINSTALL_KEY}" "NoRepair" 1
   ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
   WriteRegDWORD SHCTX "${PRODUCT_UNINSTALL_KEY}" "EstimatedSize" $0
+
+  ${If} $PatrisTaskWasRunning == "1"
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\Install-PatrisExportScheduledTask.ps1" -Action Start -DeploymentDirectory "$INSTDIR"'
+    Pop $0
+    Pop $1
+    ${If} $0 != 0
+      DetailPrint "Unable to restart the owned Patris Export task after upgrade: exit $0"
+      Abort "Patris Export was upgraded but its scheduled task could not restart."
+    ${EndIf}
+  ${EndIf}
 SectionEnd
 
 Section "Developer integration SDK (DLL and C header)" SEC_SDK
@@ -264,6 +290,20 @@ SectionEnd
 
 Section "Uninstall"
   SetRegView 64
+
+  ; Stop and remove only the default task when it points back to this exact
+  ; installation. Abort on failure so a locked executable is never silently
+  ; left behind after its registry/docs/helpers have been removed.
+  ${If} ${FileExists} "$INSTDIR\Install-PatrisExportScheduledTask.ps1"
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\Install-PatrisExportScheduledTask.ps1" -Action Remove -DeploymentDirectory "$INSTDIR" -RequireOwnedAction'
+    Pop $0
+    Pop $1
+    ${If} $0 != 0
+      DetailPrint "Unable to stop/remove the owned Patris Export task: exit $0"
+      Abort "Patris Export is still running. Stop its scheduled task and retry uninstall."
+    ${EndIf}
+  ${EndIf}
+
   Delete "$DESKTOP\Patris Export.lnk"
   Delete "$SMPROGRAMS\Patris Export\Patris Export.lnk"
   Delete "$SMPROGRAMS\Patris Export\Configuration Guide.lnk"
@@ -285,6 +325,8 @@ Section "Uninstall"
   Delete "$INSTDIR\libwinpthread-1.dll"
   Delete "$INSTDIR\README.md"
   Delete "$INSTDIR\INSTALL.md"
+  Delete "$INSTDIR\Install-PatrisExportScheduledTask.ps1"
+  Delete "$INSTDIR\Run-PatrisExportScheduledTask.ps1"
   Delete "$INSTDIR\BUILD-MANIFEST.txt"
   Delete "$INSTDIR\BUILD-VARIANT.json"
   Delete "$INSTDIR\LICENSE.txt"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -77,6 +77,8 @@ install -m 0755 "$windows_source/patris-export-windows-amd64.exe" "$windows_stag
 for file in patris-export.dll patris-export.h libpxlib.dll libgcc_s_seh-1.dll libstdc++-6.dll libwinpthread-1.dll; do
     install -m 0644 "$windows_source/$file" "$windows_stage/$file"
 done
+install -m 0644 "$root/scripts/windows/Install-PatrisExportScheduledTask.ps1" "$windows_stage/Install-PatrisExportScheduledTask.ps1"
+install -m 0644 "$root/scripts/windows/Run-PatrisExportScheduledTask.ps1" "$windows_stage/Run-PatrisExportScheduledTask.ps1"
 
 required_linux=(
     patris-export-linux-amd64

--- a/scripts/windows/Build-ALMCandidate.ps1
+++ b/scripts/windows/Build-ALMCandidate.ps1
@@ -252,6 +252,8 @@ function Assert-InstalledPayload {
         "libwinpthread-1.dll",
         "README.md",
         "INSTALL.md",
+        "Install-PatrisExportScheduledTask.ps1",
+        "Run-PatrisExportScheduledTask.ps1",
         "BUILD-MANIFEST.txt",
         "BUILD-VARIANT.json",
         "LICENSE.txt",
@@ -305,6 +307,8 @@ try {
         "NOTICE" = Join-Path $repoRoot "NOTICE"
         "LICENSING.md" = Join-Path $repoRoot "docs\LICENSING.md"
         "CHANGELOG.md" = Join-Path $repoRoot "CHANGELOG.md"
+        "Install-PatrisExportScheduledTask.ps1" = Join-Path $repoRoot "scripts\windows\Install-PatrisExportScheduledTask.ps1"
+        "Run-PatrisExportScheduledTask.ps1" = Join-Path $repoRoot "scripts\windows\Run-PatrisExportScheduledTask.ps1"
     }
     foreach ($destination in $payloadSources.Keys) {
         $source = $payloadSources[$destination]

--- a/scripts/windows/Build-Installer.ps1
+++ b/scripts/windows/Build-Installer.ps1
@@ -117,6 +117,8 @@ $requiredPayload = @(
     "libwinpthread-1.dll",
     "README.md",
     "INSTALL.md",
+    "Install-PatrisExportScheduledTask.ps1",
+    "Run-PatrisExportScheduledTask.ps1",
     "BUILD-MANIFEST.txt"
 )
 foreach ($file in $requiredPayload) {

--- a/scripts/windows/Build-LocalWindows.ps1
+++ b/scripts/windows/Build-LocalWindows.ps1
@@ -314,6 +314,8 @@ try {
         "NOTICE" = Join-Path $repoRoot "NOTICE"
         "LICENSING.md" = Join-Path $repoRoot "docs\LICENSING.md"
         "CHANGELOG.md" = Join-Path $repoRoot "CHANGELOG.md"
+        "Install-PatrisExportScheduledTask.ps1" = Join-Path $repoRoot "scripts\windows\Install-PatrisExportScheduledTask.ps1"
+        "Run-PatrisExportScheduledTask.ps1" = Join-Path $repoRoot "scripts\windows\Run-PatrisExportScheduledTask.ps1"
     }
     foreach ($destinationName in $documentation.Keys) {
         Copy-Item -LiteralPath $documentation[$destinationName] -Destination (Join-Path $resolvedStageRoot $destinationName) -Force
@@ -345,6 +347,8 @@ try {
         "NOTICE",
         "LICENSING.md",
         "CHANGELOG.md",
+        "Install-PatrisExportScheduledTask.ps1",
+        "Run-PatrisExportScheduledTask.ps1",
         "BUILD-MANIFEST.txt"
     )
     if ($PxlibBackend -ne "cgo-static") {

--- a/scripts/windows/Install-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Install-PatrisExportScheduledTask.ps1
@@ -1,32 +1,168 @@
 param(
-    [ValidateSet("Install", "Start", "Stop", "Restart", "Status", "Remove")]
+    [ValidateSet("Install", "Preview", "PrepareUpgrade", "Start", "Stop", "Restart", "Status", "Remove")]
     [string]$Action = "Install",
-    [string]$AtomicDeployRoot = "$env:USERPROFILE\Desktop\AtomicDeploy",
+    [string]$AtomicDeployRoot = "",
+    [string]$DeploymentDirectory = "",
     [string]$TaskName = "PatrisExport",
     [string]$TaskPath = "\PatrisExport\",
     [string]$DbPath = "C:\Patris\data4\kala.db",
     [string]$Address = ":18080",
     [string]$Debounce = "500ms",
+    [ValidatePattern('^[A-Za-z_][A-Za-z0-9_]*$')]
+    [string[]]$ImportEnvironmentVariable = @(),
     [string[]]$ExtraArgs = @(),
-    [switch]$Start
+    [switch]$Start,
+    [switch]$RequireOwnedAction
 )
 
 $ErrorActionPreference = "Stop"
 
-$deployRoot = Join-Path $AtomicDeployRoot "deploy"
-$exe = Join-Path $deployRoot "patris-export.exe"
-if (-not (Test-Path -LiteralPath $exe)) {
-    $fallback = Join-Path $deployRoot "patris-export-windows-amd64.exe"
-    if (Test-Path -LiteralPath $fallback) {
-        Copy-Item -LiteralPath $fallback -Destination $exe -Force
-    }
+if ($AtomicDeployRoot -and $DeploymentDirectory) {
+    throw "Specify either AtomicDeployRoot or DeploymentDirectory, not both."
 }
-if (-not (Test-Path -LiteralPath $exe)) {
-    throw "Executable not found: $exe. Run scripts\windows\Build-LocalWindows.ps1 first."
+if ($DeploymentDirectory) {
+    $deployRoot = [IO.Path]::GetFullPath($DeploymentDirectory)
+} elseif ($AtomicDeployRoot) {
+    $deployRoot = Join-Path ([IO.Path]::GetFullPath($AtomicDeployRoot)) "deploy"
+} elseif (Test-Path -LiteralPath (Join-Path $PSScriptRoot "patris-export.exe") -PathType Leaf) {
+    $deployRoot = $PSScriptRoot
+} else {
+    $deployRoot = Join-Path "$env:USERPROFILE\Desktop\AtomicDeploy" "deploy"
+}
+$exe = Join-Path $deployRoot "patris-export.exe"
+$sourceLauncher = Join-Path $PSScriptRoot "Run-PatrisExportScheduledTask.ps1"
+$launcher = Join-Path $deployRoot "Run-PatrisExportScheduledTask.ps1"
+
+function ConvertTo-TaskArgument {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    if ($Value.IndexOf([char]0) -ge 0 -or $Value -match "[`r`n]") {
+        throw "Scheduled-task arguments cannot contain nulls or newlines."
+    }
+    if ($Value -notmatch '[\s"]') {
+        return $Value
+    }
+
+    $result = New-Object System.Text.StringBuilder
+    [void]$result.Append('"')
+    $backslashes = 0
+    foreach ($character in $Value.ToCharArray()) {
+        if ($character -eq '\') {
+            $backslashes++
+            continue
+        }
+        if ($character -eq '"') {
+            [void]$result.Append((('\' * (($backslashes * 2) + 1)) -join ""))
+            [void]$result.Append('"')
+            $backslashes = 0
+            continue
+        }
+        if ($backslashes -gt 0) {
+            [void]$result.Append((('\' * $backslashes) -join ""))
+            $backslashes = 0
+        }
+        [void]$result.Append($character)
+    }
+    if ($backslashes -gt 0) {
+        [void]$result.Append((('\' * ($backslashes * 2)) -join ""))
+    }
+    [void]$result.Append('"')
+    return $result.ToString()
 }
 
 function Get-PatrisTask {
     Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+}
+
+function Get-PatrisDeploymentProcess {
+    Get-Process -Name "patris-export" -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $_.Path -and [IO.Path]::GetFullPath($_.Path).Equals(
+                    [IO.Path]::GetFullPath($exe),
+                    [StringComparison]::OrdinalIgnoreCase
+                )
+            } catch {
+                $false
+            }
+        }
+}
+
+function Test-PatrisOwnedTaskAction {
+    param([Parameter(Mandatory = $true)]$Task)
+
+    $action = @($Task.Actions) | Select-Object -First 1
+    if (-not $action) {
+        return $false
+    }
+
+    $arguments = [string]$action.Arguments
+    if ($arguments.IndexOf($launcher, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+        return $true
+    }
+
+    try {
+        $legacyExecutableMatches = [IO.Path]::GetFullPath([string]$action.Execute).Equals(
+            [IO.Path]::GetFullPath($exe),
+            [StringComparison]::OrdinalIgnoreCase
+        )
+        $legacyWorkingDirectoryMatches = [IO.Path]::GetFullPath([string]$action.WorkingDirectory).Equals(
+            [IO.Path]::GetFullPath($deployRoot),
+            [StringComparison]::OrdinalIgnoreCase
+        )
+        return $legacyExecutableMatches -and $legacyWorkingDirectoryMatches
+    } catch {
+        return $false
+    }
+}
+
+function Wait-PatrisDeploymentProcessExit {
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    while (@(Get-PatrisDeploymentProcess).Count -gt 0 -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 200
+    }
+    if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
+        throw "Patris Export is still running from the deployment directory."
+    }
+}
+
+function New-PatrisTaskAction {
+    $environmentNames = @($ImportEnvironmentVariable | Select-Object -Unique)
+    if ($environmentNames.Count -ne $ImportEnvironmentVariable.Count) {
+        throw "Imported environment variable names must be unique."
+    }
+    $powershell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    if (-not (Test-Path -LiteralPath $powershell -PathType Leaf)) {
+        $powershell = (Get-Command "powershell.exe" -ErrorAction Stop).Source
+    }
+    $argumentParts = @(
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-WindowStyle",
+        "Hidden",
+        "-File",
+        $launcher,
+        "-Executable",
+        $exe,
+        "-DbPath",
+        $DbPath,
+        "-Address",
+        $Address,
+        "-Debounce",
+        $Debounce
+    )
+    if ($environmentNames.Count -gt 0) {
+        $argumentParts += @("-EnvironmentVariableNames", ($environmentNames -join ","))
+    }
+    if ($ExtraArgs.Count -gt 0) {
+        $extraArgsJson = ConvertTo-Json -Compress -InputObject @($ExtraArgs)
+        $extraArgsBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($extraArgsJson))
+        $argumentParts += @("-ExtraArgsBase64", $extraArgsBase64)
+    }
+    $taskArguments = ($argumentParts | ForEach-Object { ConvertTo-TaskArgument $_ }) -join " "
+    New-ScheduledTaskAction -Execute $powershell -Argument $taskArguments -WorkingDirectory $deployRoot
 }
 
 function Show-PatrisTaskStatus {
@@ -43,15 +179,43 @@ function Show-PatrisTaskStatus {
         LastTaskResult = $info.LastTaskResult
         NextRunTime    = $info.NextRunTime
         Executable     = $exe
+        Launcher       = $task.Actions.Execute
         WorkingDir     = $deployRoot
     } | Format-List
 }
 
 switch ($Action) {
-    "Install" {
+    { $_ -in @("Install", "Preview") } {
+        if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+            $fallback = Join-Path $deployRoot "patris-export-windows-amd64.exe"
+            if (Test-Path -LiteralPath $fallback -PathType Leaf) {
+                if ($Action -eq "Install") {
+                    Copy-Item -LiteralPath $fallback -Destination $exe -Force
+                } else {
+                    $exe = $fallback
+                }
+            }
+        }
+        if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+            throw "Executable not found: $exe. Run scripts\windows\Build-LocalWindows.ps1 first."
+        }
+        if (-not (Test-Path -LiteralPath $sourceLauncher -PathType Leaf)) {
+            throw "Scheduled-task launcher not found: $sourceLauncher"
+        }
+
+        if ($Action -eq "Preview") {
+            New-PatrisTaskAction
+            break
+        }
+
         New-Item -ItemType Directory -Force -Path $deployRoot | Out-Null
-        $argumentParts = @("serve", "`"$DbPath`"", "--addr", $Address, "--debounce", $Debounce) + $ExtraArgs
-        $taskAction = New-ScheduledTaskAction -Execute $exe -Argument ($argumentParts -join " ") -WorkingDirectory $deployRoot
+        if (-not [IO.Path]::GetFullPath($sourceLauncher).Equals(
+            [IO.Path]::GetFullPath($launcher),
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+            Copy-Item -LiteralPath $sourceLauncher -Destination $launcher -Force
+        }
+        $taskAction = New-PatrisTaskAction
         $trigger = New-ScheduledTaskTrigger -AtLogOn
         $settings = New-ScheduledTaskSettingsSet `
             -AllowStartIfOnBatteries `
@@ -62,7 +226,12 @@ switch ($Action) {
             -RestartInterval (New-TimeSpan -Minutes 1) `
             -StartWhenAvailable
         $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
-        $task = New-ScheduledTask -Action $taskAction -Trigger $trigger -Settings $settings -Principal $principal
+        $task = New-ScheduledTask `
+            -Action $taskAction `
+            -Trigger $trigger `
+            -Settings $settings `
+            -Principal $principal `
+            -Description "Patris Export managed local server task."
         Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -InputObject $task -Force | Out-Null
         Write-Host "Installed scheduled task: $TaskPath$TaskName"
         if ($Start) {
@@ -70,6 +239,7 @@ switch ($Action) {
             Start-Sleep -Seconds 2
         }
         Show-PatrisTaskStatus
+        break
     }
     "Start" {
         Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
@@ -90,9 +260,49 @@ switch ($Action) {
     "Status" {
         Show-PatrisTaskStatus
     }
+    "PrepareUpgrade" {
+        $task = Get-PatrisTask
+        if (-not $task) {
+            if ($RequireOwnedAction -and @(Get-PatrisDeploymentProcess).Count -gt 0) {
+                throw "Patris Export is running from this deployment without the expected task."
+            }
+            Write-Host "Scheduled task not installed: $TaskPath$TaskName"
+            break
+        }
+        if ($RequireOwnedAction -and -not (Test-PatrisOwnedTaskAction -Task $task)) {
+            if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
+                throw "An unrecognized task left Patris Export running from this deployment."
+            }
+            Write-Host "Scheduled task is not owned by this deployment; leaving it unchanged: $TaskPath$TaskName"
+            break
+        }
+        $wasRunning = ([string]$task.State -eq "Running") -or @(Get-PatrisDeploymentProcess).Count -gt 0
+        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+        Wait-PatrisDeploymentProcessExit
+        if ($wasRunning) {
+            exit 10
+        }
+        break
+    }
     "Remove" {
+        $task = Get-PatrisTask
+        if (-not $task) {
+            if ($RequireOwnedAction -and @(Get-PatrisDeploymentProcess).Count -gt 0) {
+                throw "Patris Export is running from this deployment without the expected task."
+            }
+            Write-Host "Scheduled task not installed: $TaskPath$TaskName"
+            break
+        }
+        if ($RequireOwnedAction -and -not (Test-PatrisOwnedTaskAction -Task $task)) {
+            if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
+                throw "An unrecognized task left Patris Export running from this deployment."
+            }
+            Write-Host "Scheduled task is not owned by this deployment; leaving it unchanged: $TaskPath$TaskName"
+            break
+        }
         Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
         Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Confirm:$false
+        Wait-PatrisDeploymentProcessExit
         Write-Host "Removed scheduled task: $TaskPath$TaskName"
     }
 }

--- a/scripts/windows/Run-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Run-PatrisExportScheduledTask.ps1
@@ -1,0 +1,76 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+    [Parameter(Mandatory = $true)]
+    [string]$DbPath,
+    [string]$Address = ":18080",
+    [string]$Debounce = "500ms",
+    [string]$EnvironmentVariableNames = "",
+    [string]$ExtraArgsBase64 = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Executable -PathType Leaf)) {
+    throw "Patris Export executable not found: $Executable"
+}
+
+$names = @(
+    $EnvironmentVariableNames.Split(
+        [char[]]@(","),
+        [System.StringSplitOptions]::RemoveEmptyEntries
+    ) |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+)
+
+if ($names.Count -ne (@($names | Select-Object -Unique)).Count) {
+    throw "Environment variable names must be unique."
+}
+
+foreach ($name in $names) {
+    if ($name -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+        throw "Invalid environment variable name: $name"
+    }
+
+    $value = [Environment]::GetEnvironmentVariable($name, "User")
+    if ([string]::IsNullOrEmpty($value)) {
+        $value = [Environment]::GetEnvironmentVariable($name, "Machine")
+    }
+    if ([string]::IsNullOrEmpty($value)) {
+        throw "Required scheduled-task environment variable is unavailable: $name"
+    }
+
+    [Environment]::SetEnvironmentVariable($name, $value, "Process")
+}
+
+$extraArguments = @()
+if ($ExtraArgsBase64) {
+    try {
+        $extraArgsJson = [Text.Encoding]::UTF8.GetString(
+            [Convert]::FromBase64String($ExtraArgsBase64)
+        )
+        $decodedArguments = $extraArgsJson | ConvertFrom-Json
+        $extraArguments = @($decodedArguments)
+    } catch {
+        throw "Scheduled-task extra arguments are not valid encoded JSON."
+    }
+    foreach ($argument in $extraArguments) {
+        if ($argument -isnot [string] -or $argument.IndexOf([char]0) -ge 0 -or $argument -match "[`r`n]") {
+            throw "Scheduled-task extra arguments must be strings without nulls or newlines."
+        }
+    }
+}
+
+$arguments = @("serve", $DbPath, "--addr", $Address, "--debounce", $Debounce) + $extraArguments
+$workingDirectory = Split-Path -Parent $Executable
+
+Push-Location $workingDirectory
+try {
+    & $Executable @arguments
+    if ($null -ne $LASTEXITCODE) {
+        exit $LASTEXITCODE
+    }
+} finally {
+    Pop-Location
+}

--- a/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
+++ b/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
@@ -1,0 +1,142 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+$launcher = Join-Path $PSScriptRoot "Run-PatrisExportScheduledTask.ps1"
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("patris-scheduled-env-" + [guid]::NewGuid().ToString("N"))
+$probeSource = Join-Path $testRoot "EnvironmentProbe.cs"
+$probeExecutable = Join-Path $testRoot "EnvironmentProbe.exe"
+$capturePath = Join-Path $testRoot "capture.txt"
+$variableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_SECRET"
+$captureVariableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_CAPTURE_PATH"
+$secret = "synthetic-" + [guid]::NewGuid().ToString("N")
+$previousUserValue = [Environment]::GetEnvironmentVariable($variableName, "User")
+$previousProcessValue = [Environment]::GetEnvironmentVariable($variableName, "Process")
+$previousCaptureUserValue = [Environment]::GetEnvironmentVariable($captureVariableName, "User")
+$previousCaptureProcessValue = [Environment]::GetEnvironmentVariable($captureVariableName, "Process")
+
+try {
+    New-Item -ItemType Directory -Path $testRoot | Out-Null
+    @'
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+public static class EnvironmentProbe
+{
+    public static int Main(string[] args)
+    {
+        var output = Environment.GetEnvironmentVariable("PATRIS_EXPORT_SCHEDULED_TASK_TEST_CAPTURE_PATH");
+        var value = Environment.GetEnvironmentVariable("PATRIS_EXPORT_SCHEDULED_TASK_TEST_SECRET");
+        var hasProbeArgument = Array.IndexOf(args, "--bridge-probe") >= 0;
+        if (string.IsNullOrEmpty(output) || string.IsNullOrEmpty(value) || !hasProbeArgument)
+        {
+            return 2;
+        }
+        using (var sha = SHA256.Create())
+        {
+            var digest = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+            File.WriteAllText(output, BitConverter.ToString(digest).Replace("-", "").ToLowerInvariant());
+        }
+        return 0;
+    }
+}
+'@ | Set-Content -LiteralPath $probeSource -Encoding utf8
+
+    Add-Type -Path $probeSource -OutputAssembly $probeExecutable -OutputType ConsoleApplication
+    [Environment]::SetEnvironmentVariable($variableName, $secret, "User")
+    [Environment]::SetEnvironmentVariable($variableName, "stale-process-value", "Process")
+    [Environment]::SetEnvironmentVariable($captureVariableName, $capturePath, "User")
+    [Environment]::SetEnvironmentVariable($captureVariableName, "stale-capture-path", "Process")
+    $extraArgsJson = ConvertTo-Json -Compress -InputObject @("--bridge-probe")
+    $extraArgsBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($extraArgsJson))
+
+    & $launcher `
+        -Executable $probeExecutable `
+        -DbPath "ignored.db" `
+        -EnvironmentVariableNames "$variableName,$captureVariableName" `
+        -ExtraArgsBase64 $extraArgsBase64
+    if ($LASTEXITCODE -ne 0) {
+        throw "Scheduled-task environment bridge probe failed with exit code $LASTEXITCODE."
+    }
+
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $expectedHash = [BitConverter]::ToString(
+            $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($secret))
+        ).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+    $actualHash = (Get-Content -LiteralPath $capturePath -Raw).Trim()
+    if ($actualHash -ne $expectedHash) {
+        throw "The child process did not receive the current user-scoped value."
+    }
+
+    $missingName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_MISSING_" + [guid]::NewGuid().ToString("N")
+    $message = ""
+    try {
+        & $launcher -Executable $probeExecutable -DbPath "ignored.db" -EnvironmentVariableNames $missingName
+        throw "A missing required environment variable was accepted."
+    } catch {
+        $message = $_.Exception.Message
+    }
+    if ($message -notlike "*$missingName*" -or $message -like "*$secret*") {
+        throw "Missing-variable diagnostics were not name-only."
+    }
+
+    $packageRoot = Join-Path $testRoot "package"
+    New-Item -ItemType Directory -Path $packageRoot | Out-Null
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot "Install-PatrisExportScheduledTask.ps1") -Destination $packageRoot
+    Copy-Item -LiteralPath $launcher -Destination $packageRoot
+    Copy-Item -LiteralPath $probeExecutable -Destination (Join-Path $packageRoot "patris-export.exe")
+    $packagedInstaller = Join-Path $packageRoot "Install-PatrisExportScheduledTask.ps1"
+    $action = & $packagedInstaller `
+        -Action Preview `
+        -DbPath "C:\Patris\data4\kala.db" `
+        -Address "127.0.0.1:18080" `
+        -ImportEnvironmentVariable $variableName `
+        -ExtraArgs @("--raw=false", "--watch=false")
+    if (-not $action -or
+        -not [IO.Path]::GetFullPath([string]$action.WorkingDirectory).Equals(
+            [IO.Path]::GetFullPath($packageRoot),
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw "The packaged helper did not resolve its co-located deployment."
+    }
+    $taskArguments = [string]$action.Arguments
+    if (-not $taskArguments.Contains($variableName) -or $taskArguments.Contains($secret)) {
+        throw "The packaged task preview did not preserve the name-only credential boundary."
+    }
+    $encodedMatch = [regex]::Match($taskArguments, '-ExtraArgsBase64\s+([^\s"]+)')
+    if (-not $encodedMatch.Success) {
+        throw "The packaged task preview omitted encoded extra arguments."
+    }
+    $decodedPreviewArguments = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($encodedMatch.Groups[1].Value)
+    )
+    if ($decodedPreviewArguments -ne '["--raw=false","--watch=false"]') {
+        throw "The packaged task preview changed the requested extra arguments."
+    }
+
+    $missingPayloadRoot = Join-Path $testRoot "missing-payload"
+    New-Item -ItemType Directory -Path $missingPayloadRoot | Out-Null
+    $removalHelper = Join-Path $missingPayloadRoot "Install-PatrisExportScheduledTask.ps1"
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot "Install-PatrisExportScheduledTask.ps1") -Destination $removalHelper
+    & $removalHelper `
+        -Action Remove `
+        -DeploymentDirectory $missingPayloadRoot `
+        -TaskName ("PatrisExportMissing-" + [guid]::NewGuid().ToString("N")) `
+        -TaskPath "\"
+
+    Write-Host "Scheduled-task environment bridge passed name-only import and fail-closed tests."
+} finally {
+    [Environment]::SetEnvironmentVariable($variableName, $previousUserValue, "User")
+    [Environment]::SetEnvironmentVariable($variableName, $previousProcessValue, "Process")
+    [Environment]::SetEnvironmentVariable($captureVariableName, $previousCaptureUserValue, "User")
+    [Environment]::SetEnvironmentVariable($captureVariableName, $previousCaptureProcessValue, "Process")
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Outcome

Fixes the production-only credential refresh boundary tracked in #216 without placing secret values in Task Scheduler XML, process arguments, Patris config, logs, source, or artifacts.

## What changed

- adds a Windows PowerShell 5.1 launcher that re-reads explicitly named environment values from User scope, then Machine scope, immediately before starting Patris
- keeps the existing task helper compatible with AtomicDeploy while making ZIP/installer copies resolve their co-located executable
- base64-encodes only the JSON array of non-secret Patris flags so Task Scheduler argument binding remains deterministic
- adds exact ownership checks for both the new launcher action and the legacy direct-executable action
- makes remove work after a payload is missing, waits for the exact deployment process to exit, and aborts on an unrecognized process
- stops/restarts an owned running task around assisted upgrades and removes it before uninstalling locked files
- ships both helpers in standard, ALM-compatible, ZIP, and assisted-installer payloads
- runs the bridge/package preview test under the same Windows PowerShell 5.1 runtime used in production

## Verification

- Windows PowerShell 5.1 synthetic bridge test: pass
- stale Process value replaced by current User value: pass
- multiple name-only imports and missing-name fail-closed behavior: pass
- co-located ZIP/installer preview and encoded flag round-trip: pass
- missing-payload remove: pass
- PowerShell parse checks: pass
- `git diff --check`: pass
- `bash -n scripts/package-release.sh`: pass
- independent secret/lifecycle/quoting review: no remaining findings
- local NSIS compile: pass, 15,024,288-byte installer, SHA-256 `72043ba0d213104ef5d5f911adc7a983b3bca186366d73aaf7e768d3e3c62fa5`

The issue should remain open with its pending-owner-approval label after merge so the owner can perform the requested final review.