### PR TITLE
fix(server): dedupe pricing revision replays

### DIFF
--- a/pkg/server/excel_pricing_events_bridge.go
+++ b/pkg/server/excel_pricing_events_bridge.go
@@ -382,6 +382,14 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 	if epoch == 0 || bridge.epoch != epoch || revision.Source != source {
 		return errExcelPricingRemoteBridgeStale
 	}
+	// A reconnect validates the authoritative composite before replaying queued
+	// frames. Treat an identical authenticated composite as an acknowledgement,
+	// not a state change: reapplying it would advance the local generation and
+	// cancel a snapshot that already fetched the same revision.
+	if sameExcelPricingRemoteCompositeRevision(bridge.verifiedRevision.Load(), revision) {
+		bridge.acknowledged = true
+		return nil
+	}
 	bridge.verifiedRevision.Store(nil)
 	if err := bridge.dependencies.apply(revision); err != nil {
 		return err
@@ -390,6 +398,19 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 	verified := revision
 	bridge.verifiedRevision.Store(&verified)
 	return nil
+}
+
+func sameExcelPricingRemoteCompositeRevision(
+	previous *excelPricingRemoteRevision,
+	current excelPricingRemoteRevision,
+) bool {
+	return previous != nil &&
+		previous.Source == current.Source &&
+		previous.StateRevision == current.StateRevision &&
+		previous.CatalogRevision == current.CatalogRevision &&
+		previous.PricingStateRevision == current.PricingStateRevision &&
+		previous.PricingPolicyRevision == current.PricingPolicyRevision &&
+		previous.ETag == current.ETag
 }
 
 func (bridge *excelPricingRemoteEventsBridge) acceptSnapshotTerminal(

--- a/pkg/server/excel_pricing_events_bridge_test.go
+++ b/pkg/server/excel_pricing_events_bridge_test.go
@@ -658,6 +658,127 @@ func TestExcelPricingRemoteEventsBridgeCursorRequiresSuccessfulApplyAndAllowsRes
 	}
 }
 
