### PR TITLE
fix(excel): complete event-driven native pricing flow

### DIFF
--- a/docs/PRICING-SYNC-EVENTS.md
+++ b/docs/PRICING-SYNC-EVENTS.md
@@ -36,6 +36,19 @@ resolves that credential server-side from its configured environment variable.
    duplicate key, unsafe warning, or stale event, retain the previous committed
    workbook generation byte-for-byte.
 
+The companion obtains a snapshot from the protected remote bulk contract: one
+revision read, one build start, one authenticated terminal-event wait when the
+build is cold, and one immutable payload fetch. It does not assemble production
+snapshots by paging the legacy remote `/state` route, and it does not poll a
+remote build-status route. A terminal-event cursor is acknowledged only after
+the generation-fenced local terminal hub retains the event for its waiter.
+
+`max_age_seconds: 0` without `expected_state_revision` deliberately requests a
+new verification/build. Exact-revision reuse is allowed only when the requested
+composite revision matches the cached snapshot and the authenticated upstream
+event bridge still confirms that source, composite revision, and catalog
+revision. Positive `max_age_seconds` remains the separate bounded-age policy.
+
 The start document exposes both event URLs:
 
 - `events_url: /api/pricing-sync/events` is the lasting semantic stream.
@@ -112,9 +125,10 @@ source/state identity.
 ## Upstream WordPress delivery status
 
 `pkg/server/excel_pricing_events_client.go` implements the authenticated
-`digitalogic.pricing.v1` WordPress WebSocket consumer and conditional composite
-revision validation. Its server lifecycle/opt-in must remain disabled until the
-matching WordPress event endpoint is released. At the time this contract was
-written, that endpoint existed only in a held local WordPress draft and was not
-deployed; therefore WooCommerce-origin automatic refresh is not yet a live
-end-to-end capability.
+`digitalogic.pricing.v1` WordPress WebSocket consumer, conditional composite
+revision validation, and the `pricing.snapshot.build.terminal` callback used by
+the remote bulk waiter. The server wiring is active only for a valid protected
+remote configuration. This source contract does not prove that the matching
+WordPress terminal-event publisher is deployed or enabled; that external
+activation must be independently verified before claiming cold remote snapshot
+completion or WooCommerce-origin automatic refresh end to end.

--- a/docs/examples/vba/ProductCatalogSync.bas
+++ b/docs/examples/vba/ProductCatalogSync.bas
@@ -76,6 +76,7 @@ Private Const LOOPBACK_PREFIX As String = "http://127.0.0.1:18080/"
 Private Const SEARCH_BUTTON_SHAPE As String = "ProductSearchButton"
 Private Const DEFAULT_PERSIAN_FONT As String = "Yekan Bakh"
 Private Const DEFAULT_LATIN_FONT As String = "Segoe UI"
+Private Const DEFAULT_FANUM_FONT As String = "Yekan Bakh FaNum"
 Private Const RECONCILED_COLUMN_KEYS As String = _
     "sync_key,reconciliation_status,patris_code,woocommerce_id,parent_id," & _
     "product_type,publication_status,name,part_number,sku,categories," & _
@@ -104,6 +105,13 @@ Private mLastApplyRequestID As String
 Private mProposalSyncActive As Boolean
 Private mLastRefreshSucceeded As Boolean
 Private mSaveFlowActive As Boolean
+Private mSaveRenameSchedulesSuspended As Boolean
+Private mSaveRenameRefreshPending As Boolean
+Private mSaveRenameAsyncPending As Boolean
+Private mSaveRenamePreviewPending As Boolean
+Private mSaveRenameEventRefreshPending As Boolean
+Private mSaveRenameSseReconnectPending As Boolean
+Private mSaveRenameSseRenewSession As Boolean
 Private mSearchQuery As String
 Private mSearchCurrentRow As Long
 Private mPricingCSRFToken As String
@@ -124,6 +132,7 @@ Private mRequiredSnapshotStateRevision As String
 Private mRefreshCancelRequested As Boolean
 Private mRefreshCancelHotkeyRegistered As Boolean
 Private mRefreshScheduled As Boolean
+Private mRefreshScheduleFailed As Boolean
 Private mScheduledRefreshTime As Date
 Private mPricingPreviewQueued As Boolean
 Private mPricingPreviewScheduled As Boolean
@@ -140,6 +149,10 @@ Private mSseSessionRequest As AsyncWinHttpRequest
 Private mSseParser As PricingSseParser
 Private mAsyncDispatchPending As Object
 Private mAsyncDispatchActive As Boolean
+Private mAsyncDispatchScheduled As Boolean
+Private mAsyncDispatchTime As Date
+Private mAsyncDispatchErrorNumber As Long
+Private mAsyncDispatchErrorDescription As String
 Private mAsyncTokenCounter As Long
 Private mOperationKind As String
 Private mOperationStage As String
@@ -203,6 +216,8 @@ Private mSseRefreshRequired As Boolean
 Private mEventRefreshScheduled As Boolean
 Private mEventRefreshTime As Date
 Private mWorkbookClosing As Boolean
+Private mResumeRefreshAfterCancelledClose As Boolean
+Private mCatalogCommitInProgress As Boolean
 Private mLastOperationName As String
 Private mLastOperationSucceeded As Boolean
 Private mLastOperationError As String
