### PR TITLE
Release Patris Export 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.3.0] - 2026-07-26
+
+### Added
+
 - Pull requests now prove SQL sink parity and transactional rollback against
   disposable MySQL 8.4, MariaDB 11.4, and SQLite targets while preserving
   leading-zero keys, additive schemas, user-owned columns, and guarded

--- a/docs/EXCEL-PRICING-SYNC.md
+++ b/docs/EXCEL-PRICING-SYNC.md
@@ -1,8 +1,9 @@
 # Excel pricing-settings companion
 
-Patris Export is the credential boundary between the canonical
-`Digitalogic-Price-Calculator.xltm` workbook and Digitalogic's guarded
-pricing-settings API. The workbook never contains a WordPress, WooCommerce, or
+Patris Export is the credential boundary between the canonical Persian
+`لیست قیمت دیجیتالاجیک - استاندارد.xltm` and
+`لیست قیمت دیجیتالاجیک - پیشرفته.xltm` workbooks and Digitalogic's guarded
+pricing-settings API. The workbooks never contain a WordPress, WooCommerce, or
 product-sync credential.
 
 ## Local loopback contract

--- a/integrations/javascript/CHANGELOG.md
+++ b/integrations/javascript/CHANGELOG.md
@@ -7,6 +7,14 @@ documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.3.0] - 2026-07-26
+
+### Added
+
 - Added a directly usable Electron privileged-host adapter plus Tauri and
   WebView2 renderer adapters and native host-routing references, all using one
   typed result/error contract, exact origin and method allowlists,

--- a/integrations/javascript/package.json
+++ b/integrations/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicdeploy/patris-export-hosts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Privileged JavaScript host contracts for Patris Export",
   "type": "commonjs",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version   = "1.2.0"
+	Version   = "1.3.0"
 	BuildDate = "unknown"
 	Commit    = "unknown"
 )


### PR DESCRIPTION
## Summary
- promotes the complete Unreleased changelog to Patris Export 1.3.0 dated 2026-07-26
- bumps the canonical Go and JavaScript host versions to 1.3.0
- keeps a fresh Unreleased section and fixes the Excel companion document to name the canonical Persian Standard and Advanced templates

Refs #218

## Local validation
- `git diff --check`
- release metadata resolves exactly to `1.3.0 / v1.3.0`
- `go test ./pkg/version` through the project CGO environment
- JavaScript host `npm test` (29/29) and `npm run check`

Issue #218 intentionally remains open, assigned, and labeled `review: pending-owner-approval` after implementation merge.