+func TestExcelPricingRemoteEventsBridgeIdenticalCompositeDoesNotCancelActiveSnapshot(t *testing.T) {
+	server := &Server{excelPricing: newExcelPricingState()}
+	store := server.excelPricing.snapshots
+	source := excelPricingRemoteTestSource()
+	revision := excelPricingRemoteRevision{
+		Source:                source,
+		StateRevision:         excelPricingRemoteTestRevision("1"),
+		CatalogRevision:       excelPricingRemoteTestRevision("2"),
+		PricingStateRevision:  excelPricingRemoteTestRevision("3"),
+		PricingPolicyRevision: excelPricingRemoteTestRevision("4"),
+		ETag:                  `"` + excelPricingRemoteTestRevision("1") + `"`,
+		Cause:                 "initial_validation",
+		IdempotencyKey:        excelPricingRemoteTestRevision("5"),
+		EventID:               1,
+		ValidationOrigin:      "connected",
+	}
+	applyCalls := 0
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		apply: func(candidate excelPricingRemoteRevision) error {
+			applyCalls++
+			return server.notifyExcelPricingRemoteRevisionChanged(candidate)
+		},
+	})
+	bridge.mu.Lock()
+	bridge.epoch = 1
+	bridge.mu.Unlock()
+
+	store.mu.Lock()
+	initialGeneration := store.generation
+	store.mu.Unlock()
+	if err := bridge.acceptRevision(1, source, revision); err != nil {
+		t.Fatalf("accept initial revision: %v", err)
+	}
+	store.mu.Lock()
+	establishedGeneration := store.generation
+	establishedEvents := len(store.events)
+	store.mu.Unlock()
+	if applyCalls != 1 || establishedGeneration != initialGeneration+1 {
+		t.Fatalf("initial composite apply_calls=%d generation=%d want=%d",
+			applyCalls, establishedGeneration, initialGeneration+1)
+	}
+
+	jobContext, cancelJob := context.WithCancel(context.Background())
+	defer cancelJob()
+	store.mu.Lock()
+	store.jobs["active-revision-replay"] = &excelPricingSnapshotJob{
+		id:              "active-revision-replay",
+		status:          "running",
+		startGeneration: store.generation,
+		cancel:          cancelJob,
+	}
+	store.activeJobID = "active-revision-replay"
+	store.mu.Unlock()
+
+	replay := revision
+	replay.Cause = "reconnect_validation"
+	replay.IdempotencyKey = excelPricingRemoteTestRevision("6")
+	replay.EventID = 9
+	replay.ValidationOrigin = "reconnect"
+	if err := bridge.acceptRevision(1, source, replay); err != nil {
+		t.Fatalf("accept identical replay: %v", err)
+	}
+	bridge.persistCursor(1, replay.EventID)
+	select {
+	case <-jobContext.Done():
+		t.Fatal("identical composite replay cancelled the active snapshot")
+	default:
+	}
+	store.mu.Lock()
+	replayGeneration := store.generation
+	replayEvents := len(store.events)
+	replayJobStatus := store.jobs["active-revision-replay"].status
+	store.mu.Unlock()
+	_, cursor, acknowledged := excelPricingRemoteBridgeState(bridge)
+	if applyCalls != 1 || replayGeneration != establishedGeneration ||
+		replayEvents != establishedEvents || replayJobStatus != "running" ||
+		cursor != replay.EventID || !acknowledged {
+		t.Fatalf("identical replay apply_calls=%d generation=%d events=%d job=%s cursor=%d acknowledged=%v",
+			applyCalls, replayGeneration, replayEvents, replayJobStatus, cursor, acknowledged)
+	}
+
+	changed := replay
+	changed.StateRevision = excelPricingRemoteTestRevision("7")
+	changed.PricingStateRevision = excelPricingRemoteTestRevision("8")
+	changed.ETag = `"` + changed.StateRevision + `"`
+	changed.EventID++
+	if err := bridge.acceptRevision(1, source, changed); err != nil {
+		t.Fatalf("accept changed composite: %v", err)
+	}
+	select {
+	case <-jobContext.Done():
+	case <-time.After(excelPricingRemoteBridgeTestTimeout):
+		t.Fatal("changed composite did not cancel the active snapshot")
+	}
+	store.mu.Lock()
+	changedGeneration := store.generation
+	changedEvents := len(store.events)
+	changedJobStatus := store.jobs["active-revision-replay"].status
+	store.mu.Unlock()
+	if applyCalls != 2 || changedGeneration != establishedGeneration+1 ||
+		changedEvents != establishedEvents+2 || changedJobStatus != "cancelling" {
+		t.Fatalf("changed composite apply_calls=%d generation=%d events=%d job=%s",
+			applyCalls, changedGeneration, changedEvents, changedJobStatus)
+	}
+
+	changedReplay := changed
+	changedReplay.Cause = "replayed_changed_composite"
+	changedReplay.EventID++
+	if err := bridge.acceptRevision(1, source, changedReplay); err != nil {
+		t.Fatalf("accept changed-composite replay: %v", err)
+	}
+	store.mu.Lock()
+	finalGeneration := store.generation
+	finalEvents := len(store.events)
+	store.mu.Unlock()
+	if applyCalls != 2 || finalGeneration != changedGeneration || finalEvents != changedEvents {
+		t.Fatalf("changed replay reapplied: calls=%d generation=%d events=%d",
+			applyCalls, finalGeneration, finalEvents)
+	}
+}
+
 func TestResolveExcelPricingRemoteBridgeConfigTracksOnlySubscriberInputs(t *testing.T) {
 	cfg := appconfig.Default()
 	cfg.SendUpdates = excelPricingRemoteTestConfig(t, "https://digitalogic.example")


### PR DESCRIPTION
Closes #255

Follow-up to #230 and #254. Full-duplex counterpart: `Digitalogic-WP` [#197](https://github.com/atomicdeploy/digitalogic-wp/issues/197) / [#198](https://github.com/atomicdeploy/digitalogic-wp/pull/198).

## What changed

- recognize an identical authenticated pricing composite in `acceptRevision`;
- acknowledge it and keep cursor persistence safe without reapplying local invalidation;
- retain normal apply/fencing for the first composite and every genuinely changed composite;
- add a deterministic active-snapshot regression that varies reconnect metadata while keeping the authoritative composite identical, then proves one real composite change still cancels exactly once.

## Why

The exact-main Windows acceptance observed a local snapshot fail before any remote start POST. The only remote request was a valid revision GET 200. The pricing-events bridge can validate the same composite during reconnect and previously sent it through the unconditional generation invalidation hook, racing the snapshot collector after its own revision fetch.

## Verification

- `go test ./pkg/server -run '^TestExcelPricingRemoteEventsBridge(IdenticalCompositeDoesNotCancelActiveSnapshot|CursorRequiresSuccessfulApplyAndAllowsReset|ConfigRestartAndCursorOrdering|RetainsSnapshotTerminalBeforeCursorAck)$' -count=1`
- `go test ./pkg/server -run '^TestExcelPricingRemoteEventsBridgeIdenticalCompositeDoesNotCancelActiveSnapshot$' -count=100`
- `go test -race ./pkg/server -run '^TestExcelPricingRemoteEventsBridgeIdenticalCompositeDoesNotCancelActiveSnapshot$' -count=20`
- `go test -race ./pkg/server -count=1`
- packaged-runtime native proof: `go test ./... -count=1`

All pass on Windows. The first unqualified full-suite attempts failed only because the pxlib runtime directory was absent from `PATH`; rerunning with the exact packaged runtime made both native suites green.

No production cutover or additional snapshot request was performed. No credentials, private source identity, or private route are included.