@@ -377,8 +392,10 @@ Public Sub HandleWorkbookBeforeSave(ByVal saveAsUI As Boolean, _
         BeginWorkbookSaveTiming
         mSaveFlowActive = True
         On Error GoTo SaveFailed
+        SuspendQualifiedSchedulesForSaveAs
         ThisWorkbook.SaveAs Filename:=outputPath, _
             FileFormat:=xlOpenXMLWorkbookMacroEnabled
+        ResumeQualifiedSchedulesAfterSaveAs
         mSaveFlowActive = False
     End If
     Exit Sub
@@ -386,6 +403,9 @@ Public Sub HandleWorkbookBeforeSave(ByVal saveAsUI As Boolean, _
 SaveFailed:
     savedErrorNumber = Err.Number
     savedErrorDescription = Err.Description
+    On Error Resume Next
+    ResumeQualifiedSchedulesAfterSaveAs
+    On Error GoTo 0
     mSaveFlowActive = False
     FinishWorkbookSaveTiming False
     On Error Resume Next
@@ -481,13 +501,81 @@ Private Sub RemoveMacroOnlyUI(ByVal book As Workbook)
     book.Worksheets(1).Range("B3:K3").ClearContents
     book.Worksheets(1).ListObjects(PRODUCTS_TABLE). _
         DataBodyRange.FormatConditions.Delete
+    book.Worksheets(3).Range("A44:F44").ClearContents
+    book.Worksheets(3).Range("B44").Validation.Delete
     book.Names("ProductSearchQuery").Delete
     book.Names("SelectedProductRow").Delete
     book.Names("ProjectedPricePreviewRow").Delete
+    book.Names("PriceDisplayFaNum").Delete
+    On Error GoTo 0
+End Sub
+
+Private Sub SuspendQualifiedSchedulesForSaveAs()
+    If mSaveRenameSchedulesSuspended Then Exit Sub
+    mSaveRenameRefreshPending = mRefreshScheduled
+    mSaveRenameAsyncPending = mAsyncDispatchScheduled
+    If Not mAsyncDispatchPending Is Nothing Then
+        If mAsyncDispatchPending.Count > 0 Then _
+            mSaveRenameAsyncPending = True
+    End If
+    mSaveRenamePreviewPending = mPricingPreviewScheduled
+    mSaveRenameEventRefreshPending = mEventRefreshScheduled
+    mSaveRenameSseReconnectPending = mSseReconnectScheduled
+    mSaveRenameSseRenewSession = mSseRenewSessionBeforeReconnect
+    mSaveRenameSchedulesSuspended = True
+
+    CancelScheduledRefresh
+    UnscheduleQueuedAsyncDispatch
+    CancelScheduledPricingPreview False
+    CancelEventDrivenRefresh
+    If mSseReconnectScheduled Then
+        On Error Resume Next
+        Application.OnTime EarliestTime:=mSseReconnectTime, _
+            Procedure:=QualifiedWorkbookMacro("RunSseReconnect"), _
+            Schedule:=False
+        On Error GoTo 0
+        mSseReconnectScheduled = False
+    End If
+End Sub
+
+Private Sub ResumeQualifiedSchedulesAfterSaveAs()
+    Dim refreshPending As Boolean
+    Dim asyncPending As Boolean
+    Dim previewPending As Boolean
+    Dim eventRefreshPending As Boolean
+    Dim sseReconnectPending As Boolean
+    Dim sseRenewSession As Boolean
+
+    If Not mSaveRenameSchedulesSuspended Then Exit Sub
+    refreshPending = mSaveRenameRefreshPending
+    asyncPending = mSaveRenameAsyncPending
+    previewPending = mSaveRenamePreviewPending
+    eventRefreshPending = mSaveRenameEventRefreshPending
+    sseReconnectPending = mSaveRenameSseReconnectPending
+    sseRenewSession = mSaveRenameSseRenewSession
+    If Not mAsyncDispatchPending Is Nothing Then
+        If mAsyncDispatchPending.Count > 0 Then asyncPending = True
+    End If
+    mSaveRenameRefreshPending = False
+    mSaveRenameAsyncPending = False
+    mSaveRenamePreviewPending = False
+    mSaveRenameEventRefreshPending = False
+    mSaveRenameSseReconnectPending = False
+    mSaveRenameSseRenewSession = False
+    mSaveRenameSchedulesSuspended = False
+    If mWorkbookClosing Then Exit Sub
+
+    On Error Resume Next
+    If refreshPending Then ScheduleRefreshOnOpen
+    If asyncPending Then ScheduleQueuedAsyncDispatch
+    If previewPending Then SchedulePricingPreview
+    If eventRefreshPending Then ScheduleEventDrivenRefresh
+    If sseReconnectPending Then ScheduleSseReconnect sseRenewSession
     On Error GoTo 0
 End Sub
 
 Public Sub RefreshAllData(Optional ByVal silent As Boolean = False)
+    ResumeAfterCancelledClose False
     If mRefreshInProgress Then Exit Sub
     If mPricingActionInProgress And Not mInternalPricingRefresh Then Exit Sub
     BeginRefreshPipeline silent, False
@@ -578,6 +666,7 @@ Private Sub CommitRefreshSnapshot(ByVal reconciledRows As Object, _
 
     ' Network callbacks have already validated the complete immutable payload.
     ' Freeze Excel only for this short, rollback-protected atomic commit.
+    mCatalogCommitInProgress = True
     ReleaseSearchEnterHotkey
     Application.ScreenUpdating = False
     Application.EnableEvents = False
@@ -658,6 +747,7 @@ CommitExit:
         Application.EnableEvents = previousEnableEvents
         Application.ScreenUpdating = previousScreenUpdating
     End If
+    mCatalogCommitInProgress = False
     RefreshSearchEnterHotkey
     On Error GoTo 0
     If savedErrorNumber <> 0 Then
@@ -687,6 +777,11 @@ End Sub
 
 Public Sub ScheduleRefreshOnOpen()
     On Error GoTo ScheduleFailed
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenameRefreshPending = True
+        Exit Sub
+    End If
+    mRefreshScheduleFailed = False
     If Trim$(CStr(ConfigSheet().Range("B5").Value2)) = U("062806440647") Then
         CancelScheduledRefresh
         mScheduledRefreshTime = Now + _
@@ -696,16 +791,19 @@ Public Sub ScheduleRefreshOnOpen()
             EarliestTime:=mScheduledRefreshTime, _
             Procedure:=QualifiedWorkbookMacro("RunScheduledRefresh"), _
             Schedule:=True
+        mRefreshScheduleFailed = False
     End If
     Exit Sub
 
 ScheduleFailed:
     mRefreshScheduled = False
+    mRefreshScheduleFailed = True
     Err.Clear
 End Sub
 
 Public Sub RunScheduledRefresh()
     mRefreshScheduled = False
+    mRefreshScheduleFailed = False
     If mRefreshInProgress Then Exit Sub
     If Trim$(CStr(ConfigSheet().Range("B5").Value2)) <> _
        U("062806440647") Then Exit Sub
@@ -779,11 +877,20 @@ Public Sub CancelActivePricingOperations( _
         Optional ByVal workbookIsClosing As Boolean = False)
     Dim cancellationMessage As String
 
-    If workbookIsClosing Then mWorkbookClosing = True
+    If workbookIsClosing Then
+        mResumeRefreshAfterCancelledClose = _
+            (mResumeRefreshAfterCancelledClose Or _
+             Len(mOperationKind) > 0 Or mRefreshScheduled Or _
+             mEventRefreshScheduled Or mSseReconnectScheduled Or _
+             Len(mSseEventsURL) > 0 Or Not mSseRequest Is Nothing Or _
+             Not mSseSessionRequest Is Nothing)
+        mWorkbookClosing = True
+        CancelQueuedAsyncDispatch
+    End If
     CancelScheduledRefresh
     CancelScheduledPricingPreview True
     CancelEventDrivenRefresh
-    CancelSseReconnect
+    If workbookIsClosing Then CancelSseReconnect
     mOperationCancelRequested = True
     mRefreshCancelRequested = True
     cancellationMessage = T("sync_retry")
@@ -793,7 +900,11 @@ Public Sub CancelActivePricingOperations( _
         BeginBestEffortSnapshotCancel mSnapshotCancelURL, mPricingCSRFToken
     End If
     If Not mOperationRequest Is Nothing Then mOperationRequest.Abort
-    StopSseListener True
+    If workbookIsClosing And Not mCancelRequest Is Nothing Then
+        mCancelRequest.Abort
+        Set mCancelRequest = Nothing
+    End If
+    If workbookIsClosing Then StopSseListener True
     On Error GoTo 0
 
     If Len(mOperationKind) > 0 Then
@@ -806,6 +917,24 @@ Public Sub CancelActivePricingOperations( _
         ReleaseRefreshCancelHotkey
         RestoreOperationCancelKey
         RestoreOperationStatusBar
+    End If
+End Sub
+
+Public Sub ResumeAfterCancelledClose( _
+        Optional ByVal scheduleRefresh As Boolean = True)
+    Dim shouldRefresh As Boolean
+
+    If Not mWorkbookClosing Then Exit Sub
+    shouldRefresh = mResumeRefreshAfterCancelledClose
+    mResumeRefreshAfterCancelledClose = False
+    mWorkbookClosing = False
+    mOperationCancelRequested = False
+    mRefreshCancelRequested = False
+    mSseManualStop = False
+    RegisterSearchHotkey
+    If shouldRefresh And scheduleRefresh Then
+        mForceFreshSnapshot = True
+        ScheduleEventDrivenRefresh
     End If
 End Sub
 
@@ -898,24 +1027,112 @@ Private Function NextAsyncToken() As Long
 End Function
 
 Public Sub QueueAsyncDispatch(ByVal requestToken As Long)
-    Dim pendingToken As Long
-    Dim pendingKey As Variant
-
-    If requestToken < 1 Then Exit Sub
+    If requestToken < 1 Or mWorkbookClosing Then Exit Sub
     If mAsyncDispatchPending Is Nothing Then
         Set mAsyncDispatchPending = CreateObject("Scripting.Dictionary")
         mAsyncDispatchPending.CompareMode = vbBinaryCompare
     End If
+    mAsyncDispatchPending(CStr(requestToken)) = True
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenameAsyncPending = True
+        Exit Sub
+    End If
+    If mAsyncDispatchActive Or mAsyncDispatchScheduled Then Exit Sub
+
+    ScheduleQueuedAsyncDispatch
+End Sub
+
+Private Sub ScheduleQueuedAsyncDispatch()
+    If mWorkbookClosing Or mAsyncDispatchScheduled Then Exit Sub
+    If mAsyncDispatchPending Is Nothing Then Exit Sub
+    If mAsyncDispatchPending.Count = 0 Then Exit Sub
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenameAsyncPending = True
+        Exit Sub
+    End If
+
+    On Error GoTo DispatchFailed
+    mAsyncDispatchTime = Now + TimeSerial(0, 0, 1)
+    mAsyncDispatchScheduled = True
+    Application.OnTime EarliestTime:=mAsyncDispatchTime, _
+        Procedure:=QualifiedWorkbookMacro("DispatchQueuedAsyncRequests"), _
+        Schedule:=True
+    Exit Sub
+
+DispatchFailed:
+    mAsyncDispatchErrorNumber = Err.Number
+    mAsyncDispatchErrorDescription = Err.Description
+    mAsyncDispatchScheduled = False
+    Err.Clear
+End Sub
+
+Public Sub KickQueuedAsyncDispatch()
+    Dim hasPendingDispatch As Boolean
+
+    If mWorkbookClosing Or mSaveRenameSchedulesSuspended Then Exit Sub
+    If Not mAsyncDispatchPending Is Nothing Then
+        hasPendingDispatch = (mAsyncDispatchPending.Count > 0 Or _
+                              mAsyncDispatchErrorNumber <> 0)
+    End If
+
+    ' This entrypoint is called only from normal Excel workbook/input events,
+    ' never from a WinHTTP callback. It is the deterministic non-polling fault
+    ' handoff if Excel rejected the callback's one-shot OnTime request.
+    If hasPendingDispatch And Not mAsyncDispatchActive And _
+       Not mAsyncDispatchScheduled Then
+        If mAsyncDispatchErrorNumber <> 0 Then
+            DispatchQueuedAsyncRequests
+        Else
+            ScheduleQueuedAsyncDispatch
+        End If
+    End If
+
+    If Len(mOperationKind) = 0 Then
+        If mRefreshScheduleFailed Then ScheduleRefreshOnOpen
+        If mPricingPreviewQueued And Not mPricingPreviewScheduled Then _
+            SchedulePricingPreview
+        If mSseRefreshRequired And Not mEventRefreshScheduled Then _
+            ScheduleEventDrivenRefresh
+    End If
+    If Not mSseManualStop And Len(mSseEventsURL) > 0 And _
+       mSseReconnectAttempt > 0 And Not mSseReconnectScheduled And _
+       mSseRequest Is Nothing And mSseSessionRequest Is Nothing Then _
+        ScheduleSseReconnect mSseRenewSessionBeforeReconnect
+End Sub
+
+Public Sub DispatchQueuedAsyncRequests()
+    Dim pendingToken As Long
+    Dim pendingKey As Variant
+
+    mAsyncDispatchScheduled = False
+    If mWorkbookClosing Then
+        CancelQueuedAsyncDispatch
+        Exit Sub
+    End If
+    If mAsyncDispatchPending Is Nothing Then Exit Sub
     If mAsyncDispatchActive Then
-        mAsyncDispatchPending(CStr(requestToken)) = True
+        ScheduleQueuedAsyncDispatch
         Exit Sub
     End If
 
     On Error GoTo DispatchFailed
     mAsyncDispatchActive = True
-    pendingToken = requestToken
+    If mAsyncDispatchErrorNumber <> 0 Then
+        If Len(mOperationKind) > 0 Then
+            pendingToken = mAsyncDispatchErrorNumber
+            mAsyncDispatchErrorNumber = 0
+            If Not mAsyncDispatchPending Is Nothing Then _
+                mAsyncDispatchPending.RemoveAll
+            FailActiveOperation pendingToken, _
+                "ScheduleQueuedAsyncDispatch", _
+                mAsyncDispatchErrorDescription
+            mAsyncDispatchErrorDescription = vbNullString
+            GoTo DispatchExit
+        End If
+        mAsyncDispatchErrorNumber = 0
+        mAsyncDispatchErrorDescription = vbNullString
+    End If
     Do
-        DispatchAsyncRequest pendingToken
         pendingToken = 0
         If mAsyncDispatchPending.Count > 0 Then
             For Each pendingKey In mAsyncDispatchPending.Keys
@@ -924,17 +1141,40 @@ Public Sub QueueAsyncDispatch(ByVal requestToken As Long)
                 Exit For
             Next pendingKey
         End If
-    Loop While pendingToken > 0
+        If pendingToken = 0 Then Exit Do
+        DispatchAsyncRequest pendingToken
+    Loop
 
 DispatchExit:
     mAsyncDispatchActive = False
+    If Not mWorkbookClosing Then ScheduleQueuedAsyncDispatch
     Exit Sub
 
 DispatchFailed:
     mAsyncDispatchActive = False
     If Len(mOperationKind) > 0 Then
-        FailActiveOperation Err.Number, "QueueAsyncDispatch", Err.Description
+        FailActiveOperation Err.Number, "DispatchQueuedAsyncRequests", _
+            Err.Description
     End If
+End Sub
+
+Private Sub UnscheduleQueuedAsyncDispatch()
+    If mAsyncDispatchScheduled Then
+        On Error Resume Next
+        Application.OnTime EarliestTime:=mAsyncDispatchTime, _
+            Procedure:=QualifiedWorkbookMacro("DispatchQueuedAsyncRequests"), _
+            Schedule:=False
+        On Error GoTo 0
+    End If
+    mAsyncDispatchScheduled = False
+End Sub
+
+Private Sub CancelQueuedAsyncDispatch()
+    UnscheduleQueuedAsyncDispatch
+    mAsyncDispatchErrorNumber = 0
+    mAsyncDispatchErrorDescription = vbNullString
+    If Not mAsyncDispatchPending Is Nothing Then _
+        mAsyncDispatchPending.RemoveAll
 End Sub
 
 Private Sub DispatchAsyncRequest(ByVal requestToken As Long)
@@ -1077,7 +1317,7 @@ Private Sub StartFiniteRequest(ByVal methodName As String, _
         Err.Raise vbObjectError + 760, "StartFiniteRequest", _
                   T("sync_retry")
     End If
-    If pricingRequest And Not IsAllowedPricingBridgeUrl(endpoint) Then
+    If pricingRequest And Not IsAllowedPricingAuthenticatedUrl(endpoint) Then
         Err.Raise vbObjectError + 143, "StartFiniteRequest", _
                   T("bridge_missing")
     End If
@@ -1270,12 +1510,8 @@ Private Sub HandleSessionResponse(ByVal statusCode As Long, _
             mOperationStateStartedAt = PhaseTimestamp()
             BeginSnapshotStartRequest
         Case "preview"
-            EnsureSseListener PricingBaseURL() & "/events", _
-                mSnapshotJobID, csrfToken
             BeginPreviewRequest
         Case "apply"
-            EnsureSseListener PricingBaseURL() & "/events", _
-                mSnapshotJobID, csrfToken
             BeginApplyRequest
         Case Else
             Err.Raise vbObjectError + 761, "HandleSessionResponse", _
@@ -1312,8 +1548,10 @@ Private Sub HandleSnapshotStartResponse(ByVal statusCode As Long, _
         mSnapshotCompletedPages, mSnapshotTotalPages, mSnapshotRowCount
     SetSnapshotProgress mSnapshotCompletedPages, mSnapshotTotalPages, _
         mSnapshotRowCount
-    EnsureSseListener mSnapshotEventsURL, mSnapshotJobID, _
-        mPricingCSRFToken
+    ' An already-established durable listener may observe this job while the
+    ' one-shot terminal wait is active. Bind it to the new job identity now,
+    ' but do not create the first listener until the snapshot is committed.
+    mSseJobID = mSnapshotJobID
     BeginSnapshotWaitRequest
 End Sub
 
@@ -1352,6 +1590,9 @@ Private Sub HandleSnapshotPayloadResponse(ByVal statusCode As Long, _
     Dim validatedSourceRevision As String
     Dim validatedCountSignature As String
     Dim fetchedRows As Long
+    Dim committedSseEventsURL As String
+    Dim committedSseJobID As String
+    Dim committedSseCSRFToken As String
 
     RequireHTTPSuccess statusCode, responseBody, "snapshot_payload"
     responseETag = ResponseHeaderValue(responseHeaders, "ETag")
@@ -1374,6 +1615,11 @@ Private Sub HandleSnapshotPayloadResponse(ByVal statusCode As Long, _
         mSnapshotStateRevision, reconciledRows, validatedState, _
         validatedCatalog, validatedDatasetRevision, _
         validatedSourceRevision, validatedCountSignature)
+    ValidateSseListenerPrerequisites mSnapshotEventsURL, mSnapshotJobID, _
+        mPricingCSRFToken
+    committedSseEventsURL = mSnapshotEventsURL
+    committedSseJobID = mSnapshotJobID
+    committedSseCSRFToken = mPricingCSRFToken
     mOperationStateSeconds = PhaseElapsed(mOperationStateStartedAt)
     mStatePageTimingText = "snapshot=" & _
         Format$(mOperationStateSeconds, "0.000") & "s; source=" & _
@@ -1391,6 +1637,10 @@ Private Sub HandleSnapshotPayloadResponse(ByVal statusCode As Long, _
         mRequiredSnapshotStateRevision = vbNullString
     End If
     CompleteActiveOperation True
+    ' Listener failures are isolated from the already-committed snapshot. Its
+    ' first replay therefore cannot cancel or roll back the cold atomic load.
+    ArmSseListenerAfterCommit committedSseEventsURL, committedSseJobID, _
+        committedSseCSRFToken
 End Sub
 
 Private Sub HandlePreviewResponse(ByVal statusCode As Long, _
@@ -1729,6 +1979,36 @@ Private Sub EnsureSseListener(ByVal eventsURL As String, _
     StartSseConnection
 End Sub
 
+Private Sub ValidateSseListenerPrerequisites(ByVal eventsURL As String, _
+                                             ByVal jobID As String, _
+                                             ByVal csrfToken As String)
+    If SnapshotRouteURL(eventsURL) <> PricingBaseURL() & "/events" Or _
+       Len(Trim$(jobID)) = 0 Or Len(Trim$(csrfToken)) <> 43 Then
+        Err.Raise vbObjectError + 130, _
+                  "ValidateSseListenerPrerequisites", T("invalid_workbook")
+    End If
+End Sub
+
+Private Sub ArmSseListenerAfterCommit(ByVal eventsURL As String, _
+                                      ByVal jobID As String, _
+                                      ByVal csrfToken As String)
+    On Error GoTo ListenerFailed
+    EnsureSseListener eventsURL, jobID, csrfToken
+    Exit Sub
+
+ListenerFailed:
+    ' The table is already a fully validated atomic snapshot. Preserve it and
+    ' recover only the durable listener through its bounded event reconnect.
+    On Error Resume Next
+    mSseEventsURL = SnapshotRouteURL(eventsURL)
+    mSseJobID = jobID
+    mSseCSRFToken = vbNullString
+    mSseManualStop = False
+    ScheduleSseReconnect True
+    Err.Clear
+    On Error GoTo 0
+End Sub
+
 Private Sub AdoptSseSessionToken(ByVal csrfToken As String)
     csrfToken = Trim$(csrfToken)
     If Len(csrfToken) <> 43 Then
@@ -1971,6 +2251,8 @@ Private Sub HandlePricingSseEvent(ByVal eventValue As Object)
     Dim eventJobID As String
     Dim eventReason As String
     Dim currentSnapshotConfirmation As Boolean
+    Dim expectedApplyMutationEvent As Boolean
+    Dim eventStateRevision As String
     Dim verified As Boolean
     Dim stale As Boolean
     Dim alreadyForcingFreshSnapshot As Boolean
@@ -2028,6 +2310,7 @@ Private Sub HandlePricingSseEvent(ByVal eventValue As Object)
     End If
 
     eventJobID = SiteText(change, "job_id")
+    eventStateRevision = SiteText(change, "state_revision")
     verified = BooleanValue(JsonRuntime.JsonText(change, "verified"))
     stale = BooleanValue(JsonRuntime.JsonText(change, "stale"))
     currentSnapshotConfirmation = (Len(mSseJobID) > 0 And _
@@ -2038,14 +2321,31 @@ Private Sub HandlePricingSseEvent(ByVal eventValue As Object)
                 GoTo InvalidEvent
             If Not currentSnapshotConfirmation Then MarkSseRefreshRequired
 
-        Case "source_changed", "catalog_changed", _
-             "pricing_state_changed"
+        Case "source_changed", "catalog_changed"
             If Not stale Then GoTo InvalidEvent
             If Not currentSnapshotConfirmation Then MarkSseRefreshRequired
 
+        Case "pricing_state_changed"
+            If Not stale Or Not IsSHA256RevisionText(eventStateRevision) Then _
+                GoTo InvalidEvent
+            expectedApplyMutationEvent = _
+                IsExpectedApplyMutationEvent(eventStateRevision)
+            If expectedApplyMutationEvent Then
+                PreserveExpectedApplyMutationEvent
+            ElseIf Not currentSnapshotConfirmation Then
+                MarkSseRefreshRequired
+            End If
+
         Case "pricing_state_invalidated"
-            If Not stale Then GoTo InvalidEvent
-            MarkSseRefreshRequired
+            If Not stale Or Not IsSHA256RevisionText(eventStateRevision) Then _
+                GoTo InvalidEvent
+            expectedApplyMutationEvent = _
+                IsExpectedApplyMutationEvent(eventStateRevision)
+            If expectedApplyMutationEvent Then
+                PreserveExpectedApplyMutationEvent
+            Else
+                MarkSseRefreshRequired
+            End If
 
         Case Else
             GoTo InvalidEvent
@@ -2058,6 +2358,35 @@ InvalidEvent:
     mSseRefreshRequired = True
     InvalidatePricingPreview
     If Not mSseRequest Is Nothing Then mSseRequest.Abort
+End Sub
+
+Private Function IsExpectedApplyMutationEvent( _
+    ByVal eventStateRevision As String) As Boolean
+    If Not IsSHA256RevisionText(eventStateRevision) Then Exit Function
+
+    Select Case mOperationKind
+        Case "apply"
+            ' The bridge publishes the committed/verified revisions before the
+            ' apply HTTP response can reach Excel. The response remains the
+            ' authoritative transition into the exact-state refresh.
+            IsExpectedApplyMutationEvent = True
+        Case "apply_refresh"
+            IsExpectedApplyMutationEvent = _
+                (Len(mRequiredSnapshotStateRevision) > 0 And _
+                 StrComp(eventStateRevision, _
+                         mRequiredSnapshotStateRevision, _
+                         vbBinaryCompare) = 0)
+    End Select
+End Function
+
+Private Sub PreserveExpectedApplyMutationEvent()
+    mForceFreshSnapshot = True
+    InvalidatePricingPreview
+    If mOperationKind = "apply" Then
+        ' If post-apply verification fails after the remote mutation committed,
+        ' the terminal failure path must still schedule a fresh snapshot.
+        mSseRefreshRequired = True
+    End If
 End Sub
 
 Private Sub MarkSseRefreshRequired()
@@ -2164,10 +2493,16 @@ Private Sub ScheduleSseReconnect(ByVal renewSession As Boolean)
     Dim attempt As Long
 
     If renewSession Then mSseRenewSessionBeforeReconnect = True
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenameSseReconnectPending = True
+        If renewSession Then mSaveRenameSseRenewSession = True
+        Exit Sub
+    End If
     If mWorkbookClosing Or mSseManualStop Or _
        mSseReconnectScheduled Then Exit Sub
     If Not mSseRequest Is Nothing Or _
        Not mSseSessionRequest Is Nothing Then Exit Sub
+    On Error GoTo ScheduleFailed
     mSseReconnectAttempt = mSseReconnectAttempt + 1
     delaySeconds = mSseReconnectDelaySeconds
     If delaySeconds < SSE_RECONNECT_MIN_SECONDS Then _
@@ -2183,6 +2518,11 @@ Private Sub ScheduleSseReconnect(ByVal renewSession As Boolean)
     Application.OnTime EarliestTime:=mSseReconnectTime, _
         Procedure:=QualifiedWorkbookMacro("RunSseReconnect"), _
         Schedule:=True
+    Exit Sub
+
+ScheduleFailed:
+    mSseReconnectScheduled = False
+    Err.Clear
 End Sub
 
 Public Sub RunSseReconnect()
@@ -2208,16 +2548,27 @@ Private Sub CancelSseReconnect()
 End Sub
 
 Private Sub ScheduleEventDrivenRefresh()
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenameEventRefreshPending = True
+        Exit Sub
+    End If
     If mWorkbookClosing Or mEventRefreshScheduled Then Exit Sub
     If Len(mOperationKind) > 0 Then
         mSseRefreshRequired = True
         Exit Sub
     End If
+    On Error GoTo ScheduleFailed
+    mSseRefreshRequired = True
     mEventRefreshTime = Now + TimeSerial(0, 0, 1)
     mEventRefreshScheduled = True
     Application.OnTime EarliestTime:=mEventRefreshTime, _
         Procedure:=QualifiedWorkbookMacro("RunEventDrivenRefresh"), _
         Schedule:=True
+    Exit Sub
+
+ScheduleFailed:
+    mEventRefreshScheduled = False
+    Err.Clear
 End Sub
 
 Public Sub RunEventDrivenRefresh()
@@ -2242,9 +2593,14 @@ Private Sub CancelEventDrivenRefresh()
 End Sub
 
 Public Sub RegisterSearchHotkey()
+    Dim activeBook As Workbook
     Dim workbookMacro As String
     Dim nextMacro As String
 
+    If mWorkbookClosing Then Exit Sub
+    Set activeBook = Application.ActiveWorkbook
+    If activeBook Is Nothing Then Exit Sub
+    If Not activeBook Is ThisWorkbook Then Exit Sub
     workbookMacro = "'" & Replace(ThisWorkbook.Name, "'", "''") & _
         "'!ProductCatalogSync.FocusProductSearch"
     nextMacro = "'" & Replace(ThisWorkbook.Name, "'", "''") & _
@@ -2327,7 +2683,7 @@ Public Sub FocusProductSearch()
     Dim searchInput As Range
     Dim table As ListObject
 
-    If mRefreshInProgress Then Exit Sub
+    If mCatalogCommitInProgress Then Exit Sub
     On Error GoTo CleanExit
     PriceSheet().Activate
     Set searchInput = ThisWorkbook.Names("ProductSearchQuery").RefersToRange
@@ -2350,7 +2706,9 @@ Public Sub SearchProducts()
     Dim previousEnableCancelKey As XlEnableCancelKey
     Dim cancelKeyCaptured As Boolean
 
-    If mRefreshInProgress Or mSearchInProgress Then Exit Sub
+    ResumeAfterCancelledClose
+    KickQueuedAsyncDispatch
+    If mCatalogCommitInProgress Or mSearchInProgress Then Exit Sub
     On Error GoTo CleanExit
     mSearchInProgress = True
     previousEnableCancelKey = Application.EnableCancelKey
@@ -2406,7 +2764,9 @@ End Sub
 Public Sub ClearProductSearch()
     Dim table As ListObject
 
-    If mRefreshInProgress Or mSearchInProgress Then Exit Sub
+    ResumeAfterCancelledClose
+    KickQueuedAsyncDispatch
+    If mCatalogCommitInProgress Or mSearchInProgress Then Exit Sub
     On Error Resume Next
     ResetProductSearchState True
     Set table = PriceSheet().ListObjects(PRODUCTS_TABLE)
@@ -2524,7 +2884,7 @@ Public Sub HighlightSelectedProductRow(ByVal target As Range)
     Dim priceCell As Range
     Dim previousPriceCell As Range
 
-    If mRefreshInProgress Then Exit Sub
+    If mCatalogCommitInProgress Then Exit Sub
     previousEvents = Application.EnableEvents
     On Error GoTo CleanExit
     Set table = PriceSheet().ListObjects(PRODUCTS_TABLE)
@@ -2584,18 +2944,30 @@ CleanExit:
 End Sub
 
 Public Sub PreviewPricingChanges()
+    ResumeAfterCancelledClose
+    KickQueuedAsyncDispatch
     If mRefreshInProgress Or mPricingActionInProgress Then Exit Sub
     CancelScheduledPricingPreview True
     PreviewPricingChangesCore False
 End Sub
 
 Private Sub SchedulePricingPreview()
+    If mSaveRenameSchedulesSuspended Then
+        mSaveRenamePreviewPending = True
+        Exit Sub
+    End If
     If mWorkbookClosing Or mPricingPreviewScheduled Then Exit Sub
+    On Error GoTo ScheduleFailed
     mScheduledPricingPreviewTime = Now + TimeSerial(0, 0, 1)
     mPricingPreviewScheduled = True
     Application.OnTime EarliestTime:=mScheduledPricingPreviewTime, _
         Procedure:=QualifiedWorkbookMacro("RunScheduledPricingPreview"), _
         Schedule:=True
+    Exit Sub
+
+ScheduleFailed:
+    mPricingPreviewScheduled = False
+    Err.Clear
 End Sub
 
 Public Sub RunScheduledPricingPreview()
@@ -2646,6 +3018,8 @@ BeginFailed:
 End Sub
 
 Public Sub ApplyPricingChanges()
+    ResumeAfterCancelledClose
+    KickQueuedAsyncDispatch
     If mRefreshInProgress Or mPricingActionInProgress Then Exit Sub
     ApplyPricingChangesCore True, False
 End Sub
@@ -4520,13 +4894,32 @@ End Sub
 
 Public Sub ApplyPriceDisplayFontSetting()
     Dim table As ListObject
+    Dim latinFont As String
 
     On Error GoTo CleanExit
     Set table = PriceSheet().ListObjects(PRODUCTS_TABLE)
     If table.DataBodyRange Is Nothing Then Exit Sub
-    ApplyLatinFont table.ListColumns(1).DataBodyRange
+    latinFont = NamedText("LatinFont", DEFAULT_LATIN_FONT)
+    ApplyRangeFontSlots table.ListColumns(1).DataBodyRange, _
+        PriceDisplayFontName(latinFont)
 CleanExit:
 End Sub
+
+Private Function PriceDisplayFontName(ByVal latinFont As String) As String
+    Dim valid As Boolean
+    Dim useFaNum As Boolean
+
+    useFaNum = NamedYesNo("PriceDisplayFaNum", valid)
+    If Not valid Then
+        Err.Raise vbObjectError + 233, "PriceDisplayFontName", _
+                  T("font_policy_invalid")
+    End If
+    If useFaNum Then
+        PriceDisplayFontName = DEFAULT_FANUM_FONT
+    Else
+        PriceDisplayFontName = latinFont
+    End If
+End Function
 
 Private Sub ApplyPersianFont(ByVal target As Range)
     Dim fontName As String
@@ -5218,6 +5611,16 @@ Private Function IsAllowedPricingBridgeUrl(ByVal address As String) As Boolean
         InStr(1, address, "/api/pricing-sync/", vbTextCompare) > 0
 End Function
 
+Private Function IsAllowedPricingAuthenticatedUrl( _
+        ByVal address As String) As Boolean
+    If IsAllowedPricingBridgeUrl(address) Then
+        IsAllowedPricingAuthenticatedUrl = True
+        Exit Function
+    End If
+    IsAllowedPricingAuthenticatedUrl = _
+        (StrComp(Trim$(address), UniversalRefreshURL(), vbTextCompare) = 0)
+End Function
+
 Private Function IsAllowedDigitalogicUrl(ByVal address As String) As Boolean
     Dim normalized As String
 
@@ -5651,6 +6054,13 @@ Public Function ValidateFontPolicyFixturesForValidation() As Boolean
 
     ignoredMode = NormalizedFontAuditMode("invalid", valid)
     If valid Or Len(ignoredMode) <> 0 Then Exit Function
+    If NormalizedFontAuditMode( _
+           U("062A0631064506CC064500200648002006470634062F06270631"), _
+           valid) <> "RepairAndWarn" Or Not valid Then Exit Function
+    If Not NormalizedYesNo(U("062806440647"), valid) Or _
+       Not valid Then Exit Function
+    If NormalizedYesNo(U("062E06CC0631"), valid) Or _
+       Not valid Then Exit Function
     If Len(Trim$(vbNullString)) <> 0 Then Exit Function
     If FontAvailable("__PatrisExportDefinitelyMissingFont__") Then _
         Exit Function
@@ -5742,7 +6152,7 @@ Private Sub ValidateSearchLiteralRuntime()
 
     Set inputCell = ThisWorkbook.Names("ProductSearchQuery").RefersToRange
     originalValue = inputCell.Value2
-    For Each sample In Array("25.40", "12/3", "01.02", "001234", _
+    For Each sample In Array("2.4", "25.40", "12/3", "01.02", "001234", _
                              U("06F106F206F306F4"))
         inputCell.MergeArea.NumberFormat = "@"
         inputCell.Value2 = CStr(sample)
@@ -5863,10 +6273,15 @@ End Function
 Private Function NormalizedFontAuditMode(ByVal value As String, _
                                          ByRef valid As Boolean) As String
     Select Case LCase$(Trim$(value))
-        Case "off": NormalizedFontAuditMode = "Off"
-        Case "warn": NormalizedFontAuditMode = "Warn"
-        Case "repairandwarn": NormalizedFontAuditMode = "RepairAndWarn"
-        Case "strict": NormalizedFontAuditMode = "Strict"
+        Case "off", U("062E0627064506480634")
+            NormalizedFontAuditMode = "Off"
+        Case "warn", U("06470634062F06270631")
+            NormalizedFontAuditMode = "Warn"
+        Case "repairandwarn", _
+             U("062A0631064506CC064500200648002006470634062F06270631")
+            NormalizedFontAuditMode = "RepairAndWarn"
+        Case "strict", U("0633062E062A06AF06CC0631062706460647")
+            NormalizedFontAuditMode = "Strict"
         Case Else
             valid = False
             Exit Function
@@ -5883,8 +6298,8 @@ End Function
 Private Function NormalizedYesNo(ByVal value As String, _
                                  ByRef valid As Boolean) As Boolean
     Select Case LCase$(Trim$(value))
-        Case "yes": NormalizedYesNo = True
-        Case "no": NormalizedYesNo = False
+        Case "yes", U("062806440647"): NormalizedYesNo = True
+        Case "no", U("062E06CC0631"): NormalizedYesNo = False
         Case Else: valid = False: Exit Function
     End Select
     valid = True
@@ -6026,11 +6441,13 @@ Private Function AuditFixedFontMap(ByVal persianFont As String, _
     Dim sheet As Worksheet
     Dim shapeValue As Shape
     Dim columnIndex As Variant
+    Dim priceDisplayFont As String
 
     Set table = PriceSheet().ListObjects(PRODUCTS_TABLE)
     Set syncTable = SyncSheet().ListObjects(SYNC_TABLE)
     Set dashboard = ThisWorkbook.Worksheets(2)
     Set settings = ConfigSheet()
+    priceDisplayFont = PriceDisplayFontName(latinFont)
     AuditFixedFontMap = AuditFixedFontMap + _
         AuditRangeFont(table.HeaderRowRange, persianFont, repair)
     AuditFixedFontMap = AuditFixedFontMap + AuditRangeFont( _
@@ -6043,7 +6460,9 @@ Private Function AuditFixedFontMap(ByVal persianFont As String, _
                 table.ListColumns(CLng(columnIndex)).DataBodyRange, _
                 persianFont, repair)
         Next columnIndex
-        For Each columnIndex In Array(1, 2, 5, 6, 7, 9)
+        AuditFixedFontMap = AuditFixedFontMap + AuditRangeFont( _
+            table.ListColumns(1).DataBodyRange, priceDisplayFont, repair)
+        For Each columnIndex In Array(2, 5, 6, 7, 9)
             AuditFixedFontMap = AuditFixedFontMap + AuditRangeFont( _
                 table.ListColumns(CLng(columnIndex)).DataBodyRange, _
                 latinFont, repair)
@@ -6057,7 +6476,7 @@ Private Function AuditFixedFontMap(ByVal persianFont As String, _
         dashboard.Range("B1:I34"), latinCells, persianFont, latinFont, repair)
     Set latinCells = settings.Range( _
         "B3:F4,B7:F7,B10:F15,B18:F22,B24:F26," & _
-        "B39:F43,B46:F55")
+        "B39:F40,B46:F55")
     AuditFixedFontMap = AuditFixedFontMap + AuditMappedGridFont( _
         settings.Range("A1:F55"), latinCells, persianFont, latinFont, repair)
     AuditFixedFontMap = AuditFixedFontMap + AuditRangeFont( _
@@ -6136,6 +6555,7 @@ Public Function AuditConfiguredFonts( _
         Optional ByVal forceStrict As Boolean = False) As Boolean
     Dim persianFont As String
     Dim latinFont As String
+    Dim priceDisplayFont As String
     Dim auditMode As String
     Dim valid As Boolean
     Dim validateOnOpen As Boolean
@@ -6150,6 +6570,7 @@ Public Function AuditConfiguredFonts( _
     If Len(persianFont) = 0 Or Len(latinFont) = 0 Then _
         Err.Raise vbObjectError + 228, "AuditConfiguredFonts", _
                   T("font_policy_invalid")
+    priceDisplayFont = PriceDisplayFontName(latinFont)
     auditMode = NormalizedFontAuditMode( _
         NamedText("FontAuditMode", vbNullString), valid)
     If Not valid Then Err.Raise vbObjectError + 228, _
@@ -6171,6 +6592,10 @@ Public Function AuditConfiguredFonts( _
     End If
     If Not FontAvailable(persianFont) Then missingCount = missingCount + 1
     If Not FontAvailable(latinFont) Then missingCount = missingCount + 1
+    If StrComp(priceDisplayFont, latinFont, vbTextCompare) <> 0 Then
+        If Not FontAvailable(priceDisplayFont) Then _
+            missingCount = missingCount + 1
+    End If
     repair = auditMode = "RepairAndWarn"
     driftCount = AuditFixedFontMap(persianFont, latinFont, repair)
     If missingCount = 0 And driftCount = 0 Then
@@ -6209,15 +6634,34 @@ Private Sub ValidateFontPolicyRuntime()
         If NormalizedFontAuditMode(CStr(value), valid) <> CStr(value) Or _
            Not valid Then GoTo InvalidPolicy
     Next value
+    If NormalizedFontAuditMode( _
+           U("062E0627064506480634"), valid) <> "Off" Or _
+       Not valid Then GoTo InvalidPolicy
+    If NormalizedFontAuditMode( _
+           U("06470634062F06270631"), valid) <> "Warn" Or _
+       Not valid Then GoTo InvalidPolicy
+    If NormalizedFontAuditMode( _
+           U("062A0631064506CC064500200648002006470634062F06270631"), _
+           valid) <> "RepairAndWarn" Or Not valid Then GoTo InvalidPolicy
+    If NormalizedFontAuditMode( _
+           U("0633062E062A06AF06CC0631062706460647"), valid) <> _
+           "Strict" Or Not valid Then GoTo InvalidPolicy
     ignored = NormalizedFontAuditMode("invalid", valid)
     If valid Then GoTo InvalidPolicy
     If Not NormalizedYesNo("Yes", valid) Or Not valid Then _
         GoTo InvalidPolicy
     If NormalizedYesNo("No", valid) Or Not valid Then GoTo InvalidPolicy
+    If Not NormalizedYesNo(U("062806440647"), valid) Or _
+       Not valid Then GoTo InvalidPolicy
+    If NormalizedYesNo(U("062E06CC0631"), valid) Or _
+       Not valid Then GoTo InvalidPolicy
     Call NormalizedYesNo("invalid", valid)
     If valid Then GoTo InvalidPolicy
     If NamedText("PersianFont", vbNullString) <> DEFAULT_PERSIAN_FONT Or _
        NamedText("LatinFont", vbNullString) <> DEFAULT_LATIN_FONT Then _
+        GoTo InvalidPolicy
+    If Not NamedYesNo("PriceDisplayFaNum", valid) Or Not valid Or _
+       PriceDisplayFontName(DEFAULT_LATIN_FONT) <> DEFAULT_FANUM_FONT Then _
         GoTo InvalidPolicy
     If FontAvailable("__PatrisExportDefinitelyMissingFont__") Then _
         GoTo InvalidPolicy

--- a/docs/examples/vba/ThisWorkbook.cls
+++ b/docs/examples/vba/ThisWorkbook.cls
@@ -12,6 +12,16 @@ End Sub
 
 Private Sub Workbook_Activate()
     On Error Resume Next
+    ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
+    ProductCatalogSync.RegisterSearchHotkey
+    On Error GoTo 0
+End Sub
+
+Private Sub Workbook_WindowActivate(ByVal Wn As Window)
+    On Error Resume Next
+    ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
     ProductCatalogSync.RegisterSearchHotkey
     On Error GoTo 0
 End Sub
@@ -43,12 +53,17 @@ End Sub
 Private Sub Workbook_AfterSave(ByVal Success As Boolean)
     On Error Resume Next
     ProductCatalogSync.FinishWorkbookSaveTiming Success
+    If Not Success Then ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
+    If Success Then ProductCatalogSync.RegisterSearchHotkey
     On Error GoTo 0
 End Sub
 
 Private Sub Workbook_SheetChange(ByVal Sh As Object, ByVal Target As Range)
     Dim previousEvents As Boolean
 
+    ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
     previousEvents = Application.EnableEvents
     On Error GoTo CleanExit
     If Sh Is ThisWorkbook.Worksheets(1) Then
@@ -62,6 +77,11 @@ Private Sub Workbook_SheetChange(ByVal Sh As Object, ByVal Target As Range)
         GoTo CleanExit
     End If
     If Not Sh Is ThisWorkbook.Worksheets(3) Then GoTo CleanExit
+    If Not Intersect(Target, Sh.Range("B44")) Is Nothing Then
+        Application.EnableEvents = False
+        ProductCatalogSync.ApplyPriceDisplayFontSetting
+        GoTo CleanExit
+    End If
     If Intersect(Target, Union(Sh.Range("B18:B22"), _
                                Sh.Range("E20"), _
                                Sh.Range("B26"))) Is Nothing Then GoTo CleanExit
@@ -76,6 +96,8 @@ End Sub
 Private Sub Workbook_SheetSelectionChange(ByVal Sh As Object, _
                                            ByVal Target As Range)
     On Error GoTo CleanExit
+    ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
     If Sh Is ThisWorkbook.Worksheets(1) Then
         ProductCatalogSync.UpdateSearchEnterHotkey Target
     Else
@@ -88,6 +110,8 @@ End Sub
 
 Private Sub Workbook_SheetActivate(ByVal Sh As Object)
     On Error GoTo CleanExit
+    ProductCatalogSync.ResumeAfterCancelledClose
+    ProductCatalogSync.KickQueuedAsyncDispatch
     If Sh Is ThisWorkbook.Worksheets(1) Then
         ProductCatalogSync.RefreshSearchEnterHotkey
     Else

--- a/pkg/recordsink/dynamic_font.go
+++ b/pkg/recordsink/dynamic_font.go
@@ -12,12 +12,16 @@ import (
 	"github.com/xuri/excelize/v2"
 )
 
+const defaultDynamicPriceDigitFont = "Yekan Bakh FaNum"
+
 // DynamicWorkbookFontPolicy is the fixed role-map policy used by the Persian
 // calculator. Cell roles are verified through their saved OpenXML style IDs;
 // DrawingML text runs are verified through their explicit latin/ea/cs slots.
 type DynamicWorkbookFontPolicy struct {
-	PersianFont string
-	LatinFont   string
+	PersianFont          string
+	LatinFont            string
+	PriceDisplayFaNum    bool
+	HasPriceDisplayFaNum bool
 }
 
 // DynamicWorkbookFontReport reports only counts and configured family names;
@@ -25,6 +29,7 @@ type DynamicWorkbookFontPolicy struct {
 type DynamicWorkbookFontReport struct {
 	PersianFont      string
 	LatinFont        string
+	PriceDisplayFont string
 	MappedCells      int
 	DrawingTextRuns  int
 	DrawingFontSlots int
@@ -58,8 +63,9 @@ type drawingRunAudit struct {
 	slots map[string]string
 }
 
-// ReadDynamicWorkbookFontPolicy reads the two configured font roles from the
-// workbook-scoped named cells. It does not infer either role from cell text.
+// ReadDynamicWorkbookFontPolicy reads the configured font roles and optional
+// selling-price FaNum toggle from workbook-scoped named cells. It does not
+// infer any role from cell text.
 func ReadDynamicWorkbookFontPolicy(path string) (DynamicWorkbookFontPolicy, error) {
 	var policy DynamicWorkbookFontPolicy
 	book, err := excelize.OpenFile(path)
@@ -67,9 +73,10 @@ func ReadDynamicWorkbookFontPolicy(path string) (DynamicWorkbookFontPolicy, erro
 		return policy, fmt.Errorf("open workbook font configuration: %w", err)
 	}
 	defer book.Close()
-	values := make(map[string]string, 2)
+	values := make(map[string]string, 3)
 	for _, definedName := range book.GetDefinedName() {
-		if !isWorkbookDefinedNameScope(definedName.Scope) || (definedName.Name != "PersianFont" && definedName.Name != "LatinFont") {
+		if !isWorkbookDefinedNameScope(definedName.Scope) ||
+			(definedName.Name != "PersianFont" && definedName.Name != "LatinFont" && definedName.Name != "PriceDisplayFaNum") {
 			continue
 		}
 		sheet, cellRange, err := parseDefinedNameReference(definedName.RefersTo)
@@ -91,18 +98,41 @@ func ReadDynamicWorkbookFontPolicy(path string) (DynamicWorkbookFontPolicy, erro
 	if policy.PersianFont == "" || policy.LatinFont == "" {
 		return policy, errors.New("workbook font configuration requires PersianFont and LatinFont named cells")
 	}
+	if value, ok := values["PriceDisplayFaNum"]; ok {
+		enabled, err := parseWorkbookYesNo(value)
+		if err != nil {
+			return policy, fmt.Errorf("font configuration name %q: %w", "PriceDisplayFaNum", err)
+		}
+		policy.HasPriceDisplayFaNum = true
+		policy.PriceDisplayFaNum = enabled
+	}
 	return policy, nil
+}
+
+func parseWorkbookYesNo(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "yes", "بله":
+		return true, nil
+	case "no", "خیر":
+		return false, nil
+	default:
+		return false, fmt.Errorf("value %q must be localized Yes or No", value)
+	}
 }
 
 // ValidateDynamicWorkbookFontPolicy is a hard package validator for the fixed
 // calculator role map. It never guesses a role from cell contents.
 func ValidateDynamicWorkbookFontPolicy(path string, policy DynamicWorkbookFontPolicy) (DynamicWorkbookFontReport, error) {
 	report := DynamicWorkbookFontReport{
-		PersianFont: strings.TrimSpace(policy.PersianFont),
-		LatinFont:   strings.TrimSpace(policy.LatinFont),
+		PersianFont:      strings.TrimSpace(policy.PersianFont),
+		LatinFont:        strings.TrimSpace(policy.LatinFont),
+		PriceDisplayFont: strings.TrimSpace(policy.LatinFont),
 	}
 	if report.PersianFont == "" || report.LatinFont == "" {
 		return report, errors.New("font policy requires nonblank PersianFont and LatinFont")
+	}
+	if policy.HasPriceDisplayFaNum && policy.PriceDisplayFaNum {
+		report.PriceDisplayFont = defaultDynamicPriceDigitFont
 	}
 	book, err := excelize.OpenFile(path)
 	if err != nil {
@@ -127,13 +157,21 @@ func ValidateDynamicWorkbookFontPolicy(path string, policy DynamicWorkbookFontPo
 		addFontRoleRange(expected, "داشبورد", value, report.LatinFont)
 	}
 	addFontRoleRange(expected, "تنظیمات", "A1:F55", report.PersianFont)
-	for _, value := range []string{
-		"B3:F4", "B7:F7", "B10:F15", "B18:F22", "B24:F26",
-		"B39:F43", "B46:F55",
-	} {
+	settingsLatinRanges := []string{
+		"B3:F4", "B7:F7", "B10:F15", "B18:F22", "B24:F26", "B46:F55",
+	}
+	if policy.HasPriceDisplayFaNum {
+		settingsLatinRanges = append(settingsLatinRanges, "B39:F40")
+	} else {
+		settingsLatinRanges = append(settingsLatinRanges, "B39:F43")
+	}
+	for _, value := range settingsLatinRanges {
 		addFontRoleRange(expected, "تنظیمات", value, report.LatinFont)
 	}
-	if err := addTableFontRoles(book, expected, "محصولات", "Products", report.PersianFont, report.LatinFont, []int{3, 4, 8, 10}, []int{1, 2, 5, 6, 7, 9}); err != nil {
+	if err := addTableFontRoles(book, expected, "محصولات", "Products", report.PersianFont, report.LatinFont, []int{3, 4, 8, 10}, []int{2, 5, 6, 7, 9}); err != nil {
+		return report, err
+	}
+	if err := addTableColumnFontRole(book, expected, "محصولات", "Products", 1, report.PriceDisplayFont); err != nil {
 		return report, err
 	}
 	if err := addTableFontRoles(book, expected, "داده‌های همگام‌سازی", "SyncData", report.PersianFont, report.LatinFont, []int{17, 18, 19, 20}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 21, 22, 23}); err != nil {
@@ -237,6 +275,40 @@ func addTableFontRoles(book *excelize.File, target map[string]string, sheet, tab
 					target[sheet+"!"+cellName] = role.font
 				}
 			}
+		}
+		return nil
+	}
+	return fmt.Errorf("font role table %q does not exist", tableName)
+}
+
+func addTableColumnFontRole(book *excelize.File, target map[string]string, sheet, tableName string, relativeColumn int, fontName string) error {
+	tables, err := book.GetTables(sheet)
+	if err != nil {
+		return err
+	}
+	for _, table := range tables {
+		if table.Name != tableName {
+			continue
+		}
+		parts := strings.Split(strings.ReplaceAll(table.Range, "$", ""), ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("font role table %q has invalid range %q", tableName, table.Range)
+		}
+		startColumn, headerRow, err := excelize.CellNameToCoordinates(parts[0])
+		if err != nil {
+			return err
+		}
+		endColumn, endRow, err := excelize.CellNameToCoordinates(parts[1])
+		if err != nil {
+			return err
+		}
+		column := startColumn + relativeColumn - 1
+		if relativeColumn < 1 || column > endColumn {
+			return fmt.Errorf("font role column %d is outside table %q", relativeColumn, tableName)
+		}
+		for row := headerRow + 1; row <= endRow; row++ {
+			cellName, _ := excelize.CoordinatesToCellName(column, row)
+			target[sheet+"!"+cellName] = fontName
 		}
 		return nil
 	}

--- a/pkg/recordsink/dynamic_font_test.go
+++ b/pkg/recordsink/dynamic_font_test.go
@@ -20,10 +20,16 @@ func TestReadDynamicWorkbookFontPolicyUsesNamedCells(t *testing.T) {
 	if err := book.SetCellStr("Settings", "B2", "Segoe UI"); err != nil {
 		t.Fatal(err)
 	}
+	if err := book.SetCellStr("Settings", "B3", "بله"); err != nil {
+		t.Fatal(err)
+	}
 	if err := book.SetDefinedName(&excelize.DefinedName{Name: "PersianFont", RefersTo: "Settings!$B$1"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := book.SetDefinedName(&excelize.DefinedName{Name: "LatinFont", RefersTo: "Settings!$B$2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := book.SetDefinedName(&excelize.DefinedName{Name: "PriceDisplayFaNum", RefersTo: "Settings!$B$3"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := book.SaveAs(path); err != nil {
@@ -36,8 +42,30 @@ func TestReadDynamicWorkbookFontPolicyUsesNamedCells(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if policy.PersianFont != "Yekan Bakh" || policy.LatinFont != "Segoe UI" {
+	if policy.PersianFont != "Yekan Bakh" || policy.LatinFont != "Segoe UI" ||
+		!policy.HasPriceDisplayFaNum || !policy.PriceDisplayFaNum {
 		t.Fatalf("named font policy = %+v", policy)
+	}
+}
+
+func TestParseWorkbookYesNoAcceptsLocalizedAndInternalValues(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  bool
+	}{
+		{value: "Yes", want: true},
+		{value: " yes ", want: true},
+		{value: "بله", want: true},
+		{value: "No", want: false},
+		{value: "خیر", want: false},
+	} {
+		got, err := parseWorkbookYesNo(test.value)
+		if err != nil || got != test.want {
+			t.Fatalf("parseWorkbookYesNo(%q) = %v, %v; want %v", test.value, got, err, test.want)
+		}
+	}
+	if _, err := parseWorkbookYesNo("maybe"); err == nil {
+		t.Fatal("invalid visible yes/no token passed workbook font policy parsing")
 	}
 }
 
@@ -73,7 +101,7 @@ func TestForbiddenWorkbookFontsAreNarrowAndCaseInsensitive(t *testing.T) {
 			t.Fatalf("forbidden font %q was accepted", value)
 		}
 	}
-	for _, value := range []string{"Yekan Bakh", "Segoe UI", "Arial Unicode MS"} {
+	for _, value := range []string{"Yekan Bakh", "Yekan Bakh FaNum", "Segoe UI", "Arial Unicode MS"} {
 		if isForbiddenWorkbookFont(value) {
 			t.Fatalf("allowed font %q was rejected", value)
 		}

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -614,10 +614,11 @@ func TestDynamicCalculatorPackagesPassFixedOpenXMLFontPolicy(t *testing.T) {
 	if err != nil || len(paths) != 1 {
 		t.Fatalf("locate canonical calculator: paths=%v error=%v", paths, err)
 	}
-	report, err := ValidateDynamicWorkbookFontPolicy(paths[0], DynamicWorkbookFontPolicy{
-		PersianFont: "Yekan Bakh",
-		LatinFont:   "Segoe UI",
-	})
+	policy, err := ReadDynamicWorkbookFontPolicy(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := ValidateDynamicWorkbookFontPolicy(paths[0], policy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1003,27 +1004,178 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		t.Fatal("source identity must be validated before the callback pipeline creates a session")
 	}
 	startHandler := section("Private Sub HandleSnapshotStartResponse", "Private Sub HandleSnapshotWaitResponse")
-	for _, required := range []string{"ParsePricingSnapshotJob root", "EnsureSseListener", "BeginSnapshotWaitRequest"} {
+	for _, required := range []string{"ParsePricingSnapshotJob root", "mSseJobID = mSnapshotJobID", "BeginSnapshotWaitRequest"} {
 		if !strings.Contains(startHandler, required) {
 			t.Fatalf("snapshot start callback is missing %s", required)
 		}
+	}
+	if strings.Contains(startHandler, "EnsureSseListener") {
+		t.Fatal("cold refresh must not subscribe to durable SSE before the first atomic commit")
 	}
 	waitHandler := section("Private Sub HandleSnapshotWaitResponse", "Private Sub HandleSnapshotPayloadResponse")
 	if !strings.Contains(waitHandler, "BeginSnapshotPayloadRequest") || strings.Contains(waitHandler, "Do While") {
 		t.Fatal("terminal wait callback must transition once to the payload without polling")
 	}
+	queueHandler := section("Public Sub QueueAsyncDispatch", "Private Sub ScheduleQueuedAsyncDispatch")
+	if !strings.Contains(queueHandler, "ScheduleQueuedAsyncDispatch") ||
+		!strings.Contains(queueHandler, "mSaveRenameAsyncPending = True") ||
+		strings.Contains(queueHandler, "DispatchAsyncRequest") ||
+		strings.Contains(queueHandler, "FailActiveOperation") {
+		t.Fatal("WinHTTP callbacks must only queue a rename-safe deferred dispatcher and return")
+	}
+	scheduleHandler := section("Private Sub ScheduleQueuedAsyncDispatch", "Public Sub DispatchQueuedAsyncRequests")
+	for _, required := range []string{
+		"Application.OnTime",
+		"mAsyncDispatchTime = Now + TimeSerial(0, 0, 1)",
+		`QualifiedWorkbookMacro("DispatchQueuedAsyncRequests")`,
+		"DispatchFailed:",
+		"mAsyncDispatchScheduled = False",
+	} {
+		if !strings.Contains(scheduleHandler, required) {
+			t.Fatalf("async callback dispatcher is not safely deferred: %s", required)
+		}
+	}
+	if strings.Count(scheduleHandler, "Application.OnTime") != 1 ||
+		!strings.Contains(scheduleHandler, "mSaveRenameSchedulesSuspended") ||
+		strings.Contains(scheduleHandler, "DispatchAsyncRequest") ||
+		strings.Contains(scheduleHandler, "FailActiveOperation") {
+		t.Fatal("OnTime scheduling must be a single non-reentrant action with deferred failure handling")
+	}
+	kickHandler := section("Public Sub KickQueuedAsyncDispatch", "Public Sub DispatchQueuedAsyncRequests")
+	for _, required := range []string{
+		"mAsyncDispatchErrorNumber <> 0",
+		"DispatchQueuedAsyncRequests",
+		"ScheduleQueuedAsyncDispatch",
+	} {
+		if !strings.Contains(kickHandler, required) {
+			t.Fatalf("safe workbook-event dispatch kick is missing %q", required)
+		}
+	}
+	if strings.Contains(kickHandler, "DispatchAsyncRequest") {
+		t.Fatal("safe dispatch kick must not run a WinHTTP state transition directly")
+	}
+	saveResume := section("Private Sub ResumeQualifiedSchedulesAfterSaveAs", "Public Sub RefreshAllData")
+	for _, required := range []string{
+		"mAsyncDispatchPending.Count > 0",
+		"If refreshPending Then ScheduleRefreshOnOpen",
+		"If asyncPending Then ScheduleQueuedAsyncDispatch",
+		"If previewPending Then SchedulePricingPreview",
+		"If eventRefreshPending Then ScheduleEventDrivenRefresh",
+		"If sseReconnectPending Then ScheduleSseReconnect sseRenewSession",
+	} {
+		if !strings.Contains(saveResume, required) {
+			t.Fatalf("Save As schedule rebinding is missing %q", required)
+		}
+	}
+	for _, scheduler := range []struct {
+		start string
+		end   string
+		flag  string
+		reset string
+	}{
+		{"Public Sub ScheduleRefreshOnOpen", "Public Sub RunScheduledRefresh", "mSaveRenameRefreshPending = True", "mRefreshScheduled = False"},
+		{"Private Sub ScheduleSseReconnect", "Public Sub RunSseReconnect", "mSaveRenameSseReconnectPending = True", "mSseReconnectScheduled = False"},
+		{"Private Sub ScheduleEventDrivenRefresh", "Public Sub RunEventDrivenRefresh", "mSaveRenameEventRefreshPending = True", "mEventRefreshScheduled = False"},
+		{"Private Sub SchedulePricingPreview", "Public Sub RunScheduledPricingPreview", "mSaveRenamePreviewPending = True", "mPricingPreviewScheduled = False"},
+	} {
+		schedulerSource := section(scheduler.start, scheduler.end)
+		if !strings.Contains(schedulerSource, scheduler.flag) {
+			t.Fatalf("qualified scheduler %s is not suspended across Save As", scheduler.start)
+		}
+		if !strings.Contains(schedulerSource, "ScheduleFailed:") ||
+			!strings.Contains(schedulerSource, scheduler.reset) {
+			t.Fatalf("qualified scheduler %s can retain a false scheduled flag after OnTime failure", scheduler.start)
+		}
+	}
+	dispatchHandler := section("Public Sub DispatchQueuedAsyncRequests", "Private Sub CancelQueuedAsyncDispatch")
+	for _, required := range []string{
+		"mAsyncDispatchErrorNumber",
+		"FailActiveOperation pendingToken",
+		"DispatchAsyncRequest pendingToken",
+	} {
+		if !strings.Contains(dispatchHandler, required) {
+			t.Fatalf("deferred async dispatcher is missing post-callback handling: %s", required)
+		}
+	}
 	payloadHandler := section("Private Sub HandleSnapshotPayloadResponse", "Private Sub HandlePreviewResponse")
 	rawHashPosition := strings.Index(payloadHandler, "SHA256RevisionBytes(responseBody)")
 	validatePosition := strings.Index(payloadHandler, "ImportPricingSnapshotPayload(")
+	listenerValidatePosition := strings.Index(payloadHandler, "ValidateSseListenerPrerequisites")
 	commitPosition := strings.Index(payloadHandler, "CommitRefreshSnapshot reconciledRows")
-	if rawHashPosition < 0 || validatePosition < rawHashPosition || commitPosition < validatePosition {
-		t.Fatal("raw payload bytes and immutable snapshot must be validated before atomic workbook commit")
+	completePosition := strings.Index(payloadHandler, "CompleteActiveOperation True")
+	sseArmPosition := strings.Index(payloadHandler, "ArmSseListenerAfterCommit")
+	if rawHashPosition < 0 || validatePosition < rawHashPosition ||
+		listenerValidatePosition < validatePosition || commitPosition < listenerValidatePosition ||
+		completePosition < commitPosition || sseArmPosition < completePosition {
+		t.Fatal("payload/listener prerequisites must validate before commit, and listener arm must follow successful completion")
+	}
+	listenerArm := section("Private Sub ArmSseListenerAfterCommit", "Private Sub AdoptSseSessionToken")
+	for _, required := range []string{
+		"EnsureSseListener eventsURL, jobID, csrfToken",
+		"ListenerFailed:",
+		"ScheduleSseReconnect True",
+	} {
+		if !strings.Contains(listenerArm, required) {
+			t.Fatalf("post-commit listener recovery is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"FailActiveOperation",
+		"CommitRefreshSnapshot",
+		"RestoreCatalogTableSnapshot",
+	} {
+		if strings.Contains(listenerArm, forbidden) {
+			t.Fatalf("post-commit listener recovery must preserve the committed snapshot: %s", forbidden)
+		}
 	}
 	applyHandler := section("Private Sub ApplyPricingChangesCore", "Private Sub InvalidatePricingPreview")
 	idempotencyPosition := strings.Index(applyHandler, `mLastApplyRequestID = NewRequestID("apply")`)
 	savedIDPosition := strings.Index(applyHandler, "mOperationSavedApplyRequestID = mLastApplyRequestID")
 	if idempotencyPosition < 0 || savedIDPosition < idempotencyPosition {
 		t.Fatal("apply must persist its idempotency key before the asynchronous request can become uncertain")
+	}
+	sseEventHandler := section("Private Sub HandlePricingSseEvent", "Private Function IsExpectedApplyMutationEvent")
+	for _, required := range []string{
+		`Case "pricing_state_changed"`,
+		`Case "pricing_state_invalidated"`,
+		"eventStateRevision = SiteText(change, \"state_revision\")",
+		"IsExpectedApplyMutationEvent(eventStateRevision)",
+		"PreserveExpectedApplyMutationEvent",
+	} {
+		if !strings.Contains(sseEventHandler, required) {
+			t.Fatalf("SSE apply-race handling is missing %q", required)
+		}
+	}
+	expectedApplyEvent := section("Private Function IsExpectedApplyMutationEvent", "Private Sub PreserveExpectedApplyMutationEvent")
+	for _, required := range []string{
+		`Case "apply"`,
+		`Case "apply_refresh"`,
+		"mRequiredSnapshotStateRevision",
+		"vbBinaryCompare",
+	} {
+		if !strings.Contains(expectedApplyEvent, required) {
+			t.Fatalf("expected apply mutation classifier is missing %q", required)
+		}
+	}
+	preserveApplyEvent := section("Private Sub PreserveExpectedApplyMutationEvent", "Private Sub MarkSseRefreshRequired")
+	for _, required := range []string{
+		"mForceFreshSnapshot = True",
+		"InvalidatePricingPreview",
+		`If mOperationKind = "apply" Then`,
+		"mSseRefreshRequired = True",
+	} {
+		if !strings.Contains(preserveApplyEvent, required) {
+			t.Fatalf("expected apply mutation preservation is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"mOperationRequest.Abort",
+		"FailActiveOperation",
+		"ScheduleEventDrivenRefresh",
+	} {
+		if strings.Contains(preserveApplyEvent, forbidden) {
+			t.Fatalf("apply's own SSE mutation event must not terminate or bypass its HTTP response: %s", forbidden)
+		}
 	}
 	wooLinkRowPosition := strings.Index(source, "Private Sub ApplyWooLinkRow")
 	if wooLinkRowPosition < 0 {
@@ -1056,10 +1208,15 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		`Private Const PRICING_SNAPSHOT_PAYLOAD_SCHEMA As String = "patris.pricing-snapshot/v1"`,
 		`Private Const PRICING_SNAPSHOT_EVENT_SCHEMA As String = "patris.pricing-state-event/v1"`,
 		`Private Const PRICING_SNAPSHOT_PROJECTION As String = "excel-v1"`,
+		`Private Const DEFAULT_FANUM_FONT As String = "Yekan Bakh FaNum"`,
 		"Private mOperationRequest As AsyncWinHttpRequest",
 		"Private mSseRequest As AsyncWinHttpRequest",
 		"Private mSseSessionRequest As AsyncWinHttpRequest",
 		"Private mSseParser As PricingSseParser",
+		"Private mAsyncDispatchScheduled As Boolean",
+		"Private mCatalogCommitInProgress As Boolean",
+		"Public Sub DispatchQueuedAsyncRequests",
+		"Private Sub CancelQueuedAsyncDispatch",
 		"Private Sub BeginRefreshPipeline",
 		"Private Sub BeginContractRequest",
 		"Private Sub BeginSessionRequest",
@@ -1067,6 +1224,8 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		"Private Sub BeginSnapshotWaitRequest",
 		"Private Sub BeginSnapshotPayloadRequest",
 		"Private Sub StartFiniteRequest",
+		"Private Function IsAllowedPricingAuthenticatedUrl",
+		"If pricingRequest And Not IsAllowedPricingAuthenticatedUrl(endpoint) Then",
 		`requestValue.OpenAsync UCase$(methodName), endpoint`,
 		`requestValue.SetRequestHeader PRICING_CLIENT_HEADER, PRICING_CLIENT_ID`,
 		`requestValue.SetRequestHeader PRICING_CSRF_HEADER`,
@@ -1101,7 +1260,15 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		"Public Sub RunSseReconnect",
 		"Private Sub ScheduleEventDrivenRefresh",
 		"Public Sub RunEventDrivenRefresh",
+		"Set activeBook = Application.ActiveWorkbook",
+		"If Not activeBook Is ThisWorkbook Then Exit Sub",
 		"Public Sub CancelActivePricingOperations",
+		"Public Sub ResumeAfterCancelledClose",
+		"mResumeRefreshAfterCancelledClose",
+		"If workbookIsClosing And Not mCancelRequest Is Nothing Then",
+		"mCancelRequest.Abort",
+		"If workbookIsClosing Then CancelSseReconnect",
+		"If workbookIsClosing Then StopSseListener True",
 		"Private Sub CommitRefreshSnapshot",
 		"Private Sub CaptureCatalogTableSnapshot",
 		"Private Sub RestoreCatalogTableSnapshot",
@@ -1126,6 +1293,7 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		`Left$(warningCode, Len("projection_integrity"))`,
 		"Private Sub BeginRepairRequest",
 		`StartFiniteRequest "POST", UniversalRefreshURL()`,
+		`(StrComp(Trim$(address), UniversalRefreshURL(), vbTextCompare) = 0)`,
 		`JsonRuntime.JsonText(root, "source_revision")`,
 		"mSourceRevision <> mOperationDeliveredRevision",
 		"Public Sub PreviewPricingChanges()",
@@ -1194,6 +1362,12 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		`Private Const SEARCH_BUTTON_SHAPE As String = "ProductSearchButton"`,
 		"Public Sub HighlightSelectedProductRow",
 		"Public Sub ApplyPriceDisplayFontSetting()",
+		"Private Function PriceDisplayFontName",
+		`NamedYesNo("PriceDisplayFaNum", valid)`,
+		"table.ListColumns(1).DataBodyRange, priceDisplayFont, repair",
+		"For Each columnIndex In Array(2, 5, 6, 7, 9)",
+		`book.Worksheets(3).Range("A44:F44").ClearContents`,
+		`book.Names("PriceDisplayFaNum").Delete`,
 		"ValidateRoundingRuntime",
 		"Application.WorksheetFunction.Round(123450#, -2) <> 123500#",
 		"Public Sub HandleWorkbookBeforeSave",
@@ -1235,7 +1409,6 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		"MsgBox ",
 		"MsgBox(",
 		"VBA.MsgBox",
-		"Yekan Bakh" + " Fa" + "Num",
 		`"catalog_materialization"`,
 		"ApplyCatalogMaterializationState",
 		`http.Open "GET", endpoint, False`,
@@ -1296,6 +1469,8 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	}
 	commitSource := section("Private Sub CommitRefreshSnapshot", "Public Sub RefreshOnOpen")
 	for _, required := range []string{
+		"mCatalogCommitInProgress = True",
+		"mCatalogCommitInProgress = False",
 		"Application.ScreenUpdating = False",
 		"Application.EnableEvents = False",
 		"Application.Calculation = xlCalculationManual",
@@ -1308,6 +1483,21 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	}
 	if strings.Contains(refreshSource+beginRefreshSource, "ConfirmUnicodeMessage") {
 		t.Fatal("routine refresh status must remain inline and never open a modal dialog")
+	}
+	for _, uiSection := range []struct {
+		start string
+		end   string
+	}{
+		{"Public Sub FocusProductSearch", "Public Sub SearchProducts"},
+		{"Public Sub SearchProducts", "Public Sub ClearProductSearch"},
+		{"Public Sub ClearProductSearch", "Private Function ProductSearchMatchRows"},
+		{"Public Sub HighlightSelectedProductRow", "Public Sub HandlePricingProposalChanged"},
+	} {
+		sectionSource := section(uiSection.start, uiSection.end)
+		if strings.Contains(sectionSource, "mRefreshInProgress") ||
+			!strings.Contains(sectionSource, "mCatalogCommitInProgress") {
+			t.Fatalf("%s must remain usable throughout the network wait and pause only for atomic commit", uiSection.start)
+		}
 	}
 	for _, required := range []string{
 		"mOperationPreviousEnableCancelKey = Application.EnableCancelKey",
@@ -1329,7 +1519,7 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		t.Fatal("routine no-result search status must remain inline and never open a modal dialog")
 	}
 	for _, required := range []string{
-		"If mRefreshInProgress Or mSearchInProgress Then Exit Sub",
+		"If mCatalogCommitInProgress Or mSearchInProgress Then Exit Sub",
 		"mSearchInProgress = True",
 		"Application.EnableCancelKey = xlErrorHandler",
 		`SetSearchButtonCaption T("search_button") & " (0)"`,
@@ -1367,7 +1557,14 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 		"ProductCatalogSync.HandleWorkbookBeforeSave SaveAsUI, Cancel",
 		"Private Sub Workbook_AfterSave",
 		"ProductCatalogSync.FinishWorkbookSaveTiming Success",
+		"If Not Success Then ProductCatalogSync.ResumeAfterCancelledClose",
+		"Private Sub Workbook_WindowActivate",
+		"ProductCatalogSync.ResumeAfterCancelledClose",
+		"ProductCatalogSync.KickQueuedAsyncDispatch",
+		"If Success Then ProductCatalogSync.RegisterSearchHotkey",
 		"Private Sub Workbook_SheetChange",
+		`If Not Intersect(Target, Sh.Range("B44")) Is Nothing Then`,
+		"ProductCatalogSync.ApplyPriceDisplayFontSetting",
 		`Union(Sh.Range("B18:B22"), _`,
 		`Sh.Range("B26"))`,
 		"ProductCatalogSync.HandlePricingProposalChanged",
@@ -1477,6 +1674,13 @@ func TestDynamicCalculatorValidatorHandlesEmptyProductTable(t *testing.T) {
 		`if ($null -ne $priceDataRange) {`,
 		`if ($null -eq $titleColumn) {`,
 		`priceSlots = $priceSlots`,
+		`technicalSlots = $technicalSlots`,
+		`report.fontAudit.priceDisplayFaNum === 'بله'`,
+		`report.fontAudit.faNumToggle.enabled === true`,
+		`report.fontAudit.faNumToggle.disabled === true`,
+		`slot.value === 'Yekan Bakh FaNum'`,
+		`$settings.Range('B44').Value2 = 'بله'`,
+		`$settings.Range('B44').Value2 = 'خیر'`,
 		`if ($productRows.Count -eq 0 -or $tableFirstColumn -le 0 -or`,
 		`found = $false`,
 		`ProductCatalogSync.AsyncPricingIdleForValidation`,
@@ -1513,6 +1717,7 @@ func TestDynamicCalculatorBuilderStylesPersianButtonsAndChartText(t *testing.T) 
 		"function Assert-RangeFontSlots",
 		"function Assert-ShapeFontSlots",
 		"function Assert-FontFamilyAvailable",
+		"Assert-FontFamilyAvailable 'Yekan Bakh FaNum' 'Persian price digits'",
 		"function Add-DigitalogicMessageForm",
 		"$Workbook.VBProject.VBComponents.Add(3)",
 		`$workbook.VBProject.References.AddFromGuid(`,
@@ -1545,12 +1750,20 @@ func TestDynamicCalculatorBuilderStylesPersianButtonsAndChartText(t *testing.T) 
 		"$searchButton.Name = 'ProductSearchButton'",
 		"$searchButton.AlternativeText = ",
 		"[void]$workbook.Names.Add($setting.Name, $settings.Range(\"B${row}\"))",
-		"$settings.Range('B41').Validation.Add(3, 1, 1, 'Off,Warn,RepairAndWarn,Strict')",
-		"Set-RangeFontSlots $priceList.Range('B6:C6,F6:H6,J6') 'Segoe UI'",
+		"Name = 'PriceDisplayFaNum'",
+		"Value = 'ترمیم و هشدار'",
+		"Value = 'بله'",
+		"Value = 'خیر'",
+		"$settings.Range('B41').Validation.Add(3, 1, 1, 'خاموش,هشدار,ترمیم و هشدار,سختگیرانه')",
+		"$settings.Range('B44').Validation.Add(3, 1, 1, 'بله,خیر')",
+		"Set-RangeFontSlots $priceList.Range('B6') 'Yekan Bakh FaNum'",
+		"Set-RangeFontSlots $priceList.Range('C6,F6:H6,J6') 'Segoe UI'",
 		"Set-RangeFontSlots $priceList.Range('I6,K6') 'Yekan Bakh'",
 		"Products column B is narrower than the required 20-character minimum",
 		"Products column K is narrower than the required 34-character minimum",
 		"Set-RangeFontSlots $settings.Range('A1:F55') 'Yekan Bakh'",
+		"Set-RangeFontSlots $settings.Range('B3:F4,B7:F7,B10:F15,B18:F22,B24:F26,B39:F40,B46:F55') 'Segoe UI'",
+		"Assert-RangeFontSlots $settings.Range('B41:F44') 'Yekan Bakh' 'localized font policy values'",
 		"(46..55)",
 		"[void]$workbook.Names.Add('ProjectedPricePreviewRow', $settings.Range('G48'))",
 		"'مبلغ منبع قیمت'",

--- a/pkg/server/excel_pricing.go
+++ b/pkg/server/excel_pricing.go
@@ -120,6 +120,9 @@ type excelPricingState struct {
 
 	canonical func(context.Context) (recordpipe.Result, error)
 	dispatch  func(context.Context, updateout.Config, updateout.Event) (updateout.DeliveryResult, error)
+
+	snapshotCollector       excelPricingSnapshotCollector
+	snapshotRevisionCurrent func(canonical.Source, string, string) bool
 }
 
 type excelPricingRemoteResponse struct {

--- a/pkg/server/excel_pricing_events_bridge.go
+++ b/pkg/server/excel_pricing_events_bridge.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 
 	"github.com/atomicdeploy/patris-export/pkg/appconfig"
 	"github.com/atomicdeploy/patris-export/pkg/canonical"
@@ -32,6 +33,7 @@ type excelPricingRemoteBridgeDependencies struct {
 		uint64,
 		func(uint64),
 		func(excelPricingRemoteRevision) error,
+		func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error
 	apply func(excelPricingRemoteRevision) error
 	logf  func(string, ...interface{})
@@ -44,6 +46,7 @@ type excelPricingRemoteBridgeDependencies struct {
 type excelPricingRemoteEventsBridge struct {
 	dependencies excelPricingRemoteBridgeDependencies
 	wake         chan struct{}
+	terminals    *excelPricingRemoteSnapshotTerminalHub
 	startOnce    sync.Once
 	lifecycleMu  sync.Mutex
 	lifecycleCtx context.Context
@@ -56,6 +59,7 @@ type excelPricingRemoteEventsBridge struct {
 	desired           excelPricingRemoteBridgeConfig
 	cursor            uint64
 	acknowledged      bool
+	verifiedRevision  atomic.Pointer[excelPricingRemoteRevision]
 }
 
 func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEventsBridge {
@@ -83,6 +87,7 @@ func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEvents
 			initialCursor uint64,
 			onCursor func(uint64),
 			onRevision func(excelPricingRemoteRevision) error,
+			onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 		) error {
 			return runExcelPricingRemoteEvents(
 				ctx,
@@ -91,6 +96,7 @@ func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEvents
 				initialCursor,
 				onCursor,
 				onRevision,
+				onTerminal,
 			)
 		},
 		apply: server.notifyExcelPricingRemoteRevisionChanged,
@@ -107,6 +113,7 @@ func newExcelPricingRemoteEventsBridgeWithDependencies(
 	return &excelPricingRemoteEventsBridge{
 		dependencies: dependencies,
 		wake:         make(chan struct{}, 1),
+		terminals:    newExcelPricingRemoteSnapshotTerminalHub(),
 	}
 }
 
@@ -209,6 +216,7 @@ func (bridge *excelPricingRemoteEventsBridge) reconcile(
 	epoch := bridge.epoch
 	bridge.cursor = 0
 	bridge.acknowledged = false
+	bridge.verifiedRevision.Store(nil)
 	bridge.mu.Unlock()
 	if wake {
 		bridge.signal()
@@ -314,6 +322,7 @@ func (bridge *excelPricingRemoteEventsBridge) runGeneration(
 	epoch uint64,
 	cfg updateout.Config,
 ) {
+	defer bridge.clearVerifiedRevision(epoch)
 	if bridge.dependencies.materialize == nil || bridge.dependencies.run == nil ||
 		bridge.dependencies.apply == nil {
 		bridge.dependencies.logf("Pricing event subscriber is inactive: lifecycle dependencies are unavailable")
@@ -336,6 +345,9 @@ func (bridge *excelPricingRemoteEventsBridge) runGeneration(
 		func(cursor uint64) { bridge.persistCursor(epoch, cursor) },
 		func(revision excelPricingRemoteRevision) error {
 			return bridge.acceptRevision(epoch, source, revision)
+		},
+		func(event excelPricingRemoteSnapshotTerminalEvent) error {
+			return bridge.acceptSnapshotTerminal(epoch, source, event)
 		},
 	)
 	if err != nil && ctx.Err() == nil && bridge.generationCurrent(epoch) {
@@ -370,11 +382,63 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 	if epoch == 0 || bridge.epoch != epoch || revision.Source != source {
 		return errExcelPricingRemoteBridgeStale
 	}
+	bridge.verifiedRevision.Store(nil)
 	if err := bridge.dependencies.apply(revision); err != nil {
 		return err
 	}
 	bridge.acknowledged = true
+	verified := revision
+	bridge.verifiedRevision.Store(&verified)
 	return nil
+}
+
+func (bridge *excelPricingRemoteEventsBridge) acceptSnapshotTerminal(
+	epoch uint64,
+	source canonical.Source,
+	event excelPricingRemoteSnapshotTerminalEvent,
+) error {
+	if bridge == nil || bridge.terminals == nil {
+		return errExcelPricingRemoteBridgeStale
+	}
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if epoch == 0 || bridge.epoch != epoch || event.Source != source {
+		return errExcelPricingRemoteBridgeStale
+	}
+	return bridge.terminals.publishAuthenticated(event)
+}
+
+func (bridge *excelPricingRemoteEventsBridge) clearVerifiedRevision(epoch uint64) {
+	if bridge == nil || epoch == 0 {
+		return
+	}
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if bridge.epoch == epoch {
+		bridge.verifiedRevision.Store(nil)
+	}
+}
+
+func (bridge *excelPricingRemoteEventsBridge) snapshotTerminals() excelPricingRemoteSnapshotTerminalSource {
+	if bridge == nil {
+		return nil
+	}
+	return bridge.terminals
+}
+
+func (bridge *excelPricingRemoteEventsBridge) revisionCurrent(
+	source canonical.Source,
+	stateRevision string,
+	catalogRevision string,
+) bool {
+	if bridge == nil || !validExcelPricingRemoteSource(source) ||
+		!validExcelPricingRemoteRevisionParts(stateRevision, catalogRevision) {
+		return false
+	}
+	verified := bridge.verifiedRevision.Load()
+	return verified != nil && verified.Source == source &&
+		verified.StateRevision == stateRevision &&
+		verified.CatalogRevision == catalogRevision
 }
 
 func (bridge *excelPricingRemoteEventsBridge) persistCursor(epoch, cursor uint64) {

--- a/pkg/server/excel_pricing_events_bridge_test.go
+++ b/pkg/server/excel_pricing_events_bridge_test.go
@@ -23,6 +23,7 @@ type excelPricingRemoteBridgeTestRun struct {
 	initialCursor uint64
 	onCursor      func(uint64)
 	onRevision    func(excelPricingRemoteRevision) error
+	onTerminal    func(excelPricingRemoteSnapshotTerminalEvent) error
 	stopped       chan struct{}
 }
 
@@ -56,6 +57,7 @@ func excelPricingRemoteBridgeTestRunner(
 	uint64,
 	func(uint64),
 	func(excelPricingRemoteRevision) error,
+	func(excelPricingRemoteSnapshotTerminalEvent) error,
 ) error {
 	return func(
 		ctx context.Context,
@@ -64,6 +66,7 @@ func excelPricingRemoteBridgeTestRunner(
 		initialCursor uint64,
 		onCursor func(uint64),
 		onRevision func(excelPricingRemoteRevision) error,
+		onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error {
 		call := &excelPricingRemoteBridgeTestRun{
 			config:        cfg,
@@ -71,6 +74,7 @@ func excelPricingRemoteBridgeTestRunner(
 			initialCursor: initialCursor,
 			onCursor:      onCursor,
 			onRevision:    onRevision,
+			onTerminal:    onTerminal,
 			stopped:       make(chan struct{}),
 		}
 		select {
@@ -136,6 +140,7 @@ func TestExcelPricingRemoteEventsBridgeCoalescesRestartToNewestGeneration(t *tes
 		initialCursor uint64,
 		onCursor func(uint64),
 		onRevision func(excelPricingRemoteRevision) error,
+		onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error {
 		call := &excelPricingRemoteBridgeTestRun{
 			config:        cfg,
@@ -143,6 +148,7 @@ func TestExcelPricingRemoteEventsBridgeCoalescesRestartToNewestGeneration(t *tes
 			initialCursor: initialCursor,
 			onCursor:      onCursor,
 			onRevision:    onRevision,
+			onTerminal:    onTerminal,
 			stopped:       make(chan struct{}),
 		}
 		runMu.Lock()
@@ -416,6 +422,86 @@ func TestExcelPricingRemoteEventsBridgeConfigRestartAndCursorOrdering(t *testing
 	waitExcelPricingRemoteBridgeTestSignal(t, callTwo.stopped, "replacement generation cancellation")
 }
 
+func TestExcelPricingRemoteEventsBridgeRetainsSnapshotTerminalBeforeCursorAck(t *testing.T) {
+	cfg := excelPricingRemoteBridgeTestConfig("generation-terminal")
+	source := excelPricingRemoteTestSource()
+	runs := make(chan *excelPricingRemoteBridgeTestRun, 1)
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		config:      func() appconfig.Config { return cfg },
+		resolve:     excelPricingRemoteBridgeTestResolve,
+		materialize: func(context.Context) (canonical.Source, error) { return source, nil },
+		run:         excelPricingRemoteBridgeTestRunner(runs),
+		apply:       func(excelPricingRemoteRevision) error { return nil },
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	var waitGroup sync.WaitGroup
+	bridge.start(ctx, &waitGroup)
+	call := nextExcelPricingRemoteBridgeTestRun(t, runs)
+	stateRevision := excelPricingRemoteTestRevision("b")
+	catalogRevision := excelPricingRemoteTestRevision("c")
+	revision := excelPricingRemoteRevision{
+		Source:                source,
+		StateRevision:         stateRevision,
+		CatalogRevision:       catalogRevision,
+		PricingStateRevision:  excelPricingRemoteTestRevision("d"),
+		PricingPolicyRevision: excelPricingRemoteTestRevision("e"),
+		ETag:                  `"` + stateRevision + `"`,
+	}
+	if err := call.onRevision(revision); err != nil {
+		cancel()
+		waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+		t.Fatalf("accept revision: %v", err)
+	}
+	const requestID = "snapshot-terminal-request-0001"
+	subscription, err := bridge.snapshotTerminals().Subscribe(requestID, source, stateRevision)
+	if err != nil {
+		cancel()
+		waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer subscription.Close()
+	snapshotRevision := excelPricingRemoteTestRevision("f")
+	event := excelPricingRemoteSnapshotTerminalEvent{
+		Schema:               excelPricingRemoteSnapshotEventSchema,
+		SchemaVersion:        1,
+		BuildID:              "snapshot-terminal-build-0001",
+		RequestID:            requestID,
+		Status:               "ready",
+		Source:               source,
+		StateRevision:        stateRevision,
+		PricingStateRevision: revision.PricingStateRevision,
+		CatalogRevision:      catalogRevision,
+		SnapshotToken:        "snapshot-terminal-token-0001",
+		SnapshotRevision:     snapshotRevision,
+		Digest:               snapshotRevision,
+		SnapshotPath:         "/wp-json/digitalogic/pricing/sync/snapshots/snapshot-terminal-token-0001",
+		IdempotencyKey:       excelPricingRemoteTestRevision("0"),
+		EventID:              19,
+	}
+	if err := call.onTerminal(event); err != nil {
+		cancel()
+		waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+		t.Fatalf("retain terminal: %v", err)
+	}
+	call.onCursor(event.EventID)
+	received, err := subscription.Wait(t.Context())
+	if err != nil || received != event {
+		cancel()
+		waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+		t.Fatalf("terminal received=%+v err=%v", received, err)
+	}
+	_, cursor, acknowledged := excelPricingRemoteBridgeState(bridge)
+	if cursor != event.EventID || !acknowledged ||
+		!bridge.revisionCurrent(source, stateRevision, catalogRevision) {
+		cancel()
+		waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+		t.Fatalf("terminal cursor=%d acknowledged=%v revision_current=%v",
+			cursor, acknowledged, bridge.revisionCurrent(source, stateRevision, catalogRevision))
+	}
+	cancel()
+	waitExcelPricingRemoteBridgeTestGroup(t, &waitGroup)
+}
+
 func TestExcelPricingRemoteEventsBridgeSourceFenceRemovalAndReset(t *testing.T) {
 	var stateMu sync.RWMutex
 	cfg := excelPricingRemoteBridgeTestConfig("generation-a")
@@ -621,6 +707,7 @@ func TestExcelPricingRemoteEventsBridgeLogsAreSecretSafe(t *testing.T) {
 			uint64,
 			func(uint64),
 			func(excelPricingRemoteRevision) error,
+			func(excelPricingRemoteSnapshotTerminalEvent) error,
 		) error {
 			return fmt.Errorf("transport rejected %s with %s", privateEndpoint, privateSecret)
 		},

--- a/pkg/server/excel_pricing_events_client.go
+++ b/pkg/server/excel_pricing_events_client.go
@@ -728,9 +728,10 @@ func (client *excelPricingRemoteEventsClient) rememberRevision(revision excelPri
 // runExcelPricingRemoteEvents is the compile-isolated lifecycle entrypoint.
 // The Server owner must run it under backgroundCtx/backgroundWG with a freshly
 // materialized canonical source, restart it whenever that local source changes,
-// and supply a synchronous onRevision hook that invalidates the old snapshot
-// generation before returning. A returned nil acknowledgement permits the
-// durable remote cursor to advance.
+// and supply synchronous revision and snapshot-terminal hooks. The revision
+// hook invalidates the old snapshot generation; the terminal hook durably
+// retains a waiter event. Only a nil acknowledgement permits the durable
+// remote cursor to advance.
 func runExcelPricingRemoteEvents(
 	ctx context.Context,
 	cfg updateout.Config,
@@ -738,11 +739,13 @@ func runExcelPricingRemoteEvents(
 	initialCursor uint64,
 	onCursor func(uint64),
 	onRevision func(excelPricingRemoteRevision) error,
+	onSnapshotTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 ) error {
 	client, err := newExcelPricingRemoteEventsClient(cfg, source, excelPricingRemoteEventsOptions{
-		InitialCursor: initialCursor,
-		OnCursor:      onCursor,
-		OnRevision:    onRevision,
+		InitialCursor:      initialCursor,
+		OnCursor:           onCursor,
+		OnRevision:         onRevision,
+		OnSnapshotTerminal: onSnapshotTerminal,
 	})
 	if err != nil {
 		return err

--- a/pkg/server/excel_pricing_remote_snapshot.go
+++ b/pkg/server/excel_pricing_remote_snapshot.go
@@ -502,9 +502,32 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 	}
 	defer subscription.Close()
 
-	build, status, err := client.startSnapshot(ctx, requestID, maxAgeSeconds, revision)
-	if err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, err
+	}
+	// Once the idempotent start POST is dispatched, keep it alive long enough to
+	// receive the build receipt even if the local job is cancelled. Otherwise the
+	// provider can accept work while cancellation tears down the response before
+	// we learn the build ID needed for the compensating DELETE. The original
+	// deadline and the HTTP client's timeout still bound this commit window.
+	startContext := context.WithoutCancel(ctx)
+	var stopStart context.CancelFunc
+	if deadline, ok := ctx.Deadline(); ok {
+		startContext, stopStart = context.WithDeadline(startContext, deadline)
+	} else {
+		startContext, stopStart = context.WithCancel(startContext)
+	}
+	build, status, err := client.startSnapshot(startContext, requestID, maxAgeSeconds, revision)
+	stopStart()
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, err
+	}
+	if contextErr := ctx.Err(); contextErr != nil {
+		client.cancelSnapshot(build.CancelURL, build.BuildID)
+		return nil, contextErr
 	}
 	if status == http.StatusAccepted {
 		event, waitErr := subscription.Wait(ctx)
@@ -901,7 +924,9 @@ func validateExcelPricingRemoteSnapshotPayload(
 		return errExcelPricingRemoteSnapshotProtocol
 	}
 	if payload.PageSize != excelPricingSnapshotPageSize || payload.RowCount < 0 ||
+		payload.RowCount > excelPricingSnapshotPageSize*excelPricingSnapshotMaxPages ||
 		payload.DistinctSyncKeys != payload.RowCount || payload.RemoteTotal != payload.RowCount ||
+		payload.PageCount < 1 || payload.PageCount > excelPricingSnapshotMaxPages ||
 		payload.PageCount != max(1, (payload.RowCount+payload.PageSize-1)/payload.PageSize) ||
 		len(payload.PageDigests) != payload.PageCount || len(payload.Catalog.Rows) != payload.RowCount ||
 		payload.Catalog.Dataset != "reconciled_products" || payload.Catalog.Locale != "fa" ||

--- a/pkg/server/excel_pricing_remote_snapshot_test.go
+++ b/pkg/server/excel_pricing_remote_snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/atomicdeploy/patris-export/pkg/appconfig"
 	"github.com/atomicdeploy/patris-export/pkg/canonical"
 	"github.com/atomicdeploy/patris-export/pkg/updateout"
 )
@@ -32,6 +33,11 @@ type excelPricingRemoteSnapshotFixture struct {
 	mode           string
 	badSnapshotURL string
 	badETag        bool
+	acceptAnyID    bool
+	startHeld      chan struct{}
+	releaseStart   chan struct{}
+	startHeldOnce  sync.Once
+	releaseOnce    sync.Once
 
 	mu            sync.Mutex
 	revisionCalls int
@@ -39,6 +45,7 @@ type excelPricingRemoteSnapshotFixture struct {
 	bulkCalls     int
 	statusCalls   int
 	cancelCalls   int
+	legacyCalls   int
 	headerFailure string
 }
 
@@ -104,6 +111,225 @@ func TestExcelPricingRemoteSnapshotColdCompletesFromTerminalEventOnly(t *testing
 		t.Fatalf("snapshot revision = %q", result.SnapshotRevision)
 	}
 	fixture.assertCalls(t, 1, 1, 1, 0, 0)
+}
+
+func TestExcelPricingSnapshotProductionCollectorUsesBulkAndPreservesCompositeIdentity(t *testing.T) {
+	fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+	defer fixture.Close()
+	fixture.acceptAnyID = true
+	server, token := newExcelPricingRemoteSnapshotProductionServer(t, fixture)
+
+	start := func(requestID, expected string) (*httptest.ResponseRecorder, string) {
+		t.Helper()
+		request := authenticatedExcelPricingRequest(
+			http.MethodPost,
+			"/api/pricing-sync/snapshots",
+			validExcelPricingSnapshotStartBodyWithProjection(
+				fixture.source,
+				requestID,
+				"fa",
+				0,
+				expected,
+				excelPricingSnapshotProjectionExcelV1,
+			),
+			token,
+		)
+		request.Header.Set("Idempotency-Key", requestID)
+		response := httptest.NewRecorder()
+		server.router.ServeHTTP(response, request)
+		return response, excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+	}
+
+	firstResponse, firstJobID := start("snapshot-production-bulk-0001", "")
+	if firstResponse.Code != http.StatusAccepted {
+		t.Fatalf("first start=%d: %s", firstResponse.Code, firstResponse.Body.String())
+	}
+	firstStatus := waitForExcelPricingSnapshotStatus(t, server, token, firstJobID, "ready")
+	if firstStatus["state_revision"] != fixture.revision.StateRevision {
+		t.Fatalf("first composite status=%#v", firstStatus)
+	}
+
+	payloadRequest := authenticatedExcelPricingRequest(
+		http.MethodGet,
+		"/api/pricing-sync/snapshots/"+firstJobID+"/payload",
+		"",
+		token,
+	)
+	payloadResponse := httptest.NewRecorder()
+	server.router.ServeHTTP(payloadResponse, payloadRequest)
+	if payloadResponse.Code != http.StatusOK ||
+		payloadResponse.Header().Get("ETag") !=
+			excelPricingSnapshotETag(excelPricingSnapshotDigest(payloadResponse.Body.Bytes())) {
+		t.Fatalf("payload status=%d etag=%q", payloadResponse.Code, payloadResponse.Header().Get("ETag"))
+	}
+	var payload excelPricingSnapshotPayload
+	if err := json.Unmarshal(payloadResponse.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	var adaptedState struct {
+		StateRevision        string `json:"state_revision"`
+		PricingStateRevision string `json:"pricing_state_revision"`
+	}
+	if err := json.Unmarshal(payload.State, &adaptedState); err != nil {
+		t.Fatal(err)
+	}
+	if payload.StateRevision != fixture.revision.StateRevision ||
+		payload.Projection != excelPricingSnapshotProjectionExcelV1 ||
+		len(payload.RowFields) != len(excelPricingSnapshotExcelV1RowFields) ||
+		payload.MutationGuard.ExpectedStateRevision != fixture.revision.StateRevision ||
+		adaptedState.StateRevision != fixture.revision.StateRevision ||
+		adaptedState.PricingStateRevision != fixture.revision.PricingStateRevision ||
+		adaptedState.StateRevision == adaptedState.PricingStateRevision ||
+		payload.Integrity.StateDigest != excelPricingSnapshotDigest(payload.State) {
+		t.Fatalf("adapted payload=%+v adapted state=%+v", payload, adaptedState)
+	}
+	server.excelPricing.snapshots.mu.Lock()
+	firstSnapshot := server.excelPricing.snapshots.jobs[firstJobID].snapshot
+	server.excelPricing.snapshots.mu.Unlock()
+	if firstSnapshot == nil ||
+		firstSnapshot.stateRevision != fixture.revision.StateRevision ||
+		firstSnapshot.pricingStateRevision != fixture.revision.PricingStateRevision ||
+		firstSnapshot.upstreamCatalogRevision != fixture.revision.CatalogRevision {
+		t.Fatalf("internal snapshot identity=%+v", firstSnapshot)
+	}
+
+	bridge := server.excelPricingRemote
+	bridge.verifiedRevision.Store(&excelPricingRemoteRevision{
+		Source:          fixture.source,
+		StateRevision:   fixture.revision.StateRevision,
+		CatalogRevision: fixture.revision.CatalogRevision,
+	})
+
+	// max_age=0 without an expected revision remains a forced rebuild even
+	// while the authenticated event bridge confirms the cached composite.
+	secondResponse, secondJobID := start("snapshot-production-bulk-0002", "")
+	if secondResponse.Code != http.StatusAccepted {
+		t.Fatalf("second start=%d: %s", secondResponse.Code, secondResponse.Body.String())
+	}
+	waitForExcelPricingSnapshotStatus(t, server, token, secondJobID, "ready")
+
+	// An exact caller revision may reuse only while the bridge still confirms
+	// that same source/composite/catalog identity.
+	thirdResponse, thirdJobID := start(
+		"snapshot-production-bulk-0003",
+		fixture.revision.StateRevision,
+	)
+	if thirdResponse.Code != http.StatusOK || thirdJobID == secondJobID {
+		t.Fatalf("exact cache start=%d second=%q third=%q: %s",
+			thirdResponse.Code, secondJobID, thirdJobID, thirdResponse.Body.String())
+	}
+	var thirdStatus map[string]interface{}
+	if err := json.Unmarshal(thirdResponse.Body.Bytes(), &thirdStatus); err != nil {
+		t.Fatal(err)
+	}
+	if thirdStatus["cached"] != true {
+		t.Fatalf("exact cache status=%#v", thirdStatus)
+	}
+	bridge.verifiedRevision.Store(&excelPricingRemoteRevision{
+		Source:          fixture.source,
+		StateRevision:   testExcelPricingRevision('9'),
+		CatalogRevision: fixture.revision.CatalogRevision,
+	})
+	fourthResponse, fourthJobID := start(
+		"snapshot-production-bulk-0004",
+		fixture.revision.StateRevision,
+	)
+	if fourthResponse.Code != http.StatusAccepted {
+		t.Fatalf("stale exact cache start=%d: %s", fourthResponse.Code, fourthResponse.Body.String())
+	}
+	waitForExcelPricingSnapshotStatus(t, server, token, fourthJobID, "ready")
+	fixture.assertCalls(t, 3, 3, 3, 0, 0)
+	fixture.assertNoLegacyStateCalls(t)
+}
+
+func TestExcelPricingSnapshotProductionCollectorColdTerminalAndCancel(t *testing.T) {
+	t.Run("terminal", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "event_after_response")
+		defer fixture.Close()
+		fixture.acceptAnyID = true
+		server, token := newExcelPricingRemoteSnapshotProductionServer(t, fixture)
+		requestID := "snapshot-production-cold-terminal-0001"
+		request := authenticatedExcelPricingRequest(
+			http.MethodPost,
+			"/api/pricing-sync/snapshots",
+			validExcelPricingSnapshotStartBody(fixture.source, requestID, "fa", 0),
+			token,
+		)
+		request.Header.Set("Idempotency-Key", requestID)
+		response := httptest.NewRecorder()
+		server.router.ServeHTTP(response, request)
+		jobID := excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+		status := waitForExcelPricingSnapshotStatus(t, server, token, jobID, "ready")
+		if status["state_revision"] != fixture.revision.StateRevision {
+			t.Fatalf("cold terminal status=%#v", status)
+		}
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		fixture.assertNoLegacyStateCalls(t)
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cold_start_inflight")
+		defer fixture.Close()
+		fixture.acceptAnyID = true
+		server, token := newExcelPricingRemoteSnapshotProductionServer(t, fixture)
+		requestID := "snapshot-production-cold-cancel-0001"
+		request := authenticatedExcelPricingRequest(
+			http.MethodPost,
+			"/api/pricing-sync/snapshots",
+			validExcelPricingSnapshotStartBody(fixture.source, requestID, "fa", 0),
+			token,
+		)
+		request.Header.Set("Idempotency-Key", requestID)
+		response := httptest.NewRecorder()
+		server.router.ServeHTTP(response, request)
+		jobID := excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+		select {
+		case <-fixture.startHeld:
+		case <-time.After(time.Second):
+			t.Fatal("remote cold build did not reach the in-flight response gate")
+		}
+		cancelRequest := authenticatedExcelPricingRequest(
+			http.MethodDelete,
+			"/api/pricing-sync/snapshots/"+jobID,
+			"",
+			token,
+		)
+		cancelResponse := httptest.NewRecorder()
+		server.router.ServeHTTP(cancelResponse, cancelRequest)
+		if cancelResponse.Code != http.StatusAccepted {
+			t.Fatalf("cancel status=%d: %s", cancelResponse.Code, cancelResponse.Body.String())
+		}
+		fixture.releaseHeldStart()
+		waitForExcelPricingSnapshotStatus(t, server, token, jobID, "cancelled")
+		fixture.assertCalls(t, 1, 1, 0, 0, 1)
+		fixture.assertNoLegacyStateCalls(t)
+	})
+}
+
+func newExcelPricingRemoteSnapshotProductionServer(
+	t *testing.T,
+	fixture *excelPricingRemoteSnapshotFixture,
+) (*Server, string) {
+	t.Helper()
+	server := newExcelPricingTestServer(
+		t,
+		fixture.server.URL+"/wp-json/digitalogic/product-sync",
+	)
+	if err := server.config.Update(func(cfg *appconfig.Config) {
+		cfg.SendUpdates.ProductSyncSecretEnv = excelPricingRemoteSnapshotTestSecretEnv
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server.excelPricing.canonical = canonicalProjectionSequence(fixture.source)
+	server.excelPricing.snapshotCollector = nil
+	server.excelPricingRemote = &excelPricingRemoteEventsBridge{terminals: fixture.hub}
+	server.excelPricing.snapshotRevisionCurrent = server.excelPricingRemote.revisionCurrent
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close server: %v", err)
+		}
+	})
+	return server, openExcelPricingSession(t, server)
 }
 
 func TestExcelPricingRemoteSnapshotTerminalReplayIsConsumedWithoutStatusPolling(t *testing.T) {
@@ -302,6 +528,10 @@ func newExcelPricingRemoteSnapshotFixture(t *testing.T, mode string) *excelPrici
 		buildID:   "build_0000000000000001",
 		mode:      mode,
 	}
+	if mode == "cold_start_inflight" {
+		fixture.startHeld = make(chan struct{})
+		fixture.releaseStart = make(chan struct{})
+	}
 	fixture.revision = excelPricingRemoteRevisionResponse{
 		Schema:                excelPricingRemoteRevisionSchema,
 		SchemaVersion:         1,
@@ -323,7 +553,17 @@ func newExcelPricingRemoteSnapshotFixture(t *testing.T, mode string) *excelPrici
 }
 
 func (fixture *excelPricingRemoteSnapshotFixture) Close() {
+	fixture.releaseHeldStart()
 	fixture.server.Close()
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) releaseHeldStart() {
+	if fixture == nil || fixture.releaseStart == nil {
+		return
+	}
+	fixture.releaseOnce.Do(func() {
+		close(fixture.releaseStart)
+	})
 }
 
 func (fixture *excelPricingRemoteSnapshotFixture) Client(t *testing.T) *excelPricingRemoteSnapshotClient {
@@ -372,10 +612,18 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		fixture.startCalls++
 		fixture.mu.Unlock()
 		var request excelPricingRemoteSnapshotStartRequest
-		if json.NewDecoder(r.Body).Decode(&request) != nil || request.RequestID != fixture.requestID ||
+		if json.NewDecoder(r.Body).Decode(&request) != nil || request.RequestID == "" ||
 			request.Source != fixture.source || request.ExpectedStateRevision != fixture.revision.StateRevision ||
-			r.Header.Get("Idempotency-Key") != fixture.requestID ||
+			r.Header.Get("Idempotency-Key") != request.RequestID ||
 			r.Header.Get("If-Match") != `"`+fixture.revision.StateRevision+`"` {
+			http.Error(w, "bad start", http.StatusBadRequest)
+			return
+		}
+		if fixture.acceptAnyID {
+			fixture.mu.Lock()
+			fixture.requestID = request.RequestID
+			fixture.mu.Unlock()
+		} else if request.RequestID != fixture.currentRequestID() {
 			http.Error(w, "bad start", http.StatusBadRequest)
 			return
 		}
@@ -391,6 +639,12 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		build.SnapshotRevision = ""
 		build.Digest = ""
 		build.SnapshotURL = ""
+		if fixture.startHeld != nil {
+			fixture.startHeldOnce.Do(func() {
+				close(fixture.startHeld)
+			})
+			<-fixture.releaseStart
+		}
 		if fixture.mode == "event_before_response" {
 			if err := fixture.hub.publishAuthenticated(fixture.terminalEvent(1)); err != nil {
 				http.Error(w, "event", http.StatusInternalServerError)
@@ -425,6 +679,11 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			w.Header().Set("ETag", `"`+fixture.payload.Digest+`"`)
 		}
 		_, _ = w.Write(fixture.payloadBody)
+	case r.Method == http.MethodPost && r.URL.Path == "/wp-json/digitalogic/pricing/sync/state":
+		fixture.mu.Lock()
+		fixture.legacyCalls++
+		fixture.mu.Unlock()
+		http.Error(w, "legacy state paging forbidden", http.StatusTeapot)
 	default:
 		http.NotFound(w, r)
 	}
@@ -448,7 +707,7 @@ func (fixture *excelPricingRemoteSnapshotFixture) buildResponse() excelPricingRe
 		Schema:               excelPricingRemoteSnapshotBuildSchema,
 		SchemaVersion:        1,
 		BuildID:              fixture.buildID,
-		RequestID:            fixture.requestID,
+		RequestID:            fixture.currentRequestID(),
 		Status:               "ready",
 		Source:               fixture.source,
 		Locale:               "fa",
@@ -470,7 +729,7 @@ func (fixture *excelPricingRemoteSnapshotFixture) terminalEvent(eventID uint64) 
 		Schema:               excelPricingRemoteSnapshotEventSchema,
 		SchemaVersion:        1,
 		BuildID:              fixture.buildID,
-		RequestID:            fixture.requestID,
+		RequestID:            fixture.currentRequestID(),
 		Status:               "ready",
 		Source:               fixture.source,
 		StateRevision:        fixture.revision.StateRevision,
@@ -483,6 +742,12 @@ func (fixture *excelPricingRemoteSnapshotFixture) terminalEvent(eventID uint64) 
 		IdempotencyKey:       testExcelPricingRevision('6'),
 		EventID:              eventID,
 	}
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) currentRequestID() string {
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	return fixture.requestID
 }
 
 func (fixture *excelPricingRemoteSnapshotFixture) sourceQuery() string {
@@ -743,6 +1008,15 @@ func (fixture *excelPricingRemoteSnapshotFixture) assertNoStatusCalls(t *testing
 	defer fixture.mu.Unlock()
 	if fixture.statusCalls != 0 {
 		t.Fatalf("status calls = %d", fixture.statusCalls)
+	}
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) assertNoLegacyStateCalls(t *testing.T) {
+	t.Helper()
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	if fixture.legacyCalls != 0 {
+		t.Fatalf("legacy /state calls = %d", fixture.legacyCalls)
 	}
 }
 

--- a/pkg/server/excel_pricing_snapshot.go
+++ b/pkg/server/excel_pricing_snapshot.go
@@ -111,14 +111,23 @@ type excelPricingSnapshotPayload struct {
 }
 
 type excelPricingSnapshot struct {
-	revision      string
-	etagRevision  string
-	stateRevision string
-	createdAt     time.Time
-	expiresAt     time.Time
-	integrity     excelPricingSnapshotIntegrity
-	body          []byte
+	revision                string
+	etagRevision            string
+	stateRevision           string
+	pricingStateRevision    string
+	upstreamCatalogRevision string
+	createdAt               time.Time
+	expiresAt               time.Time
+	integrity               excelPricingSnapshotIntegrity
+	body                    []byte
 }
+
+type excelPricingSnapshotCollector func(
+	context.Context,
+	string,
+	excelPricingSnapshotStartRequest,
+	updateout.Config,
+) (*excelPricingSnapshot, string)
 
 type excelPricingStateChangeEvent struct {
 	Schema                   string                        `json:"schema"`
@@ -419,7 +428,13 @@ func (s *Server) handlePostExcelPricingSnapshot(w http.ResponseWriter, r *http.R
 		ageAllowed := request.MaxAgeSeconds > 0 && age >= 0 &&
 			age <= time.Duration(request.MaxAgeSeconds)*time.Second
 		revisionAllowed := request.ExpectedStateRevision != "" &&
-			request.ExpectedStateRevision == cached.stateRevision
+			request.ExpectedStateRevision == cached.stateRevision &&
+			s.excelPricing.snapshotRevisionCurrent != nil &&
+			s.excelPricing.snapshotRevisionCurrent(
+				request.Source,
+				cached.stateRevision,
+				cached.upstreamCatalogRevision,
+			)
 		if ageAllowed || revisionAllowed {
 			job := &excelPricingSnapshotJob{
 				id:                    jobID,
@@ -1862,6 +1877,90 @@ func (s *Server) collectExcelPricingSnapshot(
 	request excelPricingSnapshotStartRequest,
 	cfg updateout.Config,
 ) (*excelPricingSnapshot, string) {
+	if s != nil && s.excelPricing != nil && s.excelPricing.snapshotCollector != nil {
+		return s.excelPricing.snapshotCollector(ctx, jobID, request, cfg)
+	}
+	if s == nil || s.excelPricing == nil || s.excelPricingRemote == nil {
+		return nil, "remote_unavailable"
+	}
+	s.updateExcelPricingSnapshotProgress(jobID, "fetching_remote", 0, 1, 0)
+	client, err := newExcelPricingRemoteSnapshotClient(
+		cfg,
+		request.Source,
+		excelPricingRemoteSnapshotClientOptions{
+			HTTPClient: s.excelPricing.client,
+			Terminals:  s.excelPricingRemote.snapshotTerminals(),
+		},
+	)
+	if err != nil {
+		return nil, excelPricingRemoteSnapshotFailureCode(ctx, err)
+	}
+	result, err := client.Collect(
+		ctx,
+		excelPricingRemoteSnapshotRequestID(jobID),
+		request.MaxAgeSeconds,
+	)
+	if err != nil {
+		return nil, excelPricingRemoteSnapshotFailureCode(ctx, err)
+	}
+	s.updateExcelPricingSnapshotProgress(
+		jobID,
+		"validating",
+		resultRowsPageCount(result),
+		resultRowsPageCount(result),
+		len(result.Rows),
+	)
+	snapshot, err := buildExcelPricingSnapshotFromRemoteResult(
+		result,
+		excelPricingSnapshotProjection(request.Projection),
+		s.excelPricing.snapshots.now().UTC(),
+	)
+	if err != nil {
+		return nil, "snapshot_integrity_failed"
+	}
+	s.updateExcelPricingSnapshotProgress(
+		jobID,
+		"building",
+		snapshot.integrity.PageCount,
+		snapshot.integrity.PageCount,
+		snapshot.integrity.RowCount,
+	)
+	return snapshot, ""
+}
+
+func resultRowsPageCount(result *excelPricingRemoteSnapshotResult) int {
+	if result == nil || len(result.Rows) == 0 {
+		return 1
+	}
+	return (len(result.Rows) + excelPricingSnapshotPageSize - 1) / excelPricingSnapshotPageSize
+}
+
+func excelPricingRemoteSnapshotFailureCode(ctx context.Context, err error) string {
+	if ctx != nil && ctx.Err() != nil {
+		return excelPricingSnapshotContextCode(ctx)
+	}
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		if ctx != nil {
+			return excelPricingSnapshotContextCode(ctx)
+		}
+		return "remote_unavailable"
+	case errors.Is(err, errExcelPricingRemoteSnapshotProtocol),
+		errors.Is(err, errExcelPricingRemoteSnapshotIntegrity):
+		return "snapshot_integrity_failed"
+	case errors.Is(err, errExcelPricingRemoteSnapshotConfiguration):
+		return "remote_not_configured"
+	default:
+		return "remote_unavailable"
+	}
+}
+
+func (s *Server) collectExcelPricingSnapshotPages(
+	ctx context.Context,
+	jobID string,
+	request excelPricingSnapshotStartRequest,
+	cfg updateout.Config,
+) (*excelPricingSnapshot, string) {
 	var first *excelPricingSnapshotPage
 	var allRows []json.RawMessage
 	seenKeys := make(map[string]struct{})
@@ -2303,6 +2402,202 @@ func excelPricingSnapshotStableCatalogMetadata(
 		metadata["reconciliation_"+key] = append(json.RawMessage(nil), raw...)
 	}
 	return metadata, nil
+}
+
+func buildExcelPricingSnapshotFromRemoteResult(
+	result *excelPricingRemoteSnapshotResult,
+	projection string,
+	now time.Time,
+) (*excelPricingSnapshot, error) {
+	if result == nil || !validExcelPricingRemoteSource(result.Source) ||
+		!validExcelPricingRemoteRevisionParts(
+			result.CompositeStateRevision,
+			result.PricingStateRevision,
+			result.PricingPolicyRevision,
+			result.CatalogRevision,
+			result.DatasetRevision,
+			result.SnapshotRevision,
+			result.MutationStateRevision,
+		) ||
+		result.MutationStateRevision != result.PricingStateRevision ||
+		!isStrongExcelPricingRevisionETag(result.ETag, result.SnapshotRevision) {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+	var remote excelPricingRemoteSnapshotPayload
+	if len(result.RawPayload) == 0 || json.Unmarshal(result.RawPayload, &remote) != nil ||
+		remote.Source != result.Source ||
+		remote.StateRevision != result.CompositeStateRevision ||
+		remote.PricingStateRevision != result.PricingStateRevision ||
+		remote.PricingPolicyRevision != result.PricingPolicyRevision ||
+		remote.CatalogRevision != result.CatalogRevision ||
+		remote.DatasetRevision != result.DatasetRevision ||
+		remote.SnapshotRevision != result.SnapshotRevision ||
+		remote.MutationGuard.ExpectedStateRevision != result.MutationStateRevision ||
+		remote.RowCount != len(result.Rows) ||
+		remote.RowCount > excelPricingSnapshotPageSize*excelPricingSnapshotMaxPages ||
+		remote.PageCount < 1 || remote.PageCount > excelPricingSnapshotMaxPages ||
+		remote.Integrity.RowCount != len(result.Rows) {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+
+	var rows []json.RawMessage
+	var rowFields []string
+	switch projection {
+	case excelPricingSnapshotProjectionFull:
+		rows = append([]json.RawMessage(nil), result.Rows...)
+	case excelPricingSnapshotProjectionExcelV1:
+		if len(result.ProjectedRows) != len(result.Rows) ||
+			len(result.ProjectedRowFields) != len(excelPricingSnapshotExcelV1RowFields) {
+			return nil, errExcelPricingRemoteSnapshotIntegrity
+		}
+		for index, expected := range excelPricingSnapshotExcelV1RowFields {
+			if result.ProjectedRowFields[index] != expected {
+				return nil, errExcelPricingRemoteSnapshotIntegrity
+			}
+		}
+		rows = append([]json.RawMessage(nil), result.ProjectedRows...)
+		rowFields = append([]string(nil), result.ProjectedRowFields...)
+	default:
+		return nil, errExcelPricingRemoteSnapshotConfiguration
+	}
+
+	var reconciliation excelPricingRemoteSnapshotReconciliation
+	if json.Unmarshal(remote.Reconciliation, &reconciliation) != nil {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+	warnings := reconciliation.Warnings
+	if warnings == nil {
+		warnings = []interface{}{}
+	}
+	warningsJSON, err := json.Marshal(warnings)
+	if err != nil {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+
+	type adaptedSource struct {
+		ID                     string `json:"id"`
+		Dataset                string `json:"dataset"`
+		CurrentRevision        string `json:"current_revision"`
+		SubmittedRevision      string `json:"submitted_revision"`
+		RevisionMatchesCurrent bool   `json:"revision_matches_current"`
+	}
+	type adaptedCatalog struct {
+		Dataset         string                         `json:"dataset"`
+		DatasetRevision string                         `json:"dataset_revision"`
+		Columns         json.RawMessage                `json:"columns"`
+		Reconciliation  json.RawMessage                `json:"reconciliation"`
+		Rows            []json.RawMessage              `json:"rows"`
+		Pagination      excelPricingSnapshotPagination `json:"pagination"`
+	}
+	state := struct {
+		Schema                string          `json:"schema"`
+		StateRevision         string          `json:"state_revision"`
+		PricingStateRevision  string          `json:"pricing_state_revision"`
+		PricingPolicyRevision string          `json:"pricing_policy_revision"`
+		CatalogRevision       string          `json:"catalog_revision"`
+		Status                string          `json:"status"`
+		Warnings              []interface{}   `json:"warnings"`
+		Source                adaptedSource   `json:"source"`
+		Settings              json.RawMessage `json:"settings"`
+		Catalog               adaptedCatalog  `json:"catalog"`
+	}{
+		Schema:                excelPricingStateSchema,
+		StateRevision:         result.CompositeStateRevision,
+		PricingStateRevision:  result.PricingStateRevision,
+		PricingPolicyRevision: result.PricingPolicyRevision,
+		CatalogRevision:       result.CatalogRevision,
+		Status:                "ready",
+		Warnings:              warnings,
+		Source: adaptedSource{
+			ID:                     result.Source.ID,
+			Dataset:                result.Source.Dataset,
+			CurrentRevision:        result.Source.Revision,
+			SubmittedRevision:      result.Source.Revision,
+			RevisionMatchesCurrent: true,
+		},
+		Settings: append(json.RawMessage(nil), remote.Settings...),
+		Catalog: adaptedCatalog{
+			Dataset:         remote.Catalog.Dataset,
+			DatasetRevision: remote.Catalog.DatasetRevision,
+			Columns:         append(json.RawMessage(nil), remote.Catalog.Columns...),
+			Reconciliation:  append(json.RawMessage(nil), remote.Catalog.Reconciliation...),
+			Rows:            rows,
+			Pagination: excelPricingSnapshotPagination{
+				Page: 1, Limit: len(rows), Total: len(rows), Pages: 1, HasMore: false,
+			},
+		},
+	}
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+	integrity := excelPricingSnapshotIntegrity{
+		Algorithm:             "sha256",
+		StateDigest:           excelPricingSnapshotDigest(stateJSON),
+		CatalogMetadataDigest: remote.Integrity.CatalogMetadataDigest,
+		PageRevisionsDigest:   remote.Integrity.PageRevisionsDigest,
+		WarningsDigest:        excelPricingSnapshotDigest(warningsJSON),
+		DatasetRevision:       result.DatasetRevision,
+		RemoteTotal:           remote.RemoteTotal,
+		RowCount:              len(rows),
+		DistinctSyncKeys:      len(rows),
+		PageCount:             remote.PageCount,
+		WarningCount:          len(warnings),
+	}
+	expiresAt := now.Add(excelPricingSnapshotMaxCacheAge)
+	revisionInput, _ := json.Marshal(struct {
+		Source        canonical.Source              `json:"source"`
+		StateRevision string                        `json:"state_revision"`
+		Projection    string                        `json:"projection"`
+		Integrity     excelPricingSnapshotIntegrity `json:"integrity"`
+	}{result.Source, result.CompositeStateRevision, projection, integrity})
+	snapshotRevision := excelPricingSnapshotDigest(revisionInput)
+	payload := excelPricingSnapshotPayload{
+		Schema:           excelPricingSnapshotPayloadSchema,
+		Projection:       projection,
+		RowFields:        rowFields,
+		SnapshotRevision: snapshotRevision,
+		Source:           result.Source,
+		StateRevision:    result.CompositeStateRevision,
+		CreatedAt:        now,
+		ExpiresAt:        expiresAt,
+		Integrity:        integrity,
+		// The loopback contract intentionally keeps the composite revision as
+		// the workbook guard. The remote pricing-only revision remains separately
+		// validated above and in the adapted state's internal metadata.
+		MutationGuard: excelPricingSnapshotMutationGuard{
+			ExpectedStateRevision: result.CompositeStateRevision,
+			Preview: excelPricingSnapshotMutationOperation{
+				Method:                 http.MethodPost,
+				Path:                   "/api/pricing-sync/preview",
+				RequiresIdempotencyKey: true,
+				RequiresIfMatch:        true,
+			},
+			Apply: excelPricingSnapshotMutationOperation{
+				Method:                 http.MethodPost,
+				Path:                   "/api/pricing-sync/apply",
+				RequiresIdempotencyKey: true,
+				RequiresIfMatch:        true,
+				Confirmation:           "APPLY",
+			},
+		},
+		State: stateJSON,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errExcelPricingRemoteSnapshotIntegrity
+	}
+	return &excelPricingSnapshot{
+		revision:                snapshotRevision,
+		etagRevision:            excelPricingSnapshotDigest(body),
+		stateRevision:           result.CompositeStateRevision,
+		pricingStateRevision:    result.PricingStateRevision,
+		upstreamCatalogRevision: result.CatalogRevision,
+		createdAt:               now,
+		expiresAt:               expiresAt,
+		integrity:               integrity,
+		body:                    body,
+	}, nil
 }
 
 func buildExcelPricingSnapshot(

--- a/pkg/server/excel_pricing_test.go
+++ b/pkg/server/excel_pricing_test.go
@@ -920,6 +920,8 @@ func newExcelPricingTestServer(t *testing.T, productSyncURL string) *Server {
 		excelPricing: state,
 		dbPath:       "dataset",
 	}
+	state.snapshotCollector = server.collectExcelPricingSnapshotPages
+	state.snapshotRevisionCurrent = func(canonical.Source, string, string) bool { return true }
 	server.setupRoutes()
 	return server
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -221,6 +221,7 @@ func NewServerWithOptions(dbPath string, charMap converter.CharMapping, options 
 	}
 	s.excelPricing.canonical = s.canonicalRecordResultContext
 	s.excelPricingRemote = newExcelPricingRemoteEventsBridge(s)
+	s.excelPricing.snapshotRevisionCurrent = s.excelPricingRemote.revisionCurrent
 
 	// Set up routes
 	s.setupRoutes()

--- a/scripts/windows/Build-ExcelDashboard.ps1
+++ b/scripts/windows/Build-ExcelDashboard.ps1
@@ -658,6 +658,7 @@ function Remove-ExcelPrivatePackageMetadata([string]$Path) {
 }
 
 Assert-FontFamilyAvailable 'Yekan Bakh' 'Persian'
+Assert-FontFamilyAvailable 'Yekan Bakh FaNum' 'Persian price digits'
 Assert-FontFamilyAvailable 'Segoe UI' 'Latin'
 
 New-Item -ItemType Directory -Force (Split-Path -Parent $OutputPath) | Out-Null
@@ -1206,9 +1207,10 @@ try {
     $fontPolicy = @(
         @{ Row = 39; Label = 'قلم فارسی و متن‌های ترکیبی'; Value = 'Yekan Bakh'; Name = 'PersianFont' },
         @{ Row = 40; Label = 'قلم لاتین و شناسه‌های فنی'; Value = 'Segoe UI'; Name = 'LatinFont' },
-        @{ Row = 41; Label = 'حالت ممیزی قلم'; Value = 'RepairAndWarn'; Name = 'FontAuditMode' },
-        @{ Row = 42; Label = 'اعتبارسنجی قلم هنگام بازشدن'; Value = 'Yes'; Name = 'ValidateFontsOnOpen' },
-        @{ Row = 43; Label = 'اجازه قلم جایگزین'; Value = 'No'; Name = 'AllowFallback' }
+        @{ Row = 41; Label = 'حالت ممیزی قلم'; Value = 'ترمیم و هشدار'; Name = 'FontAuditMode' },
+        @{ Row = 42; Label = 'اعتبارسنجی قلم هنگام بازشدن'; Value = 'بله'; Name = 'ValidateFontsOnOpen' },
+        @{ Row = 43; Label = 'اجازه قلم جایگزین'; Value = 'خیر'; Name = 'AllowFallback' },
+        @{ Row = 44; Label = 'نمایش رقم‌های فارسی در قیمت فروش'; Value = 'بله'; Name = 'PriceDisplayFaNum' }
     )
     foreach ($setting in $fontPolicy) {
         $row = $setting.Row
@@ -1220,9 +1222,10 @@ try {
         $settings.Range("A${row}:F${row}").Borders.Color = ConvertTo-OleColor 'B9CCF4'
         [void]$workbook.Names.Add($setting.Name, $settings.Range("B${row}"))
     }
-    $settings.Range('B41').Validation.Add(3, 1, 1, 'Off,Warn,RepairAndWarn,Strict')
-    $settings.Range('B42').Validation.Add(3, 1, 1, 'Yes,No')
-    $settings.Range('B43').Validation.Add(3, 1, 1, 'Yes,No')
+    $settings.Range('B41').Validation.Add(3, 1, 1, 'خاموش,هشدار,ترمیم و هشدار,سختگیرانه')
+    $settings.Range('B42').Validation.Add(3, 1, 1, 'بله,خیر')
+    $settings.Range('B43').Validation.Add(3, 1, 1, 'بله,خیر')
+    $settings.Range('B44').Validation.Add(3, 1, 1, 'بله,خیر')
 
     $settings.Range('A45:F45').Merge()
     $settings.Range('A45').Value2 = 'زمان‌بندی مرحله‌های همگام‌سازی (ثانیه)'
@@ -1268,7 +1271,7 @@ try {
     # Never format only the first column of several adjacent merged rows.
     # Excel silently coalesces those rows into one large MergeArea, which
     # makes every setting except the first one inaccessible to VBA.
-    foreach ($row in @((10..15) + 18 + 19 + (21..23) + 26 + (39..43) + (46..55))) {
+    foreach ($row in @((10..15) + 18 + 19 + (21..23) + 26 + (39..44) + (46..55))) {
         $mergeCell = $settings.Range("B${row}")
         $mergeArea = $mergeCell.MergeArea
         try {
@@ -1299,14 +1302,16 @@ try {
     }
 
     # Apply the fixed role map after all cells/shapes exist. Font selection is
-    # role-based only; no content inspection or numeric font variant is used.
+    # role-based only; the sole numeric variant is the explicit selling-price
+    # FaNum toggle. Technical numerics and identifiers always remain Latin.
     Set-RangeFontSlots $priceList.Range('B1:K6') 'Yekan Bakh'
-    Set-RangeFontSlots $priceList.Range('B6:C6,F6:H6,J6') 'Segoe UI'
+    Set-RangeFontSlots $priceList.Range('B6') 'Yekan Bakh FaNum'
+    Set-RangeFontSlots $priceList.Range('C6,F6:H6,J6') 'Segoe UI'
     Set-RangeFontSlots $priceList.Range('I6,K6') 'Yekan Bakh'
     Set-RangeFontSlots $dashboard.Range('B1:I34') 'Yekan Bakh'
     Set-RangeFontSlots $dashboard.Range('B5:C6,D5:E6,F5:G6,H5:I6,B9:C10,D9:E10,F9:G10,H9:I10,B13:E14,F13:G14,H13:I14,C22:C24,C27:C29,C32:C34') 'Segoe UI'
     Set-RangeFontSlots $settings.Range('A1:F55') 'Yekan Bakh'
-    Set-RangeFontSlots $settings.Range('B3:F4,B7:F7,B10:F15,B18:F22,B24:F26,B39:F43,B46:F55') 'Segoe UI'
+    Set-RangeFontSlots $settings.Range('B3:F4,B7:F7,B10:F15,B18:F22,B24:F26,B39:F40,B46:F55') 'Segoe UI'
     Set-RangeFontSlots $syncData.Range('A1:W1') 'Yekan Bakh'
     Set-RangeFontSlots $syncData.Range('A2:P2,U2:W2') 'Segoe UI'
     Set-RangeFontSlots $syncData.Range('Q2:T2') 'Yekan Bakh'
@@ -1338,13 +1343,15 @@ try {
     }
     Assert-RangeFontSlots $priceList.Range('B5:K5') 'Yekan Bakh' 'Products headers'
     Assert-RangeFontSlots $priceList.Range('C3:E3') 'Yekan Bakh' 'search input'
-    Assert-RangeFontSlots $priceList.Range('B6:C6') 'Segoe UI' 'price and weight roles'
+    Assert-RangeFontSlots $priceList.Range('B6') 'Yekan Bakh FaNum' 'selling-price FaNum role'
+    Assert-RangeFontSlots $priceList.Range('C6') 'Segoe UI' 'weight role'
     Assert-RangeFontSlots $priceList.Range('H6,J6') 'Segoe UI' 'SKU and Woo ID roles'
     Assert-RangeFontSlots $priceList.Range('I6,K6') 'Yekan Bakh' 'name and category roles'
     Assert-RangeFontSlots $dashboard.Range('B1:I4') 'Yekan Bakh' 'dashboard text'
     Assert-RangeFontSlots $dashboard.Range('C22:C24') 'Segoe UI' 'dashboard counts'
     Assert-RangeFontSlots $settings.Range('A1:F2') 'Yekan Bakh' 'settings text'
-    Assert-RangeFontSlots $settings.Range('B39:F43') 'Segoe UI' 'font policy values'
+    Assert-RangeFontSlots $settings.Range('B39:F40') 'Segoe UI' 'font family values'
+    Assert-RangeFontSlots $settings.Range('B41:F44') 'Yekan Bakh' 'localized font policy values'
     Assert-RangeFontSlots $syncData.Range('A1:W1') 'Yekan Bakh' 'SyncData headers'
 
     $priceList.PageSetup.PrintArea = '$B$1:$O$30'

--- a/scripts/windows/Validate-ExcelPriceCalculator.cjs
+++ b/scripts/windows/Validate-ExcelPriceCalculator.cjs
@@ -276,9 +276,12 @@ function buildFailures(report, options) {
     report.fontAudit.passed === true
       && report.fontAudit.persianFont === 'Yekan Bakh'
       && report.fontAudit.latinFont === 'Segoe UI'
-      && report.fontAudit.auditMode === 'RepairAndWarn'
-      && report.fontAudit.validateOnOpen === 'Yes'
-      && report.fontAudit.allowFallback === 'No'
+      && report.fontAudit.auditMode === 'ترمیم و هشدار'
+      && report.fontAudit.validateOnOpen === 'بله'
+      && report.fontAudit.allowFallback === 'خیر'
+      && report.fontAudit.priceDisplayFaNum === 'بله'
+      && report.fontAudit.faNumToggle.enabled === true
+      && report.fontAudit.faNumToggle.disabled === true
       && report.fontAudit.invalidModeRejected === true
       && report.fontAudit.missingConfigRejected === true
       && report.fontAudit.missingFontRejected === true
@@ -289,9 +292,13 @@ function buildFailures(report, options) {
       && !report.fontAudit.friendlyError.includes('[pricing state]')
       && !report.fontAudit.friendlyError.toLowerCase().includes('http')
       && report.fontAudit.priceSlots.some((slot) => (
-        slot.name === 'Name' && slot.supported === true && slot.value === 'Segoe UI'
+        slot.name === 'Name' && slot.supported === true && slot.value === 'Yekan Bakh FaNum'
       ))
       && report.fontAudit.priceSlots.every((slot) => (
+        slot.supported === false || slot.value === 'Yekan Bakh FaNum'
+      ))
+      && report.fontAudit.technicalSlots.length > 0
+      && report.fontAudit.technicalSlots.every((slot) => (
         slot.supported === false || slot.value === 'Segoe UI'
       )),
     `the fixed font policy or hard font audit failed: ${JSON.stringify(report.fontAudit)}`,
@@ -977,14 +984,17 @@ function Test-SearchLiteralText([object]$excel, [object]$book) {
 function Test-FontAudit([object]$excel, [object]$book) {
     $settings = $null
     $table = $null
+    $tableDataRange = $null
     $priceDataRange = $null
     $priceColumn = $null
     $savedPersianFont = $null
     $savedAuditMode = $null
+    $savedPriceDisplayFaNum = $null
     $savedPriceFont = $null
     try {
         $settings = $book.Worksheets.Item(3)
         $table = Find-Table $book 'Products'
+        $tableDataRange = $table.DataBodyRange
         $priceDataRange = $table.ListColumns.Item(1).DataBodyRange
         if ($null -ne $priceDataRange) {
             $priceColumn = $priceDataRange.Cells.Item(1, 1)
@@ -1005,14 +1015,21 @@ function Test-FontAudit([object]$excel, [object]$book) {
         $policyFixturesPassed = [bool]$excel.Run($policyFixtureMacro)
         $savedPersianFont = $settings.Range('B39').Value2
         $savedAuditMode = $settings.Range('B41').Value2
+        $savedPriceDisplayFaNum = $settings.Range('B44').Value2
         $driftRepaired = $false
+        $faNumEnabled = $false
+        $faNumDisabled = $false
         $priceSlots = @()
+        $technicalSlots = @()
         if ($null -ne $priceColumn) {
             $savedPriceFont = $priceColumn.Font.Name
-            $priceColumn.Font.Name = 'Arial'
-            $repairMacro = "'$($book.Name.Replace("'", "''"))'!ProductCatalogSync.RepairFontDriftForValidation"
-            $driftRepaired = [bool]$excel.Run($repairMacro) -and
-                [Convert]::ToString($priceColumn.Font.Name, $invariant) -eq 'Segoe UI'
+            $applyPriceFontMacro = "'$($book.Name.Replace("'", "''"))'!ProductCatalogSync.ApplyPriceDisplayFontSetting"
+            $settings.Range('B44').Value2 = 'بله'
+            [void]$excel.Run($applyPriceFontMacro)
+            $faNumEnabled = [Convert]::ToString(
+                $priceColumn.Font.Name,
+                $invariant
+            ) -eq 'Yekan Bakh FaNum'
             $priceSlots = @(
                 foreach ($slot in @('Name', 'NameComplexScript', 'NameFarEast')) {
                     try {
@@ -1031,6 +1048,44 @@ function Test-FontAudit([object]$excel, [object]$book) {
                     }
                 }
             )
+            foreach ($columnIndex in @(2, 5, 6, 7, 9)) {
+                $technicalCell = $null
+                try {
+                    $technicalCell = $tableDataRange.Cells.Item(1, $columnIndex)
+                    foreach ($slot in @('Name', 'NameComplexScript', 'NameFarEast')) {
+                        try {
+                            $slotValue = [Convert]::ToString($technicalCell.Font.$slot, $invariant)
+                            $technicalSlots += [pscustomobject]@{
+                                column = $columnIndex
+                                name = $slot
+                                supported = $slot -eq 'Name' -or -not [string]::IsNullOrWhiteSpace($slotValue)
+                                value = $slotValue
+                            }
+                        } catch {
+                            $technicalSlots += [pscustomobject]@{
+                                column = $columnIndex
+                                name = $slot
+                                supported = $false
+                                value = ''
+                            }
+                        }
+                    }
+                } finally {
+                    Release-ComObject $technicalCell
+                }
+            }
+            $settings.Range('B44').Value2 = 'خیر'
+            [void]$excel.Run($applyPriceFontMacro)
+            $faNumDisabled = [Convert]::ToString(
+                $priceColumn.Font.Name,
+                $invariant
+            ) -eq 'Segoe UI'
+            $settings.Range('B44').Value2 = 'بله'
+            [void]$excel.Run($applyPriceFontMacro)
+            $priceColumn.Font.Name = 'Arial'
+            $repairMacro = "'$($book.Name.Replace("'", "''"))'!ProductCatalogSync.RepairFontDriftForValidation"
+            $driftRepaired = [bool]$excel.Run($repairMacro) -and
+                [Convert]::ToString($priceColumn.Font.Name, $invariant) -eq 'Yekan Bakh FaNum'
         }
 
         return [pscustomobject]@{
@@ -1040,6 +1095,11 @@ function Test-FontAudit([object]$excel, [object]$book) {
             auditMode = [Convert]::ToString($settings.Range('B41').Value2, $invariant)
             validateOnOpen = [Convert]::ToString($settings.Range('B42').Value2, $invariant)
             allowFallback = [Convert]::ToString($settings.Range('B43').Value2, $invariant)
+            priceDisplayFaNum = [Convert]::ToString($savedPriceDisplayFaNum, $invariant)
+            faNumToggle = [pscustomobject]@{
+                enabled = $faNumEnabled
+                disabled = $faNumDisabled
+            }
             invalidModeRejected = $policyFixturesPassed
             missingConfigRejected = $policyFixturesPassed
             missingFontRejected = $policyFixturesPassed
@@ -1047,6 +1107,7 @@ function Test-FontAudit([object]$excel, [object]$book) {
             dialogPassed = $dialogPassed
             friendlyError = $friendlyError
             priceSlots = $priceSlots
+            technicalSlots = $technicalSlots
         }
     } finally {
         if ($null -ne $settings) {
@@ -1056,12 +1117,20 @@ function Test-FontAudit([object]$excel, [object]$book) {
             if ($null -ne $savedAuditMode) {
                 $settings.Range('B41').Value2 = $savedAuditMode
             }
+            if ($null -ne $savedPriceDisplayFaNum) {
+                $settings.Range('B44').Value2 = $savedPriceDisplayFaNum
+                if ($null -ne $priceColumn) {
+                    $restorePriceFontMacro = "'$($book.Name.Replace("'", "''"))'!ProductCatalogSync.ApplyPriceDisplayFontSetting"
+                    [void]$excel.Run($restorePriceFontMacro)
+                }
+            }
         }
         if ($null -ne $priceColumn -and $null -ne $savedPriceFont) {
             $priceColumn.Font.Name = $savedPriceFont
         }
         Release-ComObject $priceColumn
         Release-ComObject $priceDataRange
+        Release-ComObject $tableDataRange
         Release-ComObject $table
         Release-ComObject $settings
     }


### PR DESCRIPTION
## نتیجه / Outcome

این PR ادامهٔ مستقیم #230 است و دو نقص پذیرش باقی‌مانده را می‌بندد: مسیر event-driven واقعی snapshot در Patris و reentrancy/UI/Save-As در فایل Excel.

This directly continues #230 and closes the remaining production event-path and native workbook lifecycle gaps.

## Changes

- Production snapshot collection consumes the durable bulk build terminal; legacy state paging is test-only.
- Terminal retention, generation/source fencing, cursor-after-ack ordering, exact composite reuse, and orphan-build cancellation are fail-closed.
- WinHTTP callbacks defer all workbook work through one qualified one-shot dispatcher.
- Search remains responsive during network waits and pauses only for the atomic table commit.
- Save As cancels and rebinds workbook-qualified timers; Apply/SSE self-invalidation is fenced.
- Selling-price FaNum is default-on and price-only; technical numerics remain Latin; visible Settings values are Persian.

## Validation

- Native-CGO `go test ./... -count=1 -timeout=10m`: PASS.
- Native-CGO `go vet ./...`: PASS.
- Cancellation regression: 100/100; focused race suites: PASS.
- Recordsink dynamic calculator and full package: PASS.
- Node syntax, PowerShell parser, gofmt, and diff checks: PASS.

WordPress terminal-publisher activation and Office/native workbook acceptance are proceeding in the same authorized release run; this PR does not claim those external gates by itself.

Closes the remaining code scope of #230; the issue stays open until the native/capture evidence is complete.