### PR TITLE
Expose stage-specific fail-closed snapshot diagnostics

### DIFF
--- a/docs/EXCEL-EXPORT.md
+++ b/docs/EXCEL-EXPORT.md
@@ -216,6 +216,14 @@ rollback-protected atomic commit. Any cancellation, error, stale event, duplicat
 identity, digest mismatch, or unsafe warning retains the previous committed
 workbook generation.
 
+Failed snapshot jobs retain their existing top-level compatibility code and may
+also include a bounded `failure` object with schema
+`patris.pricing-snapshot-failure/v1`. Its reviewed `stage` and `code` values
+distinguish revision fetch, terminal subscription, snapshot start, terminal
+wait/match, remote terminal, payload validation, remote configuration, and
+local projection failures. No URL, credential, response body, request/build
+identifier, source identity, or row data is copied into this diagnostic.
+
 The durable semantic listener uses `/api/pricing-sync/events`, comment
 keepalives, numeric `Last-Event-ID`, bounded callback-driven reconnect, and the
 same loopback-only headers. A cursor is kept only with the exact in-memory

--- a/pkg/server/excel_pricing_remote_snapshot.go
+++ b/pkg/server/excel_pricing_remote_snapshot.go
@@ -28,16 +28,115 @@ const (
 
 	excelPricingRemoteSnapshotMaxResponseBytes = 32 << 20
 	excelPricingRemoteSnapshotTerminalHistory  = 256
+
+	excelPricingRemoteSnapshotStageRevisionFetch        = "revision_fetch"
+	excelPricingRemoteSnapshotStageTerminalSubscription = "terminal_subscription"
+	excelPricingRemoteSnapshotStageSnapshotStart        = "snapshot_start"
+	excelPricingRemoteSnapshotStageTerminalWait         = "terminal_wait"
+	excelPricingRemoteSnapshotStageTerminalMatch        = "terminal_match"
+	excelPricingRemoteSnapshotStageRemoteTerminal       = "remote_terminal"
+	excelPricingRemoteSnapshotStageSnapshotPayload      = "snapshot_payload"
 )
 
 var (
 	errExcelPricingRemoteSnapshotConfiguration = errors.New("remote pricing snapshot configuration is invalid")
 	errExcelPricingRemoteSnapshotProtocol      = errors.New("remote pricing snapshot protocol violation")
 	errExcelPricingRemoteSnapshotIntegrity     = errors.New("remote pricing snapshot integrity validation failed")
+	errExcelPricingRemoteSnapshotRejected      = errors.New("remote pricing snapshot request was rejected")
 	errExcelPricingRemoteSnapshotUnavailable   = errors.New("remote pricing snapshot is unavailable")
 
 	excelPricingRemoteSnapshotIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$`)
 )
+
+// excelPricingRemoteSnapshotStageError preserves a bounded stage/code pair
+// without retaining a URL, response, credential, request/build identifier, or
+// raw transport error in the user-visible snapshot job contract.
+type excelPricingRemoteSnapshotStageError struct {
+	stage string
+	code  string
+	cause error
+}
+
+func (err *excelPricingRemoteSnapshotStageError) Error() string {
+	if err == nil {
+		return "remote pricing snapshot stage failed"
+	}
+	return "remote pricing snapshot " + err.stage + " failed: " + err.code
+}
+
+func (err *excelPricingRemoteSnapshotStageError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.cause
+}
+
+func wrapExcelPricingRemoteSnapshotStage(stage string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &excelPricingRemoteSnapshotStageError{
+		stage: stage,
+		code:  excelPricingRemoteSnapshotStageCode(stage, cause),
+		cause: cause,
+	}
+}
+
+func excelPricingRemoteSnapshotStageCode(stage string, cause error) string {
+	switch stage {
+	case excelPricingRemoteSnapshotStageRevisionFetch:
+		switch {
+		case errors.Is(cause, errExcelPricingRemoteSnapshotProtocol),
+			errors.Is(cause, errExcelPricingRemoteSnapshotIntegrity):
+			return "snapshot_revision_fetch_protocol_failed"
+		case errors.Is(cause, errExcelPricingRemoteSnapshotConfiguration):
+			return "snapshot_revision_fetch_configuration_failed"
+		default:
+			return "snapshot_revision_fetch_unavailable"
+		}
+	case excelPricingRemoteSnapshotStageTerminalSubscription:
+		return "snapshot_terminal_subscription_failed"
+	case excelPricingRemoteSnapshotStageSnapshotStart:
+		switch {
+		case errors.Is(cause, errExcelPricingRemoteSnapshotProtocol),
+			errors.Is(cause, errExcelPricingRemoteSnapshotIntegrity):
+			return "snapshot_start_protocol_failed"
+		case errors.Is(cause, errExcelPricingRemoteSnapshotConfiguration):
+			return "snapshot_start_configuration_failed"
+		case errors.Is(cause, errExcelPricingRemoteSnapshotRejected):
+			return "snapshot_start_rejected"
+		default:
+			return "snapshot_start_unavailable"
+		}
+	case excelPricingRemoteSnapshotStageTerminalWait:
+		return "snapshot_terminal_wait_failed"
+	case excelPricingRemoteSnapshotStageTerminalMatch:
+		return "snapshot_terminal_match_failed"
+	case excelPricingRemoteSnapshotStageRemoteTerminal:
+		return "snapshot_remote_terminal_failed"
+	case excelPricingRemoteSnapshotStageSnapshotPayload:
+		switch {
+		case errors.Is(cause, errExcelPricingRemoteSnapshotIntegrity):
+			return "snapshot_payload_integrity_failed"
+		case errors.Is(cause, errExcelPricingRemoteSnapshotProtocol):
+			return "snapshot_payload_protocol_failed"
+		case errors.Is(cause, errExcelPricingRemoteSnapshotConfiguration):
+			return "snapshot_payload_configuration_failed"
+		default:
+			return "snapshot_payload_unavailable"
+		}
+	default:
+		return "snapshot_remote_stage_failed"
+	}
+}
+
+func excelPricingRemoteSnapshotFailureDetails(err error) (string, string, bool) {
+	var staged *excelPricingRemoteSnapshotStageError
+	if !errors.As(err, &staged) || staged == nil || staged.stage == "" || staged.code == "" {
+		return "", "", false
+	}
+	return staged.stage, staged.code, true
+}
 
 var excelPricingRemoteSnapshotExcelV1Fields = []string{
 	"sync_key",
@@ -492,13 +591,19 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 	}
 	revision, err := client.fetchRevision(ctx)
 	if err != nil {
-		return nil, err
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageRevisionFetch,
+			err,
+		)
 	}
 	// Register before POST. A terminal event emitted by an unusually fast build
 	// can therefore be queued while the POST response is still in flight.
 	subscription, err := client.terminals.Subscribe(requestID, client.source, revision.StateRevision)
 	if err != nil {
-		return nil, errExcelPricingRemoteSnapshotUnavailable
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageTerminalSubscription,
+			errExcelPricingRemoteSnapshotUnavailable,
+		)
 	}
 	defer subscription.Close()
 
@@ -521,26 +626,44 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 	stopStart()
 	if err != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
+			return nil, wrapExcelPricingRemoteSnapshotStage(
+				excelPricingRemoteSnapshotStageSnapshotStart,
+				contextErr,
+			)
 		}
-		return nil, err
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageSnapshotStart,
+			err,
+		)
 	}
 	if contextErr := ctx.Err(); contextErr != nil {
 		client.cancelSnapshot(build.CancelURL, build.BuildID)
-		return nil, contextErr
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageSnapshotStart,
+			contextErr,
+		)
 	}
 	if status == http.StatusAccepted {
 		event, waitErr := subscription.Wait(ctx)
 		if waitErr != nil {
 			client.cancelSnapshot(build.CancelURL, build.BuildID)
-			return nil, waitErr
+			return nil, wrapExcelPricingRemoteSnapshotStage(
+				excelPricingRemoteSnapshotStageTerminalWait,
+				waitErr,
+			)
 		}
 		if validateExcelPricingRemoteSnapshotTerminalMatch(event, build, revision) != nil {
 			client.cancelSnapshot(build.CancelURL, build.BuildID)
-			return nil, errExcelPricingRemoteSnapshotProtocol
+			return nil, wrapExcelPricingRemoteSnapshotStage(
+				excelPricingRemoteSnapshotStageTerminalMatch,
+				errExcelPricingRemoteSnapshotProtocol,
+			)
 		}
 		if event.Status != "ready" {
-			return nil, errExcelPricingRemoteSnapshotUnavailable
+			return nil, wrapExcelPricingRemoteSnapshotStage(
+				excelPricingRemoteSnapshotStageRemoteTerminal,
+				errExcelPricingRemoteSnapshotUnavailable,
+			)
 		}
 		build.Status = event.Status
 		build.SnapshotToken = event.SnapshotToken
@@ -550,9 +673,19 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 		build.SnapshotURL = event.SnapshotPath
 	}
 	if build.Status != "ready" {
-		return nil, errExcelPricingRemoteSnapshotUnavailable
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageRemoteTerminal,
+			errExcelPricingRemoteSnapshotUnavailable,
+		)
 	}
-	return client.fetchSnapshot(ctx, build, revision)
+	result, err := client.fetchSnapshot(ctx, build, revision)
+	if err != nil {
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageSnapshotPayload,
+			err,
+		)
+	}
+	return result, nil
 }
 
 func (client *excelPricingRemoteSnapshotClient) fetchRevision(
@@ -572,12 +705,15 @@ func (client *excelPricingRemoteSnapshotClient) fetchRevision(
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK || !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
+	if response.StatusCode != http.StatusOK {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
 	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, excelPricingRemoteRevisionMaxBytes+1))
-	if err != nil || len(body) == 0 || len(body) > excelPricingRemoteRevisionMaxBytes {
-		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
+	if !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
+		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotProtocol
+	}
+	body, err := readExcelPricingRemoteSnapshotBody(response.Body, excelPricingRemoteRevisionMaxBytes)
+	if err != nil {
+		return excelPricingRemoteSnapshotRevision{}, err
 	}
 	if bytes.Contains(body, []byte(client.secret)) {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotProtocol
@@ -642,14 +778,14 @@ func (client *excelPricingRemoteSnapshotClient) startSnapshot(
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusAccepted {
-		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, errExcelPricingRemoteSnapshotUnavailable
+		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, errExcelPricingRemoteSnapshotRejected
 	}
 	if !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
 		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, errExcelPricingRemoteSnapshotProtocol
 	}
-	responseBody, err := io.ReadAll(io.LimitReader(response.Body, excelPricingRemoteRevisionMaxBytes+1))
-	if err != nil || len(responseBody) == 0 || len(responseBody) > excelPricingRemoteRevisionMaxBytes {
-		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, errExcelPricingRemoteSnapshotProtocol
+	responseBody, err := readExcelPricingRemoteSnapshotBody(response.Body, excelPricingRemoteRevisionMaxBytes)
+	if err != nil {
+		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, err
 	}
 	if bytes.Contains(responseBody, []byte(client.secret)) {
 		return excelPricingRemoteSnapshotBuildResponse{}, response.StatusCode, errExcelPricingRemoteSnapshotProtocol
@@ -694,12 +830,15 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 		return nil, errExcelPricingRemoteSnapshotUnavailable
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK || !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
+	if response.StatusCode != http.StatusOK {
 		return nil, errExcelPricingRemoteSnapshotUnavailable
 	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, excelPricingRemoteSnapshotMaxResponseBytes+1))
-	if err != nil || len(body) == 0 || len(body) > excelPricingRemoteSnapshotMaxResponseBytes {
-		return nil, errExcelPricingRemoteSnapshotUnavailable
+	if !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
+		return nil, errExcelPricingRemoteSnapshotProtocol
+	}
+	body, err := readExcelPricingRemoteSnapshotBody(response.Body, excelPricingRemoteSnapshotMaxResponseBytes)
+	if err != nil {
+		return nil, err
 	}
 	if bytes.Contains(body, []byte(client.secret)) {
 		return nil, errExcelPricingRemoteSnapshotProtocol
@@ -731,6 +870,17 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 		ProjectedRowFields:     fields,
 		RawPayload:             append([]byte(nil), body...),
 	}, nil
+}
+
+func readExcelPricingRemoteSnapshotBody(reader io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, errExcelPricingRemoteSnapshotUnavailable
+	}
+	if len(body) == 0 || int64(len(body)) > limit {
+		return nil, errExcelPricingRemoteSnapshotProtocol
+	}
+	return body, nil
 }
 
 func (client *excelPricingRemoteSnapshotClient) cancelSnapshot(cancelURL, buildID string) {

--- a/pkg/server/excel_pricing_remote_snapshot_test.go
+++ b/pkg/server/excel_pricing_remote_snapshot_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -47,6 +49,30 @@ type excelPricingRemoteSnapshotFixture struct {
 	cancelCalls   int
 	legacyCalls   int
 	headerFailure string
+}
+
+type rejectingExcelPricingRemoteTerminalSource struct{}
+
+type excelPricingRemoteSnapshotRoundTripFunc func(*http.Request) (*http.Response, error)
+
+type failingExcelPricingRemoteSnapshotReader struct{}
+
+func (failingExcelPricingRemoteSnapshotReader) Read([]byte) (int, error) {
+	return 0, errors.New("private response read failure")
+}
+
+func (roundTrip excelPricingRemoteSnapshotRoundTripFunc) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func (rejectingExcelPricingRemoteTerminalSource) Subscribe(
+	string,
+	canonical.Source,
+	string,
+) (excelPricingRemoteSnapshotTerminalSubscription, error) {
+	return nil, errors.New("private subscription implementation detail")
 }
 
 func TestExcelPricingRemoteSnapshotReadyUsesOneBulkFetchWithoutStatusPolling(t *testing.T) {
@@ -358,6 +384,681 @@ func TestExcelPricingRemoteSnapshotCancellationPropagatesWithoutStatusPolling(t 
 	fixture.assertCalls(t, 1, 1, 0, 0, 1)
 }
 
+func TestExcelPricingRemoteSnapshotCollectAnnotatesEveryRemoteStage(t *testing.T) {
+	assertStage := func(t *testing.T, err error, wantStage, wantCode string) {
+		t.Helper()
+		stage, code, ok := excelPricingRemoteSnapshotFailureDetails(err)
+		if !ok || stage != wantStage || code != wantCode {
+			t.Fatalf("failure details = (%q, %q, %v), want (%q, %q, true): %v",
+				stage, code, ok, wantStage, wantCode, err)
+		}
+		if strings.Contains(err.Error(), "private subscription implementation detail") ||
+			strings.Contains(err.Error(), "private transport implementation detail") {
+			t.Fatalf("structured error leaked raw cause: %v", err)
+		}
+	}
+	rejectTransport := func(
+		client *excelPricingRemoteSnapshotClient,
+		predicate func(*http.Request) bool,
+	) {
+		base := client.client.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		client.client.Transport = excelPricingRemoteSnapshotRoundTripFunc(
+			func(request *http.Request) (*http.Response, error) {
+				if predicate(request) {
+					return nil, errors.New("private transport implementation detail")
+				}
+				return base.RoundTrip(request)
+			},
+		)
+	}
+
+	t.Run("revision fetch protocol", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		fixture.revision.Schema = "invalid-revision-schema"
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_protocol_failed")
+		fixture.assertCalls(t, 1, 0, 0, 0, 0)
+	})
+
+	t.Run("revision fetch wrong content type", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "revision_wrong_content_type")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_protocol_failed")
+		fixture.assertCalls(t, 1, 0, 0, 0, 0)
+	})
+
+	for name, mode := range map[string]string{
+		"revision fetch empty body":     "revision_empty_body",
+		"revision fetch oversized body": "revision_oversized_body",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newExcelPricingRemoteSnapshotFixture(t, mode)
+			defer fixture.Close()
+			_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+			assertStage(t, err, excelPricingRemoteSnapshotStageRevisionFetch,
+				"snapshot_revision_fetch_protocol_failed")
+			fixture.assertCalls(t, 1, 0, 0, 0, 0)
+		})
+	}
+
+	t.Run("revision fetch unavailable", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		client := fixture.Client(t)
+		rejectTransport(client, func(request *http.Request) bool {
+			return request.Method == http.MethodGet &&
+				request.URL.Path == "/wp-json/digitalogic/pricing/sync/revision"
+		})
+		_, err := client.Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_unavailable")
+		fixture.assertCalls(t, 0, 0, 0, 0, 0)
+	})
+
+	t.Run("terminal subscription", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		client := fixture.Client(t)
+		client.terminals = rejectingExcelPricingRemoteTerminalSource{}
+		_, err := client.Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageTerminalSubscription,
+			"snapshot_terminal_subscription_failed")
+		fixture.assertCalls(t, 1, 0, 0, 0, 0)
+	})
+
+	t.Run("snapshot start protocol", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		fixture.badSnapshotURL = "https://attacker.invalid/wp-json/digitalogic/pricing/sync/snapshots/" +
+			fixture.payload.SnapshotToken
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotStart,
+			"snapshot_start_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 0, 0, 0)
+	})
+
+	t.Run("snapshot start unavailable", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		client := fixture.Client(t)
+		rejectTransport(client, func(request *http.Request) bool {
+			return request.Method == http.MethodPost &&
+				request.URL.Path == "/wp-json/digitalogic/pricing/sync/snapshots"
+		})
+		_, err := client.Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotStart,
+			"snapshot_start_unavailable")
+		fixture.assertCalls(t, 1, 0, 0, 0, 0)
+	})
+
+	t.Run("snapshot start rejected", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "start_rejected")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotStart,
+			"snapshot_start_rejected")
+		fixture.assertCalls(t, 1, 1, 0, 0, 0)
+	})
+
+	t.Run("terminal wait", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cold")
+		defer fixture.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+		defer cancel()
+		_, err := fixture.Client(t).Collect(ctx, fixture.requestID, 0)
+		assertStage(t, err, excelPricingRemoteSnapshotStageTerminalWait,
+			"snapshot_terminal_wait_failed")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("terminal wait lost deadline cause: %v", err)
+		}
+	})
+
+	t.Run("terminal match", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "event_bad_match")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 0)
+		assertStage(t, err, excelPricingRemoteSnapshotStageTerminalMatch,
+			"snapshot_terminal_match_failed")
+	})
+
+	t.Run("remote terminal", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "event_failed")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 0)
+		assertStage(t, err, excelPricingRemoteSnapshotStageRemoteTerminal,
+			"snapshot_remote_terminal_failed")
+	})
+
+	t.Run("snapshot payload protocol", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		fixture.badETag = true
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_protocol_failed")
+	})
+
+	t.Run("snapshot payload wrong content type", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_wrong_content_type")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+	})
+
+	for name, mode := range map[string]string{
+		"snapshot payload empty body":     "payload_empty_body",
+		"snapshot payload oversized body": "payload_oversized_body",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newExcelPricingRemoteSnapshotFixture(t, mode)
+			defer fixture.Close()
+			_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+			assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+				"snapshot_payload_protocol_failed")
+			fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		})
+	}
+
+	t.Run("snapshot payload unavailable", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		client := fixture.Client(t)
+		rejectTransport(client, func(request *http.Request) bool {
+			return request.Method == http.MethodGet &&
+				strings.HasPrefix(request.URL.Path, "/wp-json/digitalogic/pricing/sync/snapshots/")
+		})
+		_, err := client.Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_unavailable")
+		fixture.assertCalls(t, 1, 1, 0, 0, 0)
+	})
+
+	t.Run("snapshot payload integrity", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+		defer fixture.Close()
+		var columns []map[string]json.RawMessage
+		if err := json.Unmarshal(fixture.payload.Catalog.Columns, &columns); err != nil {
+			t.Fatal(err)
+		}
+		columns[0], columns[1] = columns[1], columns[0]
+		fixture.payload.Catalog.Columns = mustMarshalExcelPricingRemoteSnapshotTestJSON(t, columns)
+		fixture.finalizePayload()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_integrity_failed")
+	})
+}
+
+func TestExcelPricingRemoteSnapshotStageCodeCoversConfigurationAndTransportClasses(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		stage string
+		cause error
+		code  string
+	}{
+		{"revision configuration", excelPricingRemoteSnapshotStageRevisionFetch,
+			errExcelPricingRemoteSnapshotConfiguration, "snapshot_revision_fetch_configuration_failed"},
+		{"revision transport", excelPricingRemoteSnapshotStageRevisionFetch,
+			errExcelPricingRemoteSnapshotUnavailable, "snapshot_revision_fetch_unavailable"},
+		{"start configuration", excelPricingRemoteSnapshotStageSnapshotStart,
+			errExcelPricingRemoteSnapshotConfiguration, "snapshot_start_configuration_failed"},
+		{"start transport", excelPricingRemoteSnapshotStageSnapshotStart,
+			errExcelPricingRemoteSnapshotUnavailable, "snapshot_start_unavailable"},
+		{"start response", excelPricingRemoteSnapshotStageSnapshotStart,
+			errExcelPricingRemoteSnapshotRejected, "snapshot_start_rejected"},
+		{"payload configuration", excelPricingRemoteSnapshotStageSnapshotPayload,
+			errExcelPricingRemoteSnapshotConfiguration, "snapshot_payload_configuration_failed"},
+		{"payload transport", excelPricingRemoteSnapshotStageSnapshotPayload,
+			errExcelPricingRemoteSnapshotUnavailable, "snapshot_payload_unavailable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := wrapExcelPricingRemoteSnapshotStage(test.stage, test.cause)
+			stage, code, ok := excelPricingRemoteSnapshotFailureDetails(err)
+			if !ok || stage != test.stage || code != test.code {
+				t.Fatalf("failure details=(%q,%q,%v), want=(%q,%q,true)",
+					stage, code, ok, test.stage, test.code)
+			}
+		})
+	}
+
+	if _, err := readExcelPricingRemoteSnapshotBody(failingExcelPricingRemoteSnapshotReader{}, 8); !errors.Is(
+		err,
+		errExcelPricingRemoteSnapshotUnavailable,
+	) {
+		t.Fatalf("body read failure=%v, want unavailable", err)
+	}
+	for name, body := range map[string]string{
+		"empty":     "",
+		"oversized": "123456789",
+	} {
+		t.Run(name+" body", func(t *testing.T) {
+			if _, err := readExcelPricingRemoteSnapshotBody(strings.NewReader(body), 8); !errors.Is(
+				err,
+				errExcelPricingRemoteSnapshotProtocol,
+			) {
+				t.Fatalf("body error=%v, want protocol", err)
+			}
+		})
+	}
+}
+
+func TestExcelPricingSnapshotFailureEvidencePreservesPublicCodeAndPrivacy(t *testing.T) {
+	fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+	defer fixture.Close()
+	fixture.acceptAnyID = true
+	fixture.revision.Schema = "invalid-revision-schema"
+	server, token := newExcelPricingRemoteSnapshotProductionServer(t, fixture)
+	requestID := "snapshot-stage-evidence-0001"
+	request := authenticatedExcelPricingRequest(
+		http.MethodPost,
+		"/api/pricing-sync/snapshots",
+		validExcelPricingSnapshotStartBody(fixture.source, requestID, "fa", 0),
+		token,
+	)
+	request.Header.Set("Idempotency-Key", requestID)
+	response := httptest.NewRecorder()
+	server.router.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("snapshot start=%d: %s", response.Code, response.Body.String())
+	}
+	jobID := excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+	status := waitForExcelPricingSnapshotStatus(t, server, token, jobID, "failed")
+	if status["code"] != "snapshot_integrity_failed" {
+		t.Fatalf("stable public code changed: %#v", status)
+	}
+	failure, ok := status["failure"].(map[string]interface{})
+	if !ok || len(failure) != 3 ||
+		failure["schema"] != excelPricingSnapshotFailureSchema ||
+		failure["stage"] != excelPricingRemoteSnapshotStageRevisionFetch ||
+		failure["code"] != "snapshot_revision_fetch_protocol_failed" {
+		t.Fatalf("structured failure = %#v", status["failure"])
+	}
+	rendered, err := json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, protected := range []string{
+		"test-remote-snapshot-secret-value",
+		fixture.server.URL,
+		fixture.source.ID,
+		fixture.source.Dataset,
+		fixture.requestID,
+		fixture.buildID,
+	} {
+		if protected != "" && strings.Contains(string(rendered), protected) {
+			t.Fatalf("structured failure leaked protected material: %s", rendered)
+		}
+	}
+	fixture.assertCalls(t, 1, 0, 0, 0, 0)
+}
+
+func TestExcelPricingSnapshotFailureEvidenceRejectsUnreviewedValues(t *testing.T) {
+	for _, test := range []struct {
+		stage string
+		code  string
+	}{
+		{stage: "https://private.invalid/path", code: "snapshot_revision_fetch_protocol_failed"},
+		{stage: excelPricingRemoteSnapshotStageRevisionFetch, code: "private raw transport error"},
+		{stage: excelPricingSnapshotStageRemoteConfiguration, code: "snapshot_payload_unavailable"},
+	} {
+		if validExcelPricingSnapshotFailure(test.stage, test.code) {
+			t.Fatalf("unreviewed failure pair accepted: stage=%q code=%q", test.stage, test.code)
+		}
+	}
+
+	for _, test := range []struct {
+		stage string
+		code  string
+	}{
+		{excelPricingRemoteSnapshotStageRevisionFetch, "snapshot_revision_fetch_protocol_failed"},
+		{excelPricingRemoteSnapshotStageTerminalSubscription, "snapshot_terminal_subscription_failed"},
+		{excelPricingRemoteSnapshotStageSnapshotStart, "snapshot_start_protocol_failed"},
+		{excelPricingRemoteSnapshotStageTerminalWait, "snapshot_terminal_wait_failed"},
+		{excelPricingRemoteSnapshotStageTerminalMatch, "snapshot_terminal_match_failed"},
+		{excelPricingRemoteSnapshotStageRemoteTerminal, "snapshot_remote_terminal_failed"},
+		{excelPricingRemoteSnapshotStageSnapshotPayload, "snapshot_payload_integrity_failed"},
+		{excelPricingSnapshotStageRemoteConfiguration, "snapshot_remote_configuration_failed"},
+		{excelPricingSnapshotStageLocalProjection, "snapshot_local_projection_integrity_failed"},
+	} {
+		if !validExcelPricingSnapshotFailure(test.stage, test.code) {
+			t.Fatalf("reviewed failure pair rejected: stage=%q code=%q", test.stage, test.code)
+		}
+	}
+}
+
+func TestExcelPricingSnapshotProductionFailureStagesCoverConfigurationAndLocalProjection(t *testing.T) {
+	source := excelPricingStateSourceForTest()
+	for _, test := range []struct {
+		name       string
+		publicCode string
+		stage      string
+		code       string
+		configure  func(*Server)
+	}{
+		{
+			name:       "remote configuration",
+			publicCode: "remote_unavailable",
+			stage:      excelPricingSnapshotStageRemoteConfiguration,
+			code:       "snapshot_remote_configuration_failed",
+			configure: func(server *Server) {
+				server.excelPricing.snapshotCollector = nil
+				server.excelPricingRemote = nil
+			},
+		},
+		{
+			name:       "local projection",
+			publicCode: "snapshot_integrity_failed",
+			stage:      excelPricingSnapshotStageLocalProjection,
+			code:       "snapshot_local_projection_integrity_failed",
+			configure: func(server *Server) {
+				server.excelPricing.snapshotCollector = func(
+					_ context.Context,
+					jobID string,
+					request excelPricingSnapshotStartRequest,
+					_ updateout.Config,
+				) (*excelPricingSnapshot, string) {
+					return server.finalizeExcelPricingRemoteSnapshot(
+						jobID,
+						nil,
+						excelPricingSnapshotProjection(request.Projection),
+					)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := newExcelPricingTestServer(
+				t,
+				"http://127.0.0.1:1/wp-json/digitalogic/patris/product-sync",
+			)
+			test.configure(server)
+			token := openExcelPricingSession(t, server)
+			requestID := "snapshot-production-failure-" + strings.ReplaceAll(test.name, " ", "-")
+			request := authenticatedExcelPricingRequest(
+				http.MethodPost,
+				"/api/pricing-sync/snapshots",
+				validExcelPricingSnapshotStartBody(source, requestID, "fa", 0),
+				token,
+			)
+			request.Header.Set("Idempotency-Key", requestID)
+			response := httptest.NewRecorder()
+			server.router.ServeHTTP(response, request)
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("snapshot start=%d: %s", response.Code, response.Body.String())
+			}
+			jobID := excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+			status := waitForExcelPricingSnapshotStatus(t, server, token, jobID, "failed")
+			assertExcelPricingSnapshotFailureForTest(
+				t,
+				status,
+				test.publicCode,
+				test.stage,
+				test.code,
+			)
+		})
+	}
+}
+
+func TestExcelPricingSnapshotFailurePropagatesToTerminalWaitSSEAndFollower(t *testing.T) {
+	source := excelPricingStateSourceForTest()
+	server := newExcelPricingTestServer(
+		t,
+		"http://127.0.0.1:1/wp-json/digitalogic/patris/product-sync",
+	)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	server.excelPricing.snapshotCollector = func(
+		ctx context.Context,
+		jobID string,
+		_ excelPricingSnapshotStartRequest,
+		_ updateout.Config,
+	) (*excelPricingSnapshot, string) {
+		startedOnce.Do(func() { close(started) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, excelPricingSnapshotContextCode(ctx)
+		}
+		server.setExcelPricingSnapshotFailure(
+			jobID,
+			excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_protocol_failed",
+		)
+		return nil, "snapshot_integrity_failed"
+	}
+	token := openExcelPricingSession(t, server)
+	start := func(requestID string) (string, map[string]interface{}) {
+		t.Helper()
+		request := authenticatedExcelPricingRequest(
+			http.MethodPost,
+			"/api/pricing-sync/snapshots",
+			validExcelPricingSnapshotStartBody(source, requestID, "fa", 0),
+			token,
+		)
+		request.Header.Set("Idempotency-Key", requestID)
+		response := httptest.NewRecorder()
+		server.router.ServeHTTP(response, request)
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("snapshot start=%d: %s", response.Code, response.Body.String())
+		}
+		var status map[string]interface{}
+		if err := json.Unmarshal(response.Body.Bytes(), &status); err != nil {
+			t.Fatal(err)
+		}
+		return excelPricingSnapshotJobIDForTest(t, response.Body.Bytes()), status
+	}
+	leaderID, leaderStart := start("snapshot-failure-leader-0001")
+	if leaderStart["coalesced"] != false {
+		t.Fatalf("leader start=%#v", leaderStart)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("leader collector did not start")
+	}
+	followerID, followerStart := start("snapshot-failure-follower-0001")
+	if followerStart["coalesced"] != true {
+		t.Fatalf("follower start=%#v", followerStart)
+	}
+	close(release)
+	leader := waitForExcelPricingSnapshotStatus(t, server, token, leaderID, "failed")
+	follower := waitForExcelPricingSnapshotStatus(t, server, token, followerID, "failed")
+	for name, status := range map[string]map[string]interface{}{
+		"leader":   leader,
+		"follower": follower,
+	} {
+		t.Run(name+" terminal wait", func(t *testing.T) {
+			assertExcelPricingSnapshotFailureForTest(
+				t,
+				status,
+				"snapshot_integrity_failed",
+				excelPricingRemoteSnapshotStageRevisionFetch,
+				"snapshot_revision_fetch_protocol_failed",
+			)
+		})
+	}
+
+	loopback := httptest.NewServer(server.router)
+	defer loopback.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		loopback.URL+"/api/pricing-sync/snapshots/"+followerID,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set(excelPricingClientHeader, excelPricingClientID)
+	request.Header.Set(excelPricingCSRFHeader, token)
+	request.Header.Set("Accept", "text/event-stream")
+	response, err := loopback.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("SSE status=%d", response.StatusCode)
+	}
+	found := false
+	scanner := bufio.NewScanner(response.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event excelPricingSnapshotEventEnvelope
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Kind != "snapshot_job" || event.Job["status"] != "failed" {
+			continue
+		}
+		assertExcelPricingSnapshotFailureForTest(
+			t,
+			event.Job,
+			"snapshot_integrity_failed",
+			excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_protocol_failed",
+		)
+		found = true
+		break
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("follower SSE did not replay the structured terminal failure")
+	}
+}
+
+func TestExcelPricingSnapshotCancellationNeverRetainsUnrelatedFailureEvidence(t *testing.T) {
+	source := excelPricingStateSourceForTest()
+	server := newExcelPricingTestServer(
+		t,
+		"http://127.0.0.1:1/wp-json/digitalogic/patris/product-sync",
+	)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server.excelPricing.snapshotCollector = func(
+		_ context.Context,
+		jobID string,
+		_ excelPricingSnapshotStartRequest,
+		_ updateout.Config,
+	) (*excelPricingSnapshot, string) {
+		close(started)
+		<-release
+		server.setExcelPricingSnapshotFailure(
+			jobID,
+			excelPricingRemoteSnapshotStageRevisionFetch,
+			"snapshot_revision_fetch_protocol_failed",
+		)
+		return nil, "snapshot_integrity_failed"
+	}
+	token := openExcelPricingSession(t, server)
+	requestID := "snapshot-cancel-failure-race-0001"
+	start := authenticatedExcelPricingRequest(
+		http.MethodPost,
+		"/api/pricing-sync/snapshots",
+		validExcelPricingSnapshotStartBody(source, requestID, "fa", 0),
+		token,
+	)
+	start.Header.Set("Idempotency-Key", requestID)
+	startResponse := httptest.NewRecorder()
+	server.router.ServeHTTP(startResponse, start)
+	if startResponse.Code != http.StatusAccepted {
+		t.Fatalf("snapshot start=%d: %s", startResponse.Code, startResponse.Body.String())
+	}
+	jobID := excelPricingSnapshotJobIDForTest(t, startResponse.Body.Bytes())
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("collector did not start")
+	}
+	cancel := authenticatedExcelPricingRequest(
+		http.MethodDelete,
+		"/api/pricing-sync/snapshots/"+jobID,
+		"",
+		token,
+	)
+	cancelResponse := httptest.NewRecorder()
+	server.router.ServeHTTP(cancelResponse, cancel)
+	if cancelResponse.Code != http.StatusAccepted {
+		t.Fatalf("cancel=%d: %s", cancelResponse.Code, cancelResponse.Body.String())
+	}
+	server.setExcelPricingSnapshotFailure(
+		jobID,
+		excelPricingRemoteSnapshotStageRevisionFetch,
+		"snapshot_revision_fetch_protocol_failed",
+	)
+	statusRequest := authenticatedExcelPricingRequest(
+		http.MethodGet,
+		"/api/pricing-sync/snapshots/"+jobID,
+		"",
+		token,
+	)
+	statusResponse := httptest.NewRecorder()
+	server.router.ServeHTTP(statusResponse, statusRequest)
+	var cancelling map[string]interface{}
+	if err := json.Unmarshal(statusResponse.Body.Bytes(), &cancelling); err != nil {
+		t.Fatal(err)
+	}
+	if cancelling["status"] != "cancelling" || cancelling["code"] != "request_cancelled" {
+		t.Fatalf("cancelling status=%#v", cancelling)
+	}
+	if _, exists := cancelling["failure"]; exists {
+		t.Fatalf("cancelling response retained unrelated failure=%#v", cancelling["failure"])
+	}
+	close(release)
+	terminal := waitForExcelPricingSnapshotStatus(t, server, token, jobID, "cancelled")
+	if terminal["code"] != "request_cancelled" {
+		t.Fatalf("cancelled status=%#v", terminal)
+	}
+	if _, exists := terminal["failure"]; exists {
+		t.Fatalf("cancelled response retained unrelated failure=%#v", terminal["failure"])
+	}
+}
+
+func assertExcelPricingSnapshotFailureForTest(
+	t *testing.T,
+	status map[string]interface{},
+	publicCode, stage, code string,
+) {
+	t.Helper()
+	if status["code"] != publicCode {
+		t.Fatalf("public code=%#v, want %q", status["code"], publicCode)
+	}
+	failure, ok := status["failure"].(map[string]interface{})
+	if !ok || len(failure) != 3 ||
+		failure["schema"] != excelPricingSnapshotFailureSchema ||
+		failure["stage"] != stage || failure["code"] != code {
+		t.Fatalf("structured failure=%#v", status["failure"])
+	}
+	rendered, err := json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, protected := range []string{
+		"secret", "http://", "https://", "request_id", "build_id", "source_id", "dataset",
+	} {
+		if strings.Contains(strings.ToLower(string(rendered)), protected) {
+			t.Fatalf("structured failure exposed protected material: %s", rendered)
+		}
+	}
+}
+
 func TestExcelPricingRemoteSnapshotRejectsCrossOriginReturnedPath(t *testing.T) {
 	fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
 	defer fixture.Close()
@@ -605,7 +1306,17 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			http.Error(w, "bad query", http.StatusBadRequest)
 			return
 		}
+		if fixture.mode == "revision_wrong_content_type" {
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		}
 		w.Header().Set("ETag", `"`+fixture.revision.StateRevision+`"`)
+		if fixture.mode == "revision_empty_body" {
+			return
+		}
+		if fixture.mode == "revision_oversized_body" {
+			_, _ = w.Write(bytes.Repeat([]byte{'x'}, excelPricingRemoteRevisionMaxBytes+1))
+			return
+		}
 		_ = json.NewEncoder(w).Encode(fixture.revision)
 	case r.Method == http.MethodPost && r.URL.Path == "/wp-json/digitalogic/pricing/sync/snapshots":
 		fixture.mu.Lock()
@@ -627,8 +1338,13 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			http.Error(w, "bad start", http.StatusBadRequest)
 			return
 		}
+		if fixture.mode == "start_rejected" {
+			http.Error(w, "rejected", http.StatusConflict)
+			return
+		}
 		build := fixture.buildResponse()
-		if fixture.mode == "ready" {
+		if fixture.mode == "ready" || fixture.mode == "payload_wrong_content_type" ||
+			fixture.mode == "payload_empty_body" || fixture.mode == "payload_oversized_body" {
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(build)
 			return
@@ -653,9 +1369,23 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		}
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(build)
-		if fixture.mode == "event_after_response" {
+		if fixture.mode == "event_after_response" || fixture.mode == "event_bad_match" ||
+			fixture.mode == "event_failed" {
 			time.AfterFunc(10*time.Millisecond, func() {
-				_ = fixture.hub.publishAuthenticated(fixture.terminalEvent(1))
+				event := fixture.terminalEvent(1)
+				switch fixture.mode {
+				case "event_bad_match":
+					event.BuildID = "build_0000000000000002"
+				case "event_failed":
+					event.Status = "failed"
+					event.SnapshotToken = ""
+					event.SnapshotRevision = ""
+					event.Digest = ""
+					event.SnapshotPath = ""
+					event.Code = "digitalogic_pricing_snapshot_test_failed"
+					event.Retryable = true
+				}
+				_ = fixture.hub.publishAuthenticated(event)
 			})
 		}
 	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/wp-json/digitalogic/pricing/sync/builds/"):
@@ -677,6 +1407,16 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			w.Header().Set("ETag", `W/"`+fixture.payload.Digest+`"`)
 		} else {
 			w.Header().Set("ETag", `"`+fixture.payload.Digest+`"`)
+		}
+		if fixture.mode == "payload_wrong_content_type" {
+			w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+		}
+		if fixture.mode == "payload_empty_body" {
+			return
+		}
+		if fixture.mode == "payload_oversized_body" {
+			_, _ = w.Write(bytes.Repeat([]byte{'x'}, excelPricingRemoteSnapshotMaxResponseBytes+1))
+			return
 		}
 		_, _ = w.Write(fixture.payloadBody)
 	case r.Method == http.MethodPost && r.URL.Path == "/wp-json/digitalogic/pricing/sync/state":

--- a/pkg/server/excel_pricing_snapshot.go
+++ b/pkg/server/excel_pricing_snapshot.go
@@ -24,10 +24,14 @@ import (
 const (
 	excelPricingSnapshotRequestSchema     = "patris.pricing-snapshot-request/v1"
 	excelPricingSnapshotJobSchema         = "patris.pricing-snapshot-job/v1"
+	excelPricingSnapshotFailureSchema     = "patris.pricing-snapshot-failure/v1"
 	excelPricingSnapshotPayloadSchema     = "patris.pricing-snapshot/v1"
 	excelPricingSnapshotProjectionFull    = "full"
 	excelPricingSnapshotProjectionExcelV1 = "excel-v1"
-	excelPricingSnapshotEventSchema       = "patris.pricing-state-event/v1"
+
+	excelPricingSnapshotStageRemoteConfiguration = "remote_configuration"
+	excelPricingSnapshotStageLocalProjection     = "local_projection"
+	excelPricingSnapshotEventSchema              = "patris.pricing-state-event/v1"
 
 	excelPricingSnapshotPageSize         = 250
 	excelPricingSnapshotMaxPages         = 8
@@ -60,6 +64,16 @@ type excelPricingSnapshotProgress struct {
 	TotalPages     int       `json:"total_pages"`
 	Rows           int       `json:"rows"`
 	HeartbeatAt    time.Time `json:"heartbeat_at"`
+}
+
+// excelPricingSnapshotFailure is intentionally smaller than the internal
+// error chain. It exposes only reviewed enum-like values, so a status or SSE
+// response cannot disclose credentials, routes, identifiers, response bodies,
+// or row data while still distinguishing the failed remote stage.
+type excelPricingSnapshotFailure struct {
+	Schema string `json:"schema"`
+	Stage  string `json:"stage"`
+	Code   string `json:"code"`
 }
 
 type excelPricingSnapshotIntegrity struct {
@@ -173,6 +187,7 @@ type excelPricingSnapshotJob struct {
 	deadline              time.Time
 	progress              excelPricingSnapshotProgress
 	errorCode             string
+	failure               *excelPricingSnapshotFailure
 	cached                bool
 	coalesced             bool
 	leaderJobID           string
@@ -1171,6 +1186,7 @@ func (s *Server) cancelExcelPricingSnapshotJob(
 	if job.leaderJobID != "" {
 		job.status = "cancelled"
 		job.errorCode = "request_cancelled"
+		job.failure = nil
 		job.updatedAt = now
 		changedJobs = append(changedJobs, job)
 		leader := store.jobs[job.leaderJobID]
@@ -1178,6 +1194,7 @@ func (s *Server) cancelExcelPricingSnapshotJob(
 			!store.hasRunningFollowersLocked(leader.id) {
 			leader.status = "cancelling"
 			leader.errorCode = "request_cancelled"
+			leader.failure = nil
 			leader.updatedAt = now
 			cancel = leader.cancel
 			changedJobs = append(changedJobs, leader)
@@ -1185,11 +1202,13 @@ func (s *Server) cancelExcelPricingSnapshotJob(
 	} else if store.hasRunningFollowersLocked(job.id) {
 		job.status = "cancelled"
 		job.errorCode = "request_cancelled"
+		job.failure = nil
 		job.updatedAt = now
 		changedJobs = append(changedJobs, job)
 	} else {
 		job.status = "cancelling"
 		job.errorCode = "request_cancelled"
+		job.failure = nil
 		job.updatedAt = now
 		cancel = job.cancel
 		status = http.StatusAccepted
@@ -1278,6 +1297,7 @@ func (store *excelPricingSnapshotStore) pruneLocked(now time.Time) {
 		}
 		active.status = "failed"
 		active.errorCode = code
+		active.failure = nil
 		active.updatedAt = now
 		delete(store.idempotency, excelPricingSnapshotIdempotencyKey(active.owner, active.requestID))
 		store.publishJobLocked(active)
@@ -1287,6 +1307,7 @@ func (store *excelPricingSnapshotStore) pruneLocked(now time.Time) {
 			}
 			follower.status = "failed"
 			follower.errorCode = code
+			follower.failure = nil
 			follower.updatedAt = now
 			delete(store.idempotency, excelPricingSnapshotIdempotencyKey(follower.owner, follower.requestID))
 			store.publishJobLocked(follower)
@@ -1301,6 +1322,7 @@ func (store *excelPricingSnapshotStore) pruneLocked(now time.Time) {
 			(job.snapshot == nil || !job.snapshot.expiresAt.After(now)) {
 			job.status = "expired"
 			job.errorCode = "snapshot_expired"
+			job.failure = nil
 			job.updatedAt = now
 			store.publishJobLocked(job)
 		}
@@ -1357,6 +1379,7 @@ func (store *excelPricingSnapshotStore) invalidateGenerationLocked(
 	now := store.now().UTC()
 	leader.status = "cancelling"
 	leader.errorCode = code
+	leader.failure = nil
 	leader.updatedAt = now
 	store.publishJobLocked(leader)
 	for _, follower := range store.jobs {
@@ -1366,6 +1389,7 @@ func (store *excelPricingSnapshotStore) invalidateGenerationLocked(
 		}
 		follower.status = "cancelled"
 		follower.errorCode = code
+		follower.failure = nil
 		follower.updatedAt = now
 		store.publishJobLocked(follower)
 	}
@@ -1385,6 +1409,7 @@ func (store *excelPricingSnapshotStore) invalidateReadyJobsExceptLocked(
 			}
 			job.status = "invalidated"
 			job.errorCode = code
+			job.failure = nil
 			job.updatedAt = now
 			invalidated = append(invalidated, job)
 		}
@@ -1594,6 +1619,7 @@ func (store *excelPricingSnapshotStore) makeJobReadyLocked(
 ) {
 	job.status = "ready"
 	job.errorCode = ""
+	job.failure = nil
 	job.snapshot = snapshot
 	job.deadline = snapshot.expiresAt
 	job.updatedAt = store.now().UTC()
@@ -1643,6 +1669,11 @@ func (store *excelPricingSnapshotStore) completeFollowersLocked(
 ) ([]*excelPricingSnapshotJob, int) {
 	changed := make([]*excelPricingSnapshotJob, 0)
 	ready := 0
+	var leaderFailure *excelPricingSnapshotFailure
+	if leader := store.jobs[leaderJobID]; leader != nil && leader.failure != nil {
+		copyFailure := *leader.failure
+		leaderFailure = &copyFailure
+	}
 	for _, follower := range store.jobs {
 		if follower == nil || follower.leaderJobID != leaderJobID {
 			continue
@@ -1650,6 +1681,7 @@ func (store *excelPricingSnapshotStore) completeFollowersLocked(
 		if follower.status == "cancelling" {
 			follower.status = "cancelled"
 			follower.errorCode = "request_cancelled"
+			follower.failure = nil
 			follower.updatedAt = store.now().UTC()
 			changed = append(changed, follower)
 			continue
@@ -1658,9 +1690,14 @@ func (store *excelPricingSnapshotStore) completeFollowersLocked(
 			continue
 		}
 		if snapshot == nil {
+			if leaderFailure != nil {
+				copyFailure := *leaderFailure
+				follower.failure = &copyFailure
+			}
 			if code == "request_cancelled" {
 				follower.status = "cancelled"
 				follower.errorCode = "request_cancelled"
+				follower.failure = nil
 			} else {
 				follower.status = "failed"
 				follower.errorCode = code
@@ -1673,6 +1710,7 @@ func (store *excelPricingSnapshotStore) completeFollowersLocked(
 			follower.expectedStateRevision != snapshot.stateRevision {
 			follower.status = "failed"
 			follower.errorCode = "snapshot_state_revision_mismatch"
+			follower.failure = nil
 			follower.updatedAt = store.now().UTC()
 			changed = append(changed, follower)
 			continue
@@ -1729,6 +1767,7 @@ func (s *Server) runExcelPricingSnapshotJob(
 		}
 		job.status = "cancelled"
 		job.errorCode = code
+		job.failure = nil
 		job.snapshot = nil
 		job.updatedAt = store.now().UTC()
 		store.publishJobLocked(job)
@@ -1739,6 +1778,7 @@ func (s *Server) runExcelPricingSnapshotJob(
 			}
 			follower.status = "cancelled"
 			follower.errorCode = code
+			follower.failure = nil
 			follower.snapshot = nil
 			follower.updatedAt = store.now().UTC()
 			store.publishJobLocked(follower)
@@ -1752,6 +1792,7 @@ func (s *Server) runExcelPricingSnapshotJob(
 			if job.errorCode == "" {
 				job.errorCode = "request_cancelled"
 			}
+			job.failure = nil
 		} else {
 			job.status = "failed"
 			job.errorCode = code
@@ -1770,12 +1811,14 @@ func (s *Server) runExcelPricingSnapshotJob(
 		if job.errorCode == "" {
 			job.errorCode = "request_cancelled"
 		}
+		job.failure = nil
 		job.updatedAt = store.now().UTC()
 		jobChanged = true
 	} else if job.status == "running" {
 		if job.expectedStateRevision != "" && job.expectedStateRevision != snapshot.stateRevision {
 			job.status = "failed"
 			job.errorCode = "snapshot_state_revision_mismatch"
+			job.failure = nil
 			job.updatedAt = store.now().UTC()
 			jobChanged = true
 		} else {
@@ -1881,6 +1924,13 @@ func (s *Server) collectExcelPricingSnapshot(
 		return s.excelPricing.snapshotCollector(ctx, jobID, request, cfg)
 	}
 	if s == nil || s.excelPricing == nil || s.excelPricingRemote == nil {
+		if s != nil {
+			s.setExcelPricingSnapshotFailure(
+				jobID,
+				excelPricingSnapshotStageRemoteConfiguration,
+				"snapshot_remote_configuration_failed",
+			)
+		}
 		return nil, "remote_unavailable"
 	}
 	s.updateExcelPricingSnapshotProgress(jobID, "fetching_remote", 0, 1, 0)
@@ -1893,6 +1943,11 @@ func (s *Server) collectExcelPricingSnapshot(
 		},
 	)
 	if err != nil {
+		s.setExcelPricingSnapshotFailure(
+			jobID,
+			excelPricingSnapshotStageRemoteConfiguration,
+			"snapshot_remote_configuration_failed",
+		)
 		return nil, excelPricingRemoteSnapshotFailureCode(ctx, err)
 	}
 	result, err := client.Collect(
@@ -1901,6 +1956,9 @@ func (s *Server) collectExcelPricingSnapshot(
 		request.MaxAgeSeconds,
 	)
 	if err != nil {
+		if stage, detail, ok := excelPricingRemoteSnapshotFailureDetails(err); ok {
+			s.setExcelPricingSnapshotFailure(jobID, stage, detail)
+		}
 		return nil, excelPricingRemoteSnapshotFailureCode(ctx, err)
 	}
 	s.updateExcelPricingSnapshotProgress(
@@ -1910,13 +1968,13 @@ func (s *Server) collectExcelPricingSnapshot(
 		resultRowsPageCount(result),
 		len(result.Rows),
 	)
-	snapshot, err := buildExcelPricingSnapshotFromRemoteResult(
+	snapshot, code := s.finalizeExcelPricingRemoteSnapshot(
+		jobID,
 		result,
 		excelPricingSnapshotProjection(request.Projection),
-		s.excelPricing.snapshots.now().UTC(),
 	)
-	if err != nil {
-		return nil, "snapshot_integrity_failed"
+	if snapshot == nil {
+		return nil, code
 	}
 	s.updateExcelPricingSnapshotProgress(
 		jobID,
@@ -1925,6 +1983,27 @@ func (s *Server) collectExcelPricingSnapshot(
 		snapshot.integrity.PageCount,
 		snapshot.integrity.RowCount,
 	)
+	return snapshot, ""
+}
+
+func (s *Server) finalizeExcelPricingRemoteSnapshot(
+	jobID string,
+	result *excelPricingRemoteSnapshotResult,
+	projection string,
+) (*excelPricingSnapshot, string) {
+	snapshot, err := buildExcelPricingSnapshotFromRemoteResult(
+		result,
+		projection,
+		s.excelPricing.snapshots.now().UTC(),
+	)
+	if err != nil {
+		s.setExcelPricingSnapshotFailure(
+			jobID,
+			excelPricingSnapshotStageLocalProjection,
+			"snapshot_local_projection_integrity_failed",
+		)
+		return nil, "snapshot_integrity_failed"
+	}
 	return snapshot, ""
 }
 
@@ -2749,6 +2828,67 @@ func (s *Server) updateExcelPricingSnapshotProgress(
 	}
 }
 
+func (s *Server) setExcelPricingSnapshotFailure(jobID, stage, code string) {
+	if s == nil || s.excelPricing == nil || s.excelPricing.snapshots == nil ||
+		strings.TrimSpace(jobID) == "" || strings.TrimSpace(stage) == "" ||
+		strings.TrimSpace(code) == "" || !validExcelPricingSnapshotFailure(stage, code) {
+		return
+	}
+	failure := excelPricingSnapshotFailure{
+		Schema: excelPricingSnapshotFailureSchema,
+		Stage:  stage,
+		Code:   code,
+	}
+	store := s.excelPricing.snapshots
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if job := store.jobs[jobID]; job != nil && job.status == "running" {
+		copyFailure := failure
+		job.failure = &copyFailure
+	}
+	for _, follower := range store.jobs {
+		if follower == nil || follower.leaderJobID != jobID ||
+			follower.status != "running" {
+			continue
+		}
+		copyFailure := failure
+		follower.failure = &copyFailure
+	}
+}
+
+func validExcelPricingSnapshotFailure(stage, code string) bool {
+	switch stage {
+	case excelPricingRemoteSnapshotStageRevisionFetch:
+		return code == "snapshot_revision_fetch_protocol_failed" ||
+			code == "snapshot_revision_fetch_configuration_failed" ||
+			code == "snapshot_revision_fetch_unavailable"
+	case excelPricingRemoteSnapshotStageTerminalSubscription:
+		return code == "snapshot_terminal_subscription_failed"
+	case excelPricingRemoteSnapshotStageSnapshotStart:
+		return code == "snapshot_start_protocol_failed" ||
+			code == "snapshot_start_configuration_failed" ||
+			code == "snapshot_start_rejected" ||
+			code == "snapshot_start_unavailable"
+	case excelPricingRemoteSnapshotStageTerminalWait:
+		return code == "snapshot_terminal_wait_failed"
+	case excelPricingRemoteSnapshotStageTerminalMatch:
+		return code == "snapshot_terminal_match_failed"
+	case excelPricingRemoteSnapshotStageRemoteTerminal:
+		return code == "snapshot_remote_terminal_failed"
+	case excelPricingRemoteSnapshotStageSnapshotPayload:
+		return code == "snapshot_payload_integrity_failed" ||
+			code == "snapshot_payload_protocol_failed" ||
+			code == "snapshot_payload_configuration_failed" ||
+			code == "snapshot_payload_unavailable"
+	case excelPricingSnapshotStageRemoteConfiguration:
+		return code == "snapshot_remote_configuration_failed"
+	case excelPricingSnapshotStageLocalProjection:
+		return code == "snapshot_local_projection_integrity_failed"
+	default:
+		return false
+	}
+}
+
 func excelPricingSnapshotJobResponse(job *excelPricingSnapshotJob) map[string]interface{} {
 	response := map[string]interface{}{
 		"schema":         excelPricingSnapshotJobSchema,
@@ -2786,6 +2926,9 @@ func excelPricingSnapshotJobResponse(job *excelPricingSnapshotJob) map[string]in
 	}
 	if job.errorCode != "" {
 		response["code"] = job.errorCode
+	}
+	if job.failure != nil {
+		response["failure"] = *job.failure
 	}
 	if job.snapshot != nil {
 		response["snapshot_revision"] = job.snapshot.revision


### PR DESCRIPTION
## Outcome

Adds bounded, secret-safe stage diagnostics to failed local pricing snapshot jobs while preserving every existing top-level compatibility code.

The optional `failure` object contains only the reviewed `patris.pricing-snapshot-failure/v1` schema plus allowlisted `stage` and `code` values. It distinguishes revision fetch, terminal subscription, snapshot start transport/rejection/protocol, terminal wait/match, remote terminal, payload transport/protocol/integrity, remote configuration, and local projection. Routes, credentials, response bodies, source identity, request/build identifiers, and rows are never copied into it.

## Production evidence motivating this change

The guarded bda409a acceptance reached a fresh local, uncoalesced job and failed closed with the existing `snapshot_integrity_failed` code before WordPress admission. Correlated receiver evidence showed zero snapshot request/build/event and excluded credential, source-revision, and v1.8.9 runner drift. No retry or cutover followed. This PR makes that boundary diagnosable without widening the public or privacy surface.

## Compatibility and safety

- Existing top-level codes are unchanged.
- The new field is optional and emitted only from an exact allowlist.
- Failure evidence attaches only while a job is running, never while cancelling/cancelled.
- Coalesced followers receive the same sanitized terminal evidence.
- HTTP status, transport, content-type, body-read, empty/oversize, terminal, and payload classes fail closed.

## Verification

- `go test ./pkg/server -run '^TestExcelPricing' -count=1`
- `go test -race ./pkg/server -run '^TestExcelPricing' -count=1`
- cancel/follower race tests repeated 20x under `-race`
- `go vet ./...`
- `test-cgo.cmd` full native Windows suite
- web tests: 75/75
- delivery adapter tests: 13/13
- JavaScript host tests: 29/29
- independent stable-hash review: no P0/P1 blockers

Cross-links: #230, #257, https://github.com/atomicdeploy/digitalogic-wp/issues/203, https://github.com/atomicdeploy/digitalogic-wp/pull/207

Closes #259