### PR TITLE
Handle empty scheduled-task stop state safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Scheduled-task stop and replacement now treat an empty verified process set
+  as a successful no-op instead of failing after the task has stopped.
 - Scheduled-task stop, restart, upgrade, uninstall, and replacement now
   terminate only the exact deployment's Patris child process, preventing an
   orphan from retaining the API port after the PowerShell parent exits.

--- a/scripts/windows/Install-PatrisExportScheduledTask.ps1
+++ b/scripts/windows/Install-PatrisExportScheduledTask.ps1
@@ -449,8 +449,12 @@ function Stop-PatrisTaskAndDeploymentProcess {
         Wait-PatrisTaskStopped -Task $Task
     }
     $afterStop = @(Get-PatrisTrackedDeploymentProcess)
+    $identityCandidates = @($beforeStop + $afterStop)
+    if ($identityCandidates.Count -eq 0) {
+        return @()
+    }
     $managedProcesses = @(
-        Merge-PatrisProcessIdentity -Identity @($beforeStop + $afterStop)
+        Merge-PatrisProcessIdentity -Identity $identityCandidates
     )
     Stop-PatrisDeploymentProcess -Identity $managedProcesses
     return $managedProcesses

--- a/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
+++ b/scripts/windows/Test-ScheduledTaskEnvironmentBridge.ps1
@@ -154,6 +154,11 @@ public static class EnvironmentProbe
         -DeploymentDirectory $missingPayloadRoot `
         -TaskName ("PatrisExportMissing-" + [guid]::NewGuid().ToString("N")) `
         -TaskPath "\"
+    & $removalHelper `
+        -Action Stop `
+        -DeploymentDirectory $missingPayloadRoot `
+        -TaskName ("PatrisExportMissing-" + [guid]::NewGuid().ToString("N")) `
+        -TaskPath "\"
 
     @'
 using System.Threading;


### PR DESCRIPTION
## Summary
- treats an empty verified scheduled-task process set as a successful no-op instead of calling mandatory identity helpers with an empty array
- adds the missing-task Stop regression to the full Windows lifecycle/environment bridge test
- records the fix in the unreleased v1.3.0 changelog before retagging

Refs #216
Refs #218

## Live reproduction
During the pre-v1.3.0 deployment probe, the existing older custom task wrapper had no v2 state file. `Stop-PatrisTaskAndDeploymentProcess` stopped the task, then failed binding `Merge-PatrisProcessIdentity -Identity @()`. The old child remained alive because the custom wrapper is intentionally not guessed as an owned process. No release was published; the tag run was cancelled and the unpublished tag removed.

## Validation
- PowerShell 5.1 parser: PASS
- `Test-ScheduledTaskEnvironmentBridge.ps1`: PASS, including missing task/state Stop
- `git diff --check`: PASS

Issues #216 and #218 intentionally remain open, assigned, and pending final owner approval.