### PR TITLE
Cancel queued canonical pricing work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Canonical pricing cache fills now use context-aware serialization, so a
+  request waiting behind a slow projection returns at its own deadline instead
+  of inheriting the earlier request's runtime. Startup also skips the
+  canonical projection when initial delivery is disabled and bounds enabled
+  initial projections to the canonical request ceiling.
+
 ## [1.3.0] - 2026-07-26
 
 ### Added

--- a/docs/CANONICAL-PRODUCT-SYNC.md
+++ b/docs/CANONICAL-PRODUCT-SYNC.md
@@ -191,6 +191,14 @@ so the configured pricing phase retains an 85-second hard request ceiling.
 For a 939-Code projection, the default settings issue two 500-or-smaller pages
 concurrently instead of waiting for them sequentially.
 
+Pricing catalog and assignment-prefetch cache fills are serialized with
+context-aware gates. A request waiting behind another projection stops at its
+own cancellation or deadline and does not start another remote page after that
+deadline. Initial outbound delivery materializes a canonical snapshot only
+when both `send_updates.enabled` and `send_updates.initial` are true. When
+enabled, that background projection uses the same canonical request ceiling;
+disabling initial delivery therefore avoids a startup pricing read entirely.
+
 Transport completion is separate from catalog completeness. Digitalogic must
 still assign a shipping method to the intended product rows and configure a
 global or product-specific percentage markup before those rows can expose a

--- a/pkg/pricingcatalog/http.go
+++ b/pkg/pricingcatalog/http.go
@@ -126,6 +126,36 @@ type remoteStatusError struct {
 	status int
 }
 
+// contextGate serializes remote cache fills without making a queued caller
+// outlive its own cancellation or deadline. A sync.Mutex cannot be abandoned
+// while Lock is waiting, which allowed one slow pricing projection to hold
+// later canonical requests past their documented request ceiling.
+type contextGate struct {
+	ready chan struct{}
+}
+
+func newContextGate() *contextGate {
+	gate := &contextGate{ready: make(chan struct{}, 1)}
+	gate.ready <- struct{}{}
+	return gate
+}
+
+func (gate *contextGate) lock(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-gate.ready:
+		return nil
+	}
+}
+
+func (gate *contextGate) unlock() {
+	gate.ready <- struct{}{}
+}
+
 func (e *remoteStatusError) Error() string {
 	return fmt.Sprintf("HTTP status %d", e.status)
 }
