### PR TITLE
Track and stop the exact scheduled-task child

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,6 +368,14 @@ jobs:
           New-Item -ItemType Directory -Force $configRoot | Out-Null
           Set-Content -LiteralPath $sentinel -Value "preserve-me"
           Invoke-Installer
+          $installedHelper = Join-Path $installRoot "Install-PatrisExportScheduledTask.ps1"
+          Set-Content -LiteralPath $installedHelper -Value @'
+          throw "The legacy installed task helper must not bootstrap its own upgrade."
+          '@
+          Invoke-Installer
+          if (Select-String -LiteralPath $installedHelper -SimpleMatch "must not bootstrap" -Quiet) {
+              throw "The installer did not replace the simulated legacy task helper."
+          }
           $uninstall = Start-Process -FilePath (Join-Path $installRoot "Uninstall.exe") `
             -ArgumentList @('/S', '/CurrentUser') -Wait -PassThru
           if ($uninstall.ExitCode -ne 0) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Scheduled-task stop, restart, upgrade, uninstall, and replacement now
+  terminate only the exact deployment's Patris child process, preventing an
+  orphan from retaining the API port after the PowerShell parent exits.
 - A terminal Digitalogic assignment-page failure now cancels in-flight sibling
   requests, commits no partial assignments, and emits only typed secret-safe
   diagnostics.

--- a/docs/INSTALL-BINARIES.md
+++ b/docs/INSTALL-BINARIES.md
@@ -59,6 +59,13 @@ deployment. Repository operators retain the existing
 location with `-DeploymentDirectory`.
 Re-run the install action when task arguments or imported variable names
 change; rotating the value itself requires only a task restart.
+The launcher records only its process identity (PID, creation time, and exact
+executable path) under the current user's local application-data directory.
+The helper uses that non-secret record to stop, restart, upgrade, or uninstall
+only the scheduled server child; an unrelated viewer or CLI process from the
+same executable remains untouched. Launch reservations and an exclusive
+deployment lock prevent Task Scheduler retries from creating untracked
+duplicate children.
 The assisted uninstaller stops and removes the default task only when its
 action points to that installation. Remove a custom `-TaskName` or `-TaskPath`
 with the same helper before uninstalling.

--- a/installer/windows/patris-export.nsi
+++ b/installer/windows/patris-export.nsi
@@ -186,12 +186,15 @@ FunctionEnd
 
 Section "!Patris Export application" SEC_CORE
   SectionIn RO
+  InitPluginsDir
+  SetOutPath "$PLUGINSDIR\PatrisExportUpgrade"
+  File /oname=Install-PatrisExportScheduledTask.ps1 "${PAYLOAD_DIR}\Install-PatrisExportScheduledTask.ps1"
   SetOutPath "$INSTDIR"
   SetOverwrite on
 
   StrCpy $PatrisTaskWasRunning "0"
   ${If} ${FileExists} "$INSTDIR\Install-PatrisExportScheduledTask.ps1"
-    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\Install-PatrisExportScheduledTask.ps1" -Action PrepareUpgrade -DeploymentDirectory "$INSTDIR" -RequireOwnedAction'
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\PatrisExportUpgrade\Install-PatrisExportScheduledTask.ps1" -Action PrepareUpgrade -DeploymentDirectory "$INSTDIR" -RequireOwnedAction'
     Pop $0
     Pop $1
     ${If} $0 == 10

--- a/scripts/windows/Install-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Install-PatrisExportScheduledTask.ps1
@@ -70,22 +70,65 @@ function ConvertTo-TaskArgument {
     return $result.ToString()
 }
 
+function Get-DefaultProcessStatePath {
+    param([Parameter(Mandatory = $true)][string]$ExecutablePath)
+
+    $localAppData = [Environment]::GetFolderPath(
+        [Environment+SpecialFolder]::LocalApplicationData
+    )
+    if ([string]::IsNullOrWhiteSpace($localAppData)) {
+        throw "The current user's local application data directory is unavailable."
+    }
+    $normalizedPath = [IO.Path]::GetFullPath($ExecutablePath).ToUpperInvariant()
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = [BitConverter]::ToString(
+            $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedPath))
+        ).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+    Join-Path (
+        Join-Path $localAppData "AtomicDeploy\PatrisExport\process-state"
+    ) ($digest.Substring(0, 32) + ".json")
+}
+
+$processStatePath = Get-DefaultProcessStatePath -ExecutablePath $exe
+
 function Get-PatrisTask {
     Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
 }
 
-function Get-PatrisDeploymentProcess {
-    Get-Process -Name "patris-export" -ErrorAction SilentlyContinue |
-        Where-Object {
-            try {
-                $_.Path -and [IO.Path]::GetFullPath($_.Path).Equals(
-                    [IO.Path]::GetFullPath($exe),
-                    [StringComparison]::OrdinalIgnoreCase
-                )
-            } catch {
-                $false
+function New-PatrisProcessIdentity {
+    param([Parameter(Mandatory = $true)]$Process)
+
+    [pscustomobject]@{
+        Pid          = [int]$Process.Id
+        StartTimeUtc = $Process.StartTime.ToUniversalTime()
+        Executable   = [IO.Path]::GetFullPath([string]$Process.Path)
+    }
+}
+
+function Get-PatrisProcessIdentityById {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    for ($attempt = 0; $attempt -lt 2; $attempt++) {
+        $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+        if (-not $process) {
+            return $null
+        }
+        try {
+            return New-PatrisProcessIdentity -Process $process
+        } catch {
+            if (-not (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)) {
+                return $null
+            }
+            if ($attempt -eq 1) {
+                throw "Unable to verify the identity of live process $ProcessId."
             }
         }
+    }
+    return $null
 }
 
 function Test-PatrisOwnedTaskAction {
@@ -116,14 +159,301 @@ function Test-PatrisOwnedTaskAction {
     }
 }
 
-function Wait-PatrisDeploymentProcessExit {
+function Get-PatrisTrackedDeploymentProcess {
+    if (-not (Test-Path -LiteralPath $processStatePath -PathType Leaf)) {
+        return @()
+    }
+    try {
+        $state = Get-Content -LiteralPath $processStatePath -Raw | ConvertFrom-Json
+        $schemaVersion = [int]$state.schema_version
+        if ([string]$state.schema -ne "patris.scheduled-task-process" -or
+            $schemaVersion -notin @(1, 2) -or
+            -not [string]$state.executable) {
+            throw "invalid state"
+        }
+        if (-not [IO.Path]::GetFullPath([string]$state.executable).Equals(
+            [IO.Path]::GetFullPath($exe),
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+            throw "wrong deployment"
+        }
+
+        if ($schemaVersion -eq 2 -and [string]$state.status -eq "launching") {
+            if (-not [int]$state.launcher_pid -or
+                -not [string]$state.launcher_start_time_utc) {
+                throw "invalid launch reservation"
+            }
+            $launcherStart = [DateTime]::Parse(
+                [string]$state.launcher_start_time_utc,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [Globalization.DateTimeStyles]::RoundtripKind
+            ).ToUniversalTime()
+            $launcherIdentity = Get-PatrisProcessIdentityById -ProcessId ([int]$state.launcher_pid)
+            $launcherMatches = $launcherIdentity -and
+                $launcherIdentity.StartTimeUtc.Ticks -eq $launcherStart.Ticks
+            $reservedChildren = @()
+            foreach ($candidate in @(
+                Get-CimInstance Win32_Process -Filter (
+                    "ParentProcessId = {0}" -f [int]$state.launcher_pid
+                ) -ErrorAction Stop
+            )) {
+                try {
+                    $candidatePath = [IO.Path]::GetFullPath([string]$candidate.ExecutablePath)
+                } catch {
+                    if (-not (Get-Process -Id ([int]$candidate.ProcessId) -ErrorAction SilentlyContinue)) {
+                        continue
+                    }
+                    throw "unable to verify reserved child path"
+                }
+                if (-not $candidatePath.Equals(
+                    [IO.Path]::GetFullPath($exe),
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                    continue
+                }
+                $candidateCommandLine = [string]$candidate.CommandLine
+                if ($candidateCommandLine -notmatch '(^|\s)serve(\s|$)' -or
+                    $candidateCommandLine.IndexOf(
+                        $DbPath,
+                        [StringComparison]::OrdinalIgnoreCase
+                    ) -lt 0 -or
+                    $candidateCommandLine.IndexOf(
+                        $Address,
+                        [StringComparison]::OrdinalIgnoreCase
+                    ) -lt 0) {
+                    throw "reserved child command does not match the managed server"
+                }
+                $identity = Get-PatrisProcessIdentityById -ProcessId ([int]$candidate.ProcessId)
+                if (-not $identity -or $identity.StartTimeUtc -lt $launcherStart) {
+                    continue
+                }
+                if (-not $launcherMatches -and $launcherIdentity -and
+                    $identity.StartTimeUtc -ge $launcherIdentity.StartTimeUtc) {
+                    continue
+                }
+                $reservedChildren += $identity
+            }
+            if ($reservedChildren.Count -gt 1) {
+                throw "launch reservation has multiple matching child processes"
+            }
+            if ($reservedChildren.Count -eq 1) {
+                return @($reservedChildren[0])
+            }
+            if ($launcherMatches) {
+                return @()
+            }
+            Remove-Item -LiteralPath $processStatePath -Force -ErrorAction Stop
+            return @()
+        }
+
+        if (-not [int]$state.pid -or -not [string]$state.start_time_utc -or
+            ($schemaVersion -eq 2 -and [string]$state.status -ne "running")) {
+            throw "invalid running state"
+        }
+        $identity = Get-PatrisProcessIdentityById -ProcessId ([int]$state.pid)
+        if ($identity) {
+            $recordedStart = [DateTime]::Parse(
+                [string]$state.start_time_utc,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [Globalization.DateTimeStyles]::RoundtripKind
+            ).ToUniversalTime()
+            if (-not $identity.Executable.Equals(
+                [IO.Path]::GetFullPath($exe),
+                [StringComparison]::OrdinalIgnoreCase
+            ) -or $identity.StartTimeUtc.Ticks -ne $recordedStart.Ticks) {
+                throw "stale or reused process identity"
+            }
+            return @($identity)
+        }
+        Remove-Item -LiteralPath $processStatePath -Force -ErrorAction Stop
+        return @()
+    } catch {
+        throw "Scheduled-task process state is invalid; refusing to terminate a process: $processStatePath"
+    }
+}
+
+function Get-PatrisLegacyTaskChildProcess {
+    param([Parameter(Mandatory = $true)]$Task)
+
+    if ([string]$Task.State -ne "Running" -or -not (Test-PatrisOwnedTaskAction -Task $Task)) {
+        return @()
+    }
+    $processes = @(Get-CimInstance Win32_Process -ErrorAction Stop)
+    $identities = @()
+    foreach ($candidate in @($processes | Where-Object { $_.Name -ieq "patris-export.exe" })) {
+        try {
+            if (-not [IO.Path]::GetFullPath([string]$candidate.ExecutablePath).Equals(
+                [IO.Path]::GetFullPath($exe),
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+                continue
+            }
+            $parent = $processes |
+                Where-Object { [int]$_.ProcessId -eq [int]$candidate.ParentProcessId } |
+                Select-Object -First 1
+            $parentCommandLine = [string]$parent.CommandLine
+            $candidateCommandLine = [string]$candidate.CommandLine
+            if (-not $parent -or
+                $parentCommandLine.IndexOf(
+                    $launcher,
+                    [StringComparison]::OrdinalIgnoreCase
+                ) -lt 0 -or
+                $candidateCommandLine -notmatch '(^|\s)serve(\s|$)' -or
+                $candidateCommandLine.IndexOf(
+                    $DbPath,
+                    [StringComparison]::OrdinalIgnoreCase
+                ) -lt 0 -or
+                $candidateCommandLine.IndexOf(
+                    $Address,
+                    [StringComparison]::OrdinalIgnoreCase
+                ) -lt 0) {
+                continue
+            }
+            $identity = Get-PatrisProcessIdentityById -ProcessId ([int]$candidate.ProcessId)
+            if ($identity) {
+                $identities += $identity
+            }
+        } catch {
+        }
+    }
+    return @($identities)
+}
+
+function Get-PatrisManagedProcessSnapshot {
+    param($Task)
+
+    $tracked = @(Get-PatrisTrackedDeploymentProcess)
+    if ($tracked.Count -gt 0) {
+        return $tracked
+    }
+    if ($Task) {
+        return @(Get-PatrisLegacyTaskChildProcess -Task $Task)
+    }
+    return @()
+}
+
+function Merge-PatrisProcessIdentity {
+    param([Parameter(Mandatory = $true)][object[]]$Identity)
+
+    $merged = [ordered]@{}
+    foreach ($candidate in $Identity) {
+        if (-not $candidate) {
+            continue
+        }
+        $key = "{0}|{1}|{2}" -f @(
+            [int]$candidate.Pid,
+            $candidate.StartTimeUtc.Ticks,
+            ([string]$candidate.Executable).ToUpperInvariant()
+        )
+        $merged[$key] = $candidate
+    }
+    return @($merged.Values)
+}
+
+function Wait-PatrisTaskStopped {
+    param($Task)
+
+    if (-not $Task) {
+        return
+    }
     $deadline = [DateTime]::UtcNow.AddSeconds(15)
-    while (@(Get-PatrisDeploymentProcess).Count -gt 0 -and [DateTime]::UtcNow -lt $deadline) {
-        Start-Sleep -Milliseconds 200
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $currentTask = Get-PatrisTask
+        if (-not $currentTask -or [string]$currentTask.State -ne "Running") {
+            return
+        }
+        Start-Sleep -Milliseconds 100
     }
-    if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
-        throw "Patris Export is still running from the deployment directory."
+    throw "The Patris Export scheduled task did not stop."
+}
+
+function Wait-PatrisDeploymentProcessExit {
+    param([Parameter(Mandatory = $true)][object[]]$Identity)
+
+    $deadline = [DateTime]::UtcNow.AddSeconds(15)
+    foreach ($expected in $Identity) {
+        while ([DateTime]::UtcNow -lt $deadline) {
+            $current = Get-PatrisProcessIdentityById -ProcessId $expected.Pid
+            if (-not $current) {
+                break
+            }
+            if ($current.StartTimeUtc.Ticks -ne $expected.StartTimeUtc.Ticks -or
+                -not $current.Executable.Equals(
+                    $expected.Executable,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                break
+            }
+            Start-Sleep -Milliseconds 200
+        }
+        $current = Get-PatrisProcessIdentityById -ProcessId $expected.Pid
+        if ($current) {
+            if ($current.StartTimeUtc.Ticks -eq $expected.StartTimeUtc.Ticks -and
+                $current.Executable.Equals(
+                    $expected.Executable,
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw "The tracked Patris Export process is still running."
+            }
+        }
     }
+}
+
+function Stop-PatrisDeploymentProcess {
+    param([Parameter(Mandatory = $true)][object[]]$Identity)
+
+    foreach ($expected in $Identity) {
+        $current = Get-PatrisProcessIdentityById -ProcessId $expected.Pid
+        if (-not $current) {
+            continue
+        }
+        if ($current.StartTimeUtc.Ticks -ne $expected.StartTimeUtc.Ticks -or
+            -not $current.Executable.Equals(
+                $expected.Executable,
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
+            throw "A tracked Patris Export process identity changed before termination."
+        }
+        $process = Get-Process -Id $expected.Pid -ErrorAction SilentlyContinue
+        if (-not $process) {
+            continue
+        }
+        try {
+            Stop-Process -InputObject $process -Force -ErrorAction Stop
+        } catch {
+            $remaining = Get-PatrisProcessIdentityById -ProcessId $expected.Pid
+            if ($remaining) {
+                if ($remaining.StartTimeUtc.Ticks -eq $expected.StartTimeUtc.Ticks -and
+                    $remaining.Executable.Equals(
+                        $expected.Executable,
+                        [StringComparison]::OrdinalIgnoreCase
+                    )) {
+                    throw
+                }
+            }
+        }
+    }
+    Wait-PatrisDeploymentProcessExit -Identity $Identity
+    $remainingTracked = @(Get-PatrisTrackedDeploymentProcess)
+    if ($remainingTracked.Count -gt 0) {
+        throw "A tracked Patris Export child process appeared or remained during termination."
+    }
+}
+
+function Stop-PatrisTaskAndDeploymentProcess {
+    param($Task)
+
+    $beforeStop = @(Get-PatrisManagedProcessSnapshot -Task $Task)
+    if ($Task) {
+        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+        Wait-PatrisTaskStopped -Task $Task
+    }
+    $afterStop = @(Get-PatrisTrackedDeploymentProcess)
+    $managedProcesses = @(
+        Merge-PatrisProcessIdentity -Identity @($beforeStop + $afterStop)
+    )
+    Stop-PatrisDeploymentProcess -Identity $managedProcesses
+    return $managedProcesses
 }
 
 function New-PatrisTaskAction {
@@ -151,7 +481,9 @@ function New-PatrisTaskAction {
         "-Address",
         $Address,
         "-Debounce",
-        $Debounce
+        $Debounce,
+        "-ProcessStatePath",
+        $processStatePath
     )
     if ($environmentNames.Count -gt 0) {
         $argumentParts += @("-EnvironmentVariableNames", ($environmentNames -join ","))
@@ -215,6 +547,8 @@ switch ($Action) {
         )) {
             Copy-Item -LiteralPath $sourceLauncher -Destination $launcher -Force
         }
+        $existingTask = Get-PatrisTask
+        [void](Stop-PatrisTaskAndDeploymentProcess -Task $existingTask)
         $taskAction = New-PatrisTaskAction
         $trigger = New-ScheduledTaskTrigger -AtLogOn
         $settings = New-ScheduledTaskSettingsSet `