@@ -202,17 +232,17 @@ type httpProvider struct {
 	freshFor time.Duration
 	maxStale time.Duration
 
-	mu             sync.Mutex
-	catalogFetchMu sync.Mutex
-	prefetchMu     sync.Mutex
-	catalog        *catalogSnapshot
-	catalogFailure time.Time
-	batchFailure   *prefetchDiagnostic
-	assignments    map[string]*list.Element
-	diagnostics    map[string]*list.Element
-	lru            *list.List
-	diagnosticLRU  *list.List
-	configError    string
+	mu               sync.Mutex
+	catalogFetchGate *contextGate
+	prefetchGate     *contextGate
+	catalog          *catalogSnapshot
+	catalogFailure   time.Time
+	batchFailure     *prefetchDiagnostic
+	assignments      map[string]*list.Element
+	diagnostics      map[string]*list.Element
+	lru              *list.List
+	diagnosticLRU    *list.List
+	configError      string
 }
 
 func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time.Time) *httpProvider {
@@ -229,15 +259,17 @@ func newHTTPProvider(cfg DigitalogicConfig, client *http.Client, now func() time
 		}
 	}
 	provider := &httpProvider{
-		config:        normalized,
-		client:        client,
-		now:           now,
-		freshFor:      parseDuration(normalized.FreshFor, defaultFreshFor),
-		maxStale:      parseDuration(normalized.MaxStale, defaultMaxStale),
-		assignments:   make(map[string]*list.Element),
-		diagnostics:   make(map[string]*list.Element),
-		lru:           list.New(),
-		diagnosticLRU: list.New(),
+		config:           normalized,
+		client:           client,
+		now:              now,
+		freshFor:         parseDuration(normalized.FreshFor, defaultFreshFor),
+		maxStale:         parseDuration(normalized.MaxStale, defaultMaxStale),
+		catalogFetchGate: newContextGate(),
+		prefetchGate:     newContextGate(),
+		assignments:      make(map[string]*list.Element),
+		diagnostics:      make(map[string]*list.Element),
+		lru:              list.New(),
+		diagnosticLRU:    list.New(),
 	}
 	provider.configError = validateBaseURL(normalized.BaseURL)
 	if provider.configError == "" {
@@ -274,8 +306,16 @@ func (p *httpProvider) Prefetch(ctx context.Context, codes []string) Provider {
 	if p.configError != "" || len(codes) == 0 {
 		return p
 	}
-	p.prefetchMu.Lock()
-	defer p.prefetchMu.Unlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := p.prefetchGate.lock(ctx); err != nil {
+		return p
+	}
+	defer p.prefetchGate.unlock()
+	if err := ctx.Err(); err != nil {
+		return p
+	}
 	if catalog, _, _ := p.resolveCatalog(ctx); catalog == nil {
 		return p
 	}
@@ -533,6 +573,9 @@ func (p *httpProvider) resolve(ctx context.Context, code string, run *prefetchRu
 }
 
 func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, string, []string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	now := p.now().UTC()
 	p.mu.Lock()
 	cached := p.catalog
@@ -551,8 +594,13 @@ func (p *httpProvider) resolveCatalog(ctx context.Context) (*catalogSnapshot, st
 		return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
 	}
 	p.mu.Unlock()
-	p.catalogFetchMu.Lock()
-	defer p.catalogFetchMu.Unlock()
+	if err := p.catalogFetchGate.lock(ctx); err != nil {
+		return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
+	}
+	defer p.catalogFetchGate.unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, "unavailable", []string{"pricing_catalog_fetch_failed"}
+	}
 
 	// Another resolver may have refreshed the catalog while this caller waited.
 	now = p.now().UTC()

--- a/pkg/pricingcatalog/prefetch_concurrency_test.go
+++ b/pkg/pricingcatalog/prefetch_concurrency_test.go
@@ -3,6 +3,7 @@ package pricingcatalog
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -229,6 +230,155 @@ func TestHTTPProviderConcurrentPrefetchHonorsCallerCancellation(t *testing.T) {
 	provider.mu.Unlock()
 	if committed != 0 {
 		t.Fatalf("caller-canceled prefetch committed %d assignments", committed)
+	}
+}
+
+func TestHTTPProviderQueuedPrefetchHonorsCallerDeadline(t *testing.T) {
+	firstBatchStarted := make(chan struct{})
+	releaseFirstBatch := make(chan struct{})
+	firstPrefetchDone := make(chan struct{})
+	var batchRequests atomic.Int32
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseFirstBatch) })
+
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		recorder := httptest.NewRecorder()
+		if r.URL.Path == "/integration/catalog" {
+			writeConcurrentPricingCatalog(recorder)
+			response := recorder.Result()
+			response.Request = r
+			return response, nil
+		}
+		if r.URL.Path != "/integration/pricing-assignments/batch" {
+			http.NotFound(recorder, r)
+			response := recorder.Result()
+			response.Request = r
+			return response, nil
+		}
+
+		var request struct {
+			Codes []string `json:"codes"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			return nil, err
+		}
+		if batchRequests.Add(1) == 1 {
+			startedOnce.Do(func() { close(firstBatchStarted) })
+			select {
+			case <-releaseFirstBatch:
+			case <-r.Context().Done():
+				return nil, r.Context().Err()
+			}
+		}
+		writeConcurrentAssignmentPage(recorder, request.Codes)
+		response := recorder.Result()
+		response.Request = r
+		return response, nil
+	})}
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: "https://digitalogic.example", BatchSize: 1, Timeout: "2s",
+	}, client, time.Now)
+	go func() {
+		defer close(firstPrefetchDone)
+		provider.Prefetch(context.Background(), []string{"A"})
+	}()
+	select {
+	case <-firstBatchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first pricing prefetch did not reach the batch transport")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	provider.Prefetch(ctx, []string{"B"})
+	if elapsed := time.Since(startedAt); elapsed > 250*time.Millisecond {
+		t.Fatalf("queued pricing prefetch outlived caller deadline: %s", elapsed)
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("queued pricing prefetch context error = %v, want deadline exceeded", ctx.Err())
+	}
+	if got := batchRequests.Load(); got != 1 {
+		t.Fatalf("deadline-expired queued prefetch started %d batch requests, want one existing request", got)
+	}
+
+	releaseOnce.Do(func() { close(releaseFirstBatch) })
+	select {
+	case <-firstPrefetchDone:
+	case <-time.After(time.Second):
+		t.Fatal("first pricing prefetch did not finish after release")
+	}
+}
+
+func TestHTTPProviderQueuedCatalogFetchHonorsCallerDeadline(t *testing.T) {
+	firstCatalogStarted := make(chan struct{})
+	releaseFirstCatalog := make(chan struct{})
+	firstResolveDone := make(chan struct{})
+	var catalogRequests atomic.Int32
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseFirstCatalog) })
+
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		recorder := httptest.NewRecorder()
+		switch r.URL.Path {
+		case "/integration/catalog":
+			if catalogRequests.Add(1) == 1 {
+				startedOnce.Do(func() { close(firstCatalogStarted) })
+				select {
+				case <-releaseFirstCatalog:
+				case <-r.Context().Done():
+					return nil, r.Context().Err()
+				}
+			}
+			writeConcurrentPricingCatalog(recorder)
+		case "/integration/products/by-code/A/pricing":
+			fmt.Fprint(recorder, `{"data":{"code":"A","shipping_method_id":"air","profit_percent":"30","profit_percent_source":"global_default","pricing_warnings":[]}}`)
+		default:
+			http.NotFound(recorder, r)
+		}
+		response := recorder.Result()
+		response.Request = r
+		return response, nil
+	})}
+
+	provider := newHTTPProvider(DigitalogicConfig{
+		BaseURL: "https://digitalogic.example", Timeout: "2s",
+	}, client, time.Now)
+	go func() {
+		defer close(firstResolveDone)
+		provider.Resolve(context.Background(), "A")
+	}()
+	select {
+	case <-firstCatalogStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first catalog fetch did not reach the transport")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	resolution := provider.Resolve(ctx, "B")
+	if elapsed := time.Since(startedAt); elapsed > 250*time.Millisecond {
+		t.Fatalf("queued catalog fetch outlived caller deadline: %s", elapsed)
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("queued catalog fetch context error = %v, want deadline exceeded", ctx.Err())
+	}
+	if resolution.CatalogStatus != "unavailable" || !contains(resolution.Warnings, "pricing_catalog_fetch_failed") {
+		t.Fatalf("queued catalog resolution did not fail closed: %+v", resolution)
+	}
+	if got := catalogRequests.Load(); got != 1 {
+		t.Fatalf("deadline-expired queued catalog fetch started %d requests, want one existing request", got)
+	}
+
+	releaseOnce.Do(func() { close(releaseFirstCatalog) })
+	select {
+	case <-firstResolveDone:
+	case <-time.After(time.Second):
+		t.Fatal("first catalog resolution did not finish after release")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1582,9 +1582,13 @@ func (s *Server) broadcastUpdate() {
 }
 
 func (s *Server) dispatchInitialUpdate(ctx context.Context) {
+	cfg := s.Config().SendUpdates
+	if !cfg.Enabled || !cfg.Initial {
+		return
+	}
 	result, err := s.RecordResultContext(ctx)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return
 		}
 		log.Printf("Failed to prepare initial send update payload: %v", err)
@@ -1603,10 +1607,16 @@ func (s *Server) dispatchInitialUpdate(ctx context.Context) {
 }
 
 func (s *Server) dispatchInitialUpdateAsync() {
+	cfg := s.Config()
+	if !cfg.SendUpdates.Enabled || !cfg.SendUpdates.Initial {
+		return
+	}
 	s.backgroundWG.Add(1)
 	go func() {
 		defer s.backgroundWG.Done()
-		s.dispatchInitialUpdate(s.backgroundCtx)
+		ctx, cancel := context.WithTimeout(s.backgroundCtx, canonicalRequestTimeout(cfg))
+		defer cancel()
+		s.dispatchInitialUpdate(ctx)
 	}()
 }
 

--- a/pkg/server/startup_timeout_test.go
+++ b/pkg/server/startup_timeout_test.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +20,24 @@ import (
 type canonicalProjectionTestSource struct {
 	path string
 	rows []map[string]interface{}
+}
+
+type blockingCanonicalPricingProvider struct {
+	started      chan struct{}
+	canceled     chan struct{}
+	startedOnce  sync.Once
+	canceledOnce sync.Once
+}
+
+func (provider *blockingCanonicalPricingProvider) Prefetch(ctx context.Context, _ []string) pricingcatalog.Provider {
+	provider.startedOnce.Do(func() { close(provider.started) })
+	<-ctx.Done()
+	provider.canceledOnce.Do(func() { close(provider.canceled) })
+	return provider
+}
+
+func (*blockingCanonicalPricingProvider) Resolve(context.Context, string) pricingcatalog.Resolution {
+	return pricingcatalog.Resolution{}
 }
 
 func (source *canonicalProjectionTestSource) GetRecords() ([]map[string]interface{}, error) {
@@ -65,7 +85,7 @@ func TestStartWatchingDoesNotWaitForInitialDigitalogicProjection(t *testing.T) {
 	defer remote.Close()
 	defer releaseOnce.Do(func() { close(releaseBatch) })
 
-	srv := newCanonicalProjectionTestServer(t, remote.URL, "5s")
+	srv := newCanonicalProjectionTestServer(t, remote.URL, "5s", true, true)
 	startedAt := time.Now()
 	if err := srv.StartWatching(0); err != nil {
 		t.Fatalf("start watcher: %v", err)
@@ -97,7 +117,87 @@ func TestStartWatchingDoesNotWaitForInitialDigitalogicProjection(t *testing.T) {
 	releaseOnce.Do(func() { close(releaseBatch) })
 }
 
-func newCanonicalProjectionTestServer(t *testing.T, baseURL, timeout string) *Server {
+func TestStartWatchingSkipsDisabledInitialProjection(t *testing.T) {
+	tests := []struct {
+		name        string
+		sendEnabled bool
+		sendInitial bool
+	}{
+		{name: "updates disabled", sendEnabled: false, sendInitial: true},
+		{name: "initial delivery disabled", sendEnabled: true, sendInitial: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				http.Error(w, "initial projection should not run", http.StatusInternalServerError)
+			}))
+			defer remote.Close()
+
+			srv := newCanonicalProjectionTestServer(
+				t, remote.URL, "5s", test.sendEnabled, test.sendInitial,
+			)
+			if err := srv.StartWatching(0); err != nil {
+				t.Fatalf("start watcher: %v", err)
+			}
+			time.Sleep(100 * time.Millisecond)
+			if got := requests.Load(); got != 0 {
+				t.Fatalf("disabled initial delivery issued %d pricing requests", got)
+			}
+			if err := srv.Close(); err != nil {
+				t.Fatalf("close server: %v", err)
+			}
+		})
+	}
+}
+
+func TestInitialProjectionUsesCanonicalRequestDeadline(t *testing.T) {
+	srv := newCanonicalProjectionTestServer(
+		t, "https://digitalogic.example", "100ms", true, true,
+	)
+	provider := &blockingCanonicalPricingProvider{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+	}
+	cfg := srv.Config()
+	material, err := json.Marshal(cfg.Canonical.Pricing)
+	if err != nil {
+		t.Fatalf("marshal pricing config key: %v", err)
+	}
+	srv.catalogProviderMu.Lock()
+	srv.catalogProvider = provider
+	srv.catalogProviderKey = string(material)
+	srv.catalogProviderMu.Unlock()
+
+	startedAt := time.Now()
+	if err := srv.StartWatching(0); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		t.Fatal("enabled initial projection did not start")
+	}
+	select {
+	case <-provider.canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background initial projection outlived the canonical request ceiling")
+	}
+	if elapsed := time.Since(startedAt); elapsed > 1500*time.Millisecond {
+		t.Fatalf("background initial projection cancellation took %s, want at most 1.5s", elapsed)
+	}
+	srv.backgroundWG.Wait()
+	if err := srv.Close(); err != nil {
+		t.Fatalf("close server: %v", err)
+	}
+}
+
+func newCanonicalProjectionTestServer(
+	t *testing.T,
+	baseURL, timeout string,
+	sendEnabled, sendInitial bool,
+) *Server {
 	t.Helper()
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.json")
@@ -114,6 +214,8 @@ func newCanonicalProjectionTestServer(t *testing.T, baseURL, timeout string) *Se
 			Timeout:   timeout,
 		},
 	}
+	cfg.SendUpdates.Enabled = sendEnabled
+	cfg.SendUpdates.Initial = sendInitial
 	if err := manager.Replace(cfg); err != nil {
 		t.Fatalf("store test config: %v", err)
 	}


### PR DESCRIPTION
## What changed
- skip initial canonical/pricing materialization unless outbound updates and initial delivery are both enabled
- bound enabled background initial projections to the canonical request ceiling
- replace non-cancellable pricing prefetch/catalog-fetch mutex waits with context-aware serialization gates
- document the lifecycle and add deterministic queue/deadline regression coverage

## Root cause
The initial-delivery flag was checked only after a complete canonical snapshot had been built, so a disabled initial delivery still performed and discarded a full external-pricing projection. Pricing cache fills were also serialized with plain mutexes; a caller whose context expired while queued could not return until the current holder released the lock. Together these allowed later `/api/product-sync` requests to exceed their own request ceiling.

## Validation
- focused queue/startup tests, repeated 10 times
- `go test ./... -count=1`
- focused `go test -race`
- `go vet ./...`
- Web UI build and 74/74 Node tests
- `git diff --check`

Refs #153