@@ -242,19 +576,46 @@ switch ($Action) {
         break
     }
     "Start" {
+        $task = Get-PatrisTask
+        if (-not $task) {
+            throw "Scheduled task not installed: $TaskPath$TaskName"
+        }
+        $managedProcesses = @(Get-PatrisManagedProcessSnapshot -Task $task)
+        if ([string]$task.State -eq "Running") {
+            if ($managedProcesses.Count -gt 0) {
+                Show-PatrisTaskStatus
+                break
+            }
+            throw "The scheduled task is running without a verified Patris Export child process."
+        }
+        if ($managedProcesses.Count -gt 0) {
+            throw "A verified Patris Export child process exists outside the task state."
+        }
         Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
         Start-Sleep -Seconds 2
+        $startedTask = Get-PatrisTask
+        if (@(Get-PatrisManagedProcessSnapshot -Task $startedTask).Count -eq 0) {
+            throw "The scheduled task did not start a verified Patris Export child process."
+        }
         Show-PatrisTaskStatus
     }
     "Stop" {
-        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
+        $task = Get-PatrisTask
+        [void](Stop-PatrisTaskAndDeploymentProcess -Task $task)
         Show-PatrisTaskStatus
     }
     "Restart" {
-        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
-        Start-Sleep -Seconds 1
+        $task = Get-PatrisTask
+        if (-not $task) {
+            throw "Scheduled task not installed: $TaskPath$TaskName"
+        }
+        [void](Stop-PatrisTaskAndDeploymentProcess -Task $task)
         Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
         Start-Sleep -Seconds 2
+        $startedTask = Get-PatrisTask
+        if (@(Get-PatrisManagedProcessSnapshot -Task $startedTask).Count -eq 0) {
+            throw "The scheduled task did not restart a verified Patris Export child process."
+        }
         Show-PatrisTaskStatus
     }
     "Status" {
@@ -263,22 +624,22 @@ switch ($Action) {
     "PrepareUpgrade" {
         $task = Get-PatrisTask
         if (-not $task) {
-            if ($RequireOwnedAction -and @(Get-PatrisDeploymentProcess).Count -gt 0) {
-                throw "Patris Export is running from this deployment without the expected task."
+            if ($RequireOwnedAction -and @(Get-PatrisTrackedDeploymentProcess).Count -gt 0) {
+                throw "A tracked Patris Export child process exists without the expected task."
             }
             Write-Host "Scheduled task not installed: $TaskPath$TaskName"
             break
         }
         if ($RequireOwnedAction -and -not (Test-PatrisOwnedTaskAction -Task $task)) {
-            if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
-                throw "An unrecognized task left Patris Export running from this deployment."
+            if (@(Get-PatrisTrackedDeploymentProcess).Count -gt 0) {
+                throw "An unrecognized task owns the tracked Patris Export child process."
             }
             Write-Host "Scheduled task is not owned by this deployment; leaving it unchanged: $TaskPath$TaskName"
             break
         }
-        $wasRunning = ([string]$task.State -eq "Running") -or @(Get-PatrisDeploymentProcess).Count -gt 0
-        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
-        Wait-PatrisDeploymentProcessExit
+        $managedProcesses = @(Get-PatrisManagedProcessSnapshot -Task $task)
+        $wasRunning = ([string]$task.State -eq "Running") -or $managedProcesses.Count -gt 0
+        [void](Stop-PatrisTaskAndDeploymentProcess -Task $task)
         if ($wasRunning) {
             exit 10
         }
@@ -287,22 +648,21 @@ switch ($Action) {
     "Remove" {
         $task = Get-PatrisTask
         if (-not $task) {
-            if ($RequireOwnedAction -and @(Get-PatrisDeploymentProcess).Count -gt 0) {
-                throw "Patris Export is running from this deployment without the expected task."
+            if ($RequireOwnedAction -and @(Get-PatrisTrackedDeploymentProcess).Count -gt 0) {
+                throw "A tracked Patris Export child process exists without the expected task."
             }
             Write-Host "Scheduled task not installed: $TaskPath$TaskName"
             break
         }
         if ($RequireOwnedAction -and -not (Test-PatrisOwnedTaskAction -Task $task)) {
-            if (@(Get-PatrisDeploymentProcess).Count -gt 0) {
-                throw "An unrecognized task left Patris Export running from this deployment."
+            if (@(Get-PatrisTrackedDeploymentProcess).Count -gt 0) {
+                throw "An unrecognized task owns the tracked Patris Export child process."
             }
             Write-Host "Scheduled task is not owned by this deployment; leaving it unchanged: $TaskPath$TaskName"
             break
         }
-        Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+        [void](Stop-PatrisTaskAndDeploymentProcess -Task $task)
         Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Confirm:$false
-        Wait-PatrisDeploymentProcessExit
         Write-Host "Removed scheduled task: $TaskPath$TaskName"
     }
 }

--- a/scripts/windows/Run-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Run-PatrisExportScheduledTask.ps1
@@ -6,10 +6,71 @@ param(
     [string]$Address = ":18080",
     [string]$Debounce = "500ms",
     [string]$EnvironmentVariableNames = "",
-    [string]$ExtraArgsBase64 = ""
+    [string]$ExtraArgsBase64 = "",
+    [string]$ProcessStatePath = ""
 )
 
 $ErrorActionPreference = "Stop"
+
+function ConvertTo-ProcessArgument {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    if ($Value.IndexOf([char]0) -ge 0 -or $Value -match "[`r`n]") {
+        throw "Scheduled-task arguments cannot contain nulls or newlines."
+    }
+    if ($Value -notmatch '[\s"]') {
+        return $Value
+    }
+
+    $result = New-Object System.Text.StringBuilder
+    [void]$result.Append('"')
+    $backslashes = 0
+    foreach ($character in $Value.ToCharArray()) {
+        if ($character -eq '\') {
+            $backslashes++
+            continue
+        }
+        if ($character -eq '"') {
+            [void]$result.Append((('\' * (($backslashes * 2) + 1)) -join ""))
+            [void]$result.Append('"')
+            $backslashes = 0
+            continue
+        }
+        if ($backslashes -gt 0) {
+            [void]$result.Append((('\' * $backslashes) -join ""))
+            $backslashes = 0
+        }
+        [void]$result.Append($character)
+    }
+    if ($backslashes -gt 0) {
+        [void]$result.Append((('\' * ($backslashes * 2)) -join ""))
+    }
+    [void]$result.Append('"')
+    return $result.ToString()
+}
+
+function Get-DefaultProcessStatePath {
+    param([Parameter(Mandatory = $true)][string]$ExecutablePath)
+
+    $localAppData = [Environment]::GetFolderPath(
+        [Environment+SpecialFolder]::LocalApplicationData
+    )
+    if ([string]::IsNullOrWhiteSpace($localAppData)) {
+        throw "The current user's local application data directory is unavailable."
+    }
+    $normalizedPath = [IO.Path]::GetFullPath($ExecutablePath).ToUpperInvariant()
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = [BitConverter]::ToString(
+            $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedPath))
+        ).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+    Join-Path (
+        Join-Path $localAppData "AtomicDeploy\PatrisExport\process-state"
+    ) ($digest.Substring(0, 32) + ".json")
+}
 
 if (-not (Test-Path -LiteralPath $Executable -PathType Leaf)) {
     throw "Patris Export executable not found: $Executable"
@@ -64,13 +125,165 @@ if ($ExtraArgsBase64) {
 
 $arguments = @("serve", $DbPath, "--addr", $Address, "--debounce", $Debounce) + $extraArguments
 $workingDirectory = Split-Path -Parent $Executable
-
-Push-Location $workingDirectory
+if (-not $ProcessStatePath) {
+    $ProcessStatePath = Get-DefaultProcessStatePath -ExecutablePath $Executable
+}
+$ProcessStatePath = [IO.Path]::GetFullPath($ProcessStatePath)
+$processStateDirectory = [IO.Path]::GetDirectoryName($ProcessStatePath)
+New-Item -ItemType Directory -Path $processStateDirectory -Force | Out-Null
+$stateLockPath = "$ProcessStatePath.lock"
 try {
-    & $Executable @arguments
-    if ($null -ne $LASTEXITCODE) {
-        exit $LASTEXITCODE
+    $stateLock = [IO.File]::Open(
+        $stateLockPath,
+        [IO.FileMode]::OpenOrCreate,
+        [IO.FileAccess]::ReadWrite,
+        [IO.FileShare]::None
+    )
+} catch [IO.IOException] {
+    $win32Code = $_.Exception.HResult -band 0xFFFF
+    if ($win32Code -in @(32, 33)) {
+        throw "Another scheduled-task launcher owns the deployment process state."
+    }
+    throw "Scheduled-task process-state storage access is unavailable."
+} catch {
+    throw "Scheduled-task process-state storage access is unavailable."
+}
+try {
+    if (Test-Path -LiteralPath $ProcessStatePath -PathType Leaf) {
+        try {
+            $existingState = Get-Content -LiteralPath $ProcessStatePath -Raw | ConvertFrom-Json
+            if ([string]$existingState.schema -ne "patris.scheduled-task-process" -or
+                [int]$existingState.schema_version -notin @(1, 2) -or
+                -not [string]$existingState.executable -or
+                -not [IO.Path]::GetFullPath([string]$existingState.executable).Equals(
+                    [IO.Path]::GetFullPath($Executable),
+                    [StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw "invalid state"
+            }
+            if ([int]$existingState.schema_version -eq 2 -and
+                [string]$existingState.status -eq "launching") {
+                throw "launch reservation requires recovery"
+            }
+            if (-not [int]$existingState.pid -or -not [string]$existingState.start_time_utc) {
+                throw "invalid running state"
+            }
+            $existingProcess = Get-Process -Id ([int]$existingState.pid) -ErrorAction SilentlyContinue
+            if ($existingProcess) {
+                $existingStart = [DateTime]::Parse(
+                    [string]$existingState.start_time_utc,
+                    [Globalization.CultureInfo]::InvariantCulture,
+                    [Globalization.DateTimeStyles]::RoundtripKind
+                ).ToUniversalTime()
+                try {
+                    if ($existingProcess.StartTime.ToUniversalTime().Ticks -eq $existingStart.Ticks -and
+                        [IO.Path]::GetFullPath([string]$existingProcess.Path).Equals(
+                            [IO.Path]::GetFullPath($Executable),
+                            [StringComparison]::OrdinalIgnoreCase
+                        )) {
+                        throw "tracked child is already running"
+                    }
+                } catch {
+                    if (Get-Process -Id ([int]$existingState.pid) -ErrorAction SilentlyContinue) {
+                        throw
+                    }
+                }
+            }
+            Remove-Item -LiteralPath $ProcessStatePath -Force -ErrorAction Stop
+        } catch {
+            throw "Existing scheduled-task process state requires the installer helper's stop or restart action: $ProcessStatePath"
+        }
+    }
+} catch {
+    $stateLock.Dispose()
+    throw
+}
+$process = $null
+$launcherProcess = Get-Process -Id $PID -ErrorAction Stop
+$launcherStartedUtc = $launcherProcess.StartTime.ToUniversalTime().ToString("O")
+$startedPid = 0
+$startedUtc = ""
+$stateTempPath = "$ProcessStatePath.$PID.tmp"
+$stateOwned = $false
+
+try {
+    $launchingState = [ordered]@{
+        schema         = "patris.scheduled-task-process"
+        schema_version = 2
+        status         = "launching"
+        launcher_pid   = $PID
+        launcher_start_time_utc = $launcherStartedUtc
+        executable     = [IO.Path]::GetFullPath($Executable)
+    }
+    $launchingState | ConvertTo-Json -Compress |
+        Set-Content -LiteralPath $stateTempPath -Encoding utf8
+    Move-Item -LiteralPath $stateTempPath -Destination $ProcessStatePath -Force
+    $stateOwned = $true
+
+    Push-Location $workingDirectory
+    try {
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $Executable
+        $startInfo.WorkingDirectory = $workingDirectory
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.Arguments = ($arguments | ForEach-Object {
+            ConvertTo-ProcessArgument ([string]$_)
+        }) -join " "
+        $process = [Diagnostics.Process]::Start($startInfo)
+        if (-not $process) {
+            throw "Unable to start Patris Export."
+        }
+        $startedPid = $process.Id
+        $startedUtc = $process.StartTime.ToUniversalTime().ToString("O")
+        $runningState = [ordered]@{
+            schema         = "patris.scheduled-task-process"
+            schema_version = 2
+            status         = "running"
+            launcher_pid   = $PID
+            launcher_start_time_utc = $launcherStartedUtc
+            pid            = $startedPid
+            start_time_utc = $startedUtc
+            executable     = [IO.Path]::GetFullPath($Executable)
+        }
+        $runningState | ConvertTo-Json -Compress |
+            Set-Content -LiteralPath $stateTempPath -Encoding utf8
+        Move-Item -LiteralPath $stateTempPath -Destination $ProcessStatePath -Force
+        $process.WaitForExit()
+        exit $process.ExitCode
+    } finally {
+        Pop-Location
     }
 } finally {
-    Pop-Location
+    if ($process) {
+        try {
+            try {
+                if (-not $process.HasExited) {
+                    $process.Kill()
+                    $process.WaitForExit()
+                }
+            } catch {
+                if (-not $process.HasExited) {
+                    throw
+                }
+            }
+        } finally {
+            $process.Dispose()
+        }
+    }
+    if ($stateOwned -and
+        (Test-Path -LiteralPath $ProcessStatePath -PathType Leaf)) {
+        try {
+            $currentState = Get-Content -LiteralPath $ProcessStatePath -Raw | ConvertFrom-Json
+            if ([int]$currentState.launcher_pid -eq $PID -and
+                [string]$currentState.launcher_start_time_utc -eq $launcherStartedUtc) {
+                Remove-Item -LiteralPath $ProcessStatePath -Force
+            }
+        } catch {
+        }
+    }
+    if (Test-Path -LiteralPath $stateTempPath -PathType Leaf) {
+        Remove-Item -LiteralPath $stateTempPath -Force -ErrorAction SilentlyContinue
+    }
+    $stateLock.Dispose()
 }

--- a/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
+++ b/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
@@ -3,21 +3,42 @@ param()
 $ErrorActionPreference = "Stop"
 
 $launcher = Join-Path $PSScriptRoot "Run-PatrisExportScheduledTask.ps1"
-$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("patris-scheduled-env-" + [guid]::NewGuid().ToString("N"))
+$testId = [guid]::NewGuid().ToString("N")
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("patris-scheduled-env-" + $testId)
 $probeSource = Join-Path $testRoot "EnvironmentProbe.cs"
 $probeExecutable = Join-Path $testRoot "EnvironmentProbe.exe"
 $capturePath = Join-Path $testRoot "capture.txt"
-$variableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_SECRET"
-$captureVariableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_CAPTURE_PATH"
+$sleeperSource = Join-Path $testRoot "Sleeper.cs"
+$variableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_SECRET_$testId"
+$captureVariableName = "PATRIS_EXPORT_SCHEDULED_TASK_TEST_CAPTURE_PATH_$testId"
 $secret = "synthetic-" + [guid]::NewGuid().ToString("N")
 $previousUserValue = [Environment]::GetEnvironmentVariable($variableName, "User")
 $previousProcessValue = [Environment]::GetEnvironmentVariable($variableName, "Process")
 $previousCaptureUserValue = [Environment]::GetEnvironmentVariable($captureVariableName, "User")
 $previousCaptureProcessValue = [Environment]::GetEnvironmentVariable($captureVariableName, "Process")
 
+function Get-TestProcessStatePath {
+    param([Parameter(Mandatory = $true)][string]$ExecutablePath)
+
+    $normalizedPath = [IO.Path]::GetFullPath($ExecutablePath).ToUpperInvariant()
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = [BitConverter]::ToString(
+            $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($normalizedPath))
+        ).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+    Join-Path (
+        Join-Path ([Environment]::GetFolderPath(
+            [Environment+SpecialFolder]::LocalApplicationData
+        )) "AtomicDeploy\PatrisExport\process-state"
+    ) ($digest.Substring(0, 32) + ".json")
+}
+
 try {
     New-Item -ItemType Directory -Path $testRoot | Out-Null
-    @'
+    $probeProgram = @'
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -27,8 +48,8 @@ public static class EnvironmentProbe
 {
     public static int Main(string[] args)
     {
-        var output = Environment.GetEnvironmentVariable("PATRIS_EXPORT_SCHEDULED_TASK_TEST_CAPTURE_PATH");
-        var value = Environment.GetEnvironmentVariable("PATRIS_EXPORT_SCHEDULED_TASK_TEST_SECRET");
+        var output = Environment.GetEnvironmentVariable("__CAPTURE_VARIABLE__");
+        var value = Environment.GetEnvironmentVariable("__SECRET_VARIABLE__");
         var hasProbeArgument = Array.IndexOf(args, "--bridge-probe") >= 0;
         if (string.IsNullOrEmpty(output) || string.IsNullOrEmpty(value) || !hasProbeArgument)
         {
@@ -42,7 +63,11 @@ public static class EnvironmentProbe
         return 0;
     }
 }
-'@ | Set-Content -LiteralPath $probeSource -Encoding utf8
+'@
+    $probeProgram = $probeProgram.Replace("__CAPTURE_VARIABLE__", $captureVariableName)
+    $probeProgram = $probeProgram.Replace("__SECRET_VARIABLE__", $variableName)
+    $probeProgram |
+        Set-Content -LiteralPath $probeSource -Encoding utf8
 
     Add-Type -Path $probeSource -OutputAssembly $probeExecutable -OutputType ConsoleApplication
     [Environment]::SetEnvironmentVariable($variableName, $secret, "User")
@@ -129,6 +154,214 @@ public static class EnvironmentProbe
         -DeploymentDirectory $missingPayloadRoot `
         -TaskName ("PatrisExportMissing-" + [guid]::NewGuid().ToString("N")) `
         -TaskPath "\"
+
+    @'
+using System.Threading;
+
+public static class Sleeper
+{
+    public static int Main()
+    {
+        Thread.Sleep(60000);
+        return 0;
+    }
+}
+'@ | Set-Content -LiteralPath $sleeperSource -Encoding utf8
+
+    $targetRoot = Join-Path $testRoot "target-deployment"
+    New-Item -ItemType Directory -Path $targetRoot | Out-Null
+    $targetExecutable = Join-Path $targetRoot "patris-export.exe"
+    Add-Type -Path $sleeperSource -OutputAssembly $targetExecutable -OutputType ConsoleApplication
+    $targetProcess = Start-Process -FilePath $targetExecutable -PassThru -WindowStyle Hidden
+    $controlProcess = Start-Process -FilePath $targetExecutable -PassThru -WindowStyle Hidden
+    try {
+        $targetStatePath = Get-TestProcessStatePath -ExecutablePath $targetExecutable
+        New-Item -ItemType Directory -Path ([IO.Path]::GetDirectoryName($targetStatePath)) -Force |
+            Out-Null
+        [ordered]@{
+            schema         = "patris.scheduled-task-process"
+            schema_version = 1
+            pid            = $targetProcess.Id
+            start_time_utc = $targetProcess.StartTime.ToUniversalTime().ToString("O")
+            executable     = [IO.Path]::GetFullPath($targetExecutable)
+            database       = "ignored.db"
+            address        = "127.0.0.1:0"
+        } | ConvertTo-Json -Compress |
+            Set-Content -LiteralPath $targetStatePath -Encoding utf8
+        & (Join-Path $PSScriptRoot "Install-PatrisExportScheduledTask.ps1") `
+            -Action Stop `
+            -DeploymentDirectory $targetRoot `
+            -TaskName ("PatrisExportMissing-" + [guid]::NewGuid().ToString("N")) `
+            -TaskPath "\"
+        $targetProcess.Refresh()
+        $controlProcess.Refresh()
+        if (-not $targetProcess.HasExited) {
+            throw "The exact deployment child process survived the stop action."
+        }
+        if ($controlProcess.HasExited) {
+            throw "The stop action terminated an untracked same-path process."
+        }
+    } finally {
+        foreach ($process in @($targetProcess, $controlProcess)) {
+            try {
+                if (-not $process.HasExited) {
+                    Stop-Process -Id $process.Id -Force
+                }
+            } catch {
+            }
+            $process.Dispose()
+        }
+    }
+
+    $concurrentRoot = Join-Path $testRoot "concurrent-launcher"
+    New-Item -ItemType Directory -Path $concurrentRoot | Out-Null
+    $concurrentExecutable = Join-Path $concurrentRoot "patris-export.exe"
+    Copy-Item -LiteralPath $targetExecutable -Destination $concurrentExecutable
+    $concurrentStatePath = Join-Path $testRoot "concurrent-process-state.json"
+    $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
+    $firstLauncher = Start-Process -FilePath $powershell -ArgumentList @(
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        $launcher,
+        "-Executable",
+        $concurrentExecutable,
+        "-DbPath",
+        "ignored.db",
+        "-Address",
+        "127.0.0.1:0",
+        "-ProcessStatePath",
+        $concurrentStatePath
+    ) -PassThru -WindowStyle Hidden
+    try {
+        $deadline = [DateTime]::UtcNow.AddSeconds(10)
+        $runningState = $null
+        while ([DateTime]::UtcNow -lt $deadline) {
+            if (Test-Path -LiteralPath $concurrentStatePath -PathType Leaf) {
+                try {
+                    $candidateState = Get-Content -LiteralPath $concurrentStatePath -Raw |
+                        ConvertFrom-Json
+                    if ([string]$candidateState.status -eq "running") {
+                        $runningState = $candidateState
+                        break
+                    }
+                } catch {
+                }
+            }
+            Start-Sleep -Milliseconds 100
+        }
+        if (-not $runningState) {
+            throw "The first launcher did not commit a running process state."
+        }
+        $stateBeforeSecondLaunch = Get-Content -LiteralPath $concurrentStatePath -Raw
+        $secondLaunchMessage = ""
+        try {
+            & $launcher `
+                -Executable $concurrentExecutable `
+                -DbPath "ignored.db" `
+                -Address "127.0.0.1:0" `
+                -ProcessStatePath $concurrentStatePath
+            throw "A concurrent launcher was accepted."
+        } catch {
+            $secondLaunchMessage = $_.Exception.Message
+        }
+        if ($secondLaunchMessage -notlike "*owns the deployment process state*") {
+            throw "The concurrent launcher did not fail on the deployment-state lock."
+        }
+        if ((Get-Content -LiteralPath $concurrentStatePath -Raw) -ne $stateBeforeSecondLaunch) {
+            throw "A concurrent launcher replaced the original process identity."
+        }
+        $concurrentChildren = @(
+            Get-Process -Name "patris-export" -ErrorAction SilentlyContinue |
+                Where-Object {
+                    try {
+                        $_.Path -and [IO.Path]::GetFullPath($_.Path).Equals(
+                            [IO.Path]::GetFullPath($concurrentExecutable),
+                            [StringComparison]::OrdinalIgnoreCase
+                        )
+                    } catch {
+                        $false
+                    }
+                }
+        )
+        if ($concurrentChildren.Count -ne 1 -or
+            $concurrentChildren[0].Id -ne [int]$runningState.pid) {
+            throw "Concurrent launch protection did not preserve exactly one tracked child."
+        }
+    } finally {
+        if ($runningState) {
+            Stop-Process -Id ([int]$runningState.pid) -Force -ErrorAction SilentlyContinue
+        }
+        if (-not $firstLauncher.WaitForExit(10000)) {
+            Stop-Process -Id $firstLauncher.Id -Force -ErrorAction SilentlyContinue
+        }
+        $firstLauncher.Dispose()
+        Remove-Item -LiteralPath $concurrentStatePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath "$concurrentStatePath.lock" -Force -ErrorAction SilentlyContinue
+    }
+
+    $blockedRoot = Join-Path $testRoot "blocked-process-state"
+    New-Item -ItemType Directory -Path $blockedRoot | Out-Null
+    $blockedAcl = Get-Acl -LiteralPath $blockedRoot
+    $originalBlockedSddl = $blockedAcl.GetSecurityDescriptorSddlForm("All")
+    $currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+    $deniedRights = (
+        [Security.AccessControl.FileSystemRights]::CreateFiles -bor
+        [Security.AccessControl.FileSystemRights]::WriteData -bor
+        [Security.AccessControl.FileSystemRights]::AppendData -bor
+        [Security.AccessControl.FileSystemRights]::Delete
+    )
+    $deniedInheritance = (
+        [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [Security.AccessControl.InheritanceFlags]::ObjectInherit
+    )
+    $denyWrite = New-Object Security.AccessControl.FileSystemAccessRule -ArgumentList @(
+        $currentSid,
+        $deniedRights,
+        $deniedInheritance,
+        [Security.AccessControl.PropagationFlags]::None,
+        [Security.AccessControl.AccessControlType]::Deny
+    )
+    $blockedAcl.AddAccessRule($denyWrite)
+    Set-Acl -LiteralPath $blockedRoot -AclObject $blockedAcl
+    try {
+        $failureMessage = ""
+        try {
+            & $launcher `
+                -Executable $targetExecutable `
+                -DbPath "ignored.db" `
+                -ProcessStatePath (Join-Path $blockedRoot "state.json")
+            throw "An unwritable process-state path was accepted."
+        } catch {
+            $failureMessage = $_.Exception.Message
+        }
+        if ($failureMessage -notlike "*denied*" -and
+            $failureMessage -notlike "*access*") {
+            throw "The process-state write did not fail for the expected reason."
+        }
+        $survivors = @(
+            Get-Process -Name "patris-export" -ErrorAction SilentlyContinue |
+                Where-Object {
+                    try {
+                        $_.Path -and [IO.Path]::GetFullPath($_.Path).Equals(
+                            [IO.Path]::GetFullPath($targetExecutable),
+                            [StringComparison]::OrdinalIgnoreCase
+                        )
+                    } catch {
+                        $false
+                    }
+                }
+        )
+        if ($survivors.Count -gt 0) {
+            throw "A process-state write failure left an untracked child process."
+        }
+    } finally {
+        $restoreAcl = New-Object Security.AccessControl.DirectorySecurity
+        $restoreAcl.SetSecurityDescriptorSddlForm($originalBlockedSddl)
+        Set-Acl -LiteralPath $blockedRoot -AclObject $restoreAcl
+    }
 
     Write-Host "Scheduled-task environment bridge passed name-only import and fail-closed tests."
 } finally {


### PR DESCRIPTION
## Summary
- persist a non-secret PID/start-time identity and pre-spawn reservation for the scheduled Patris server child
- serialize launchers and stop only the verified task child, preserving unrelated same-path viewer/CLI processes
- make restart, upgrade, uninstall, and replacement race-safe, including legacy task migration
- bootstrap upgrades with the new helper from the NSIS temporary payload
- add Windows PowerShell lifecycle and simulated legacy-upgrade regressions

## Verification
- Windows PowerShell 5.1 parse: PASS
- scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1: PASS
- git diff --check: PASS
- independent blocker review: PASS

Refs #216