### PR TITLE
Preserve identity ETags for remote snapshots

### DIFF
--- a/docs/EXCEL-EXPORT.md
+++ b/docs/EXCEL-EXPORT.md
@@ -216,6 +216,11 @@ rollback-protected atomic commit. Any cancellation, error, stale event, duplicat
 identity, digest mismatch, or unsafe warning retains the previous committed
 workbook generation.
 
+The companion explicitly requests the HTTP `identity` representation for remote
+revision validation and immutable snapshot payload fetches. Their strong ETags
+bind the identity JSON bytes; an intermediary gzip validator is not substituted
+or accepted. Snapshot-start and terminal-event semantics are unchanged.
+
 Failed snapshot jobs retain their existing top-level compatibility code and may
 also include a bounded `failure` object with schema
 `patris.pricing-snapshot-failure/v1`. Its reviewed `stage` and `code` values

--- a/pkg/server/excel_pricing_events_client.go
+++ b/pkg/server/excel_pricing_events_client.go
@@ -25,6 +25,7 @@ const (
 	excelPricingRemoteRevisionSchema    = "digitalogic.pricing-sync-revision/v1"
 	excelPricingRemoteProjection        = "excel-v1"
 	excelPricingRemoteProjectionSchema  = "digitalogic.pricing-projection/excel-v1"
+	excelPricingRemoteIdentityEncoding  = "identity"
 
 	excelPricingRemoteEventsMaxFrameBytes = 64 << 10
 	excelPricingRemoteRevisionMaxBytes    = 64 << 10
@@ -569,6 +570,10 @@ func (client *excelPricingRemoteEventsClient) validateExcelPricingRemoteRevision
 		return errExcelPricingRemoteRevision
 	}
 	request.Header.Set("Accept", "application/json")
+	// Revision ETags bind the identity JSON bytes to state_revision. Selecting
+	// the identity representation prevents an intermediary from replacing that
+	// validator with a gzip-representation ETag before the fail-closed check.
+	request.Header.Set("Accept-Encoding", excelPricingRemoteIdentityEncoding)
 	request.Header.Set(excelPricingRemoteSecretHeader, client.secret)
 	request.Header.Set(excelPricingRemoteSourceIDHeader, client.source.ID)
 	request.Header.Set(excelPricingRemoteDatasetHeader, client.source.Dataset)

--- a/pkg/server/excel_pricing_events_client_test.go
+++ b/pkg/server/excel_pricing_events_client_test.go
@@ -138,6 +138,7 @@ func TestExcelPricingRemoteEventsConnectValidateAndConsumePHPFrame(t *testing.T)
 		case "/wp-json/digitalogic/pricing/sync/revision":
 			revisionCalls.Add(1)
 			valid := r.Header.Get(excelPricingRemoteSecretHeader) == excelPricingRemoteTestSecret &&
+				r.Header.Get("Accept-Encoding") == excelPricingRemoteIdentityEncoding &&
 				r.Header.Get(excelPricingRemoteSourceIDHeader) == source.ID &&
 				r.Header.Get(excelPricingRemoteDatasetHeader) == source.Dataset &&
 				r.URL.Query().Get("source_id") == source.ID &&

--- a/pkg/server/excel_pricing_remote_snapshot.go
+++ b/pkg/server/excel_pricing_remote_snapshot.go
@@ -700,6 +700,7 @@ func (client *excelPricingRemoteSnapshotClient) fetchRevision(
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotConfiguration
 	}
 	client.setRemoteHeaders(request, false)
+	request.Header.Set("Accept-Encoding", excelPricingRemoteIdentityEncoding)
 	response, err := client.client.Do(request)
 	if err != nil {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
@@ -825,6 +826,9 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 		return nil, errExcelPricingRemoteSnapshotConfiguration
 	}
 	client.setRemoteHeaders(request, false)
+	// The payload ETag is the SHA-256 of the identity response bytes. Do not let
+	// automatic gzip negotiation substitute a representation-specific ETag.
+	request.Header.Set("Accept-Encoding", excelPricingRemoteIdentityEncoding)
 	response, err := client.client.Do(request)
 	if err != nil {
 		return nil, errExcelPricingRemoteSnapshotUnavailable

--- a/pkg/server/excel_pricing_remote_snapshot_test.go
+++ b/pkg/server/excel_pricing_remote_snapshot_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -41,14 +42,18 @@ type excelPricingRemoteSnapshotFixture struct {
 	startHeldOnce  sync.Once
 	releaseOnce    sync.Once
 
-	mu            sync.Mutex
-	revisionCalls int
-	startCalls    int
-	bulkCalls     int
-	statusCalls   int
-	cancelCalls   int
-	legacyCalls   int
-	headerFailure string
+	mu                      sync.Mutex
+	revisionCalls           int
+	startCalls              int
+	bulkCalls               int
+	statusCalls             int
+	cancelCalls             int
+	legacyCalls             int
+	headerFailure           string
+	revisionIdentityCalls   int
+	revisionCompressedCalls int
+	payloadIdentityCalls    int
+	payloadCompressedCalls  int
 }
 
 type rejectingExcelPricingRemoteTerminalSource struct{}
@@ -137,6 +142,111 @@ func TestExcelPricingRemoteSnapshotColdCompletesFromTerminalEventOnly(t *testing
 		t.Fatalf("snapshot revision = %q", result.SnapshotRevision)
 	}
 	fixture.assertCalls(t, 1, 1, 1, 0, 0)
+}
+
+func TestExcelPricingRemoteSnapshotIdentityEncodingPreservesOriginETags(t *testing.T) {
+	t.Run("revision", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cdn_rewritten_etag")
+		defer fixture.Close()
+
+		client := fixture.Client(t)
+		base := client.client.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		autoDecompressed := false
+		client.client.Transport = excelPricingRemoteSnapshotRoundTripFunc(
+			func(request *http.Request) (*http.Response, error) {
+				clone := request.Clone(request.Context())
+				clone.Header = request.Header.Clone()
+				if clone.URL.Path == "/wp-json/digitalogic/pricing/sync/revision" {
+					clone.Header.Del("Accept-Encoding")
+				}
+				response, err := base.RoundTrip(clone)
+				if response != nil && clone.URL.Path == "/wp-json/digitalogic/pricing/sync/revision" {
+					autoDecompressed = response.Uncompressed
+				}
+				return response, err
+			},
+		)
+		if _, err := client.fetchRevision(context.Background()); !errors.Is(
+			err, errExcelPricingRemoteSnapshotProtocol,
+		) {
+			t.Fatalf("compressed representation revision error = %v", err)
+		}
+		if !autoDecompressed {
+			t.Fatal("control response was not transparently decompressed")
+		}
+
+		client = fixture.Client(t)
+		if _, err := client.fetchRevision(context.Background()); err != nil {
+			t.Fatalf("identity revision error = %v", err)
+		}
+		fixture.assertRepresentationCalls(t, 1, 1, 0, 0)
+	})
+
+	t.Run("immutable payload", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cdn_rewritten_etag")
+		defer fixture.Close()
+
+		client := fixture.Client(t)
+		revision, err := client.fetchRevision(context.Background())
+		if err != nil {
+			t.Fatalf("revision error = %v", err)
+		}
+		build := fixture.buildResponse()
+		base := client.client.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		autoDecompressed := false
+		client.client.Transport = excelPricingRemoteSnapshotRoundTripFunc(
+			func(request *http.Request) (*http.Response, error) {
+				clone := request.Clone(request.Context())
+				clone.Header = request.Header.Clone()
+				if strings.HasPrefix(clone.URL.Path, "/wp-json/digitalogic/pricing/sync/snapshots/") {
+					clone.Header.Del("Accept-Encoding")
+				}
+				response, err := base.RoundTrip(clone)
+				if response != nil && strings.HasPrefix(
+					clone.URL.Path, "/wp-json/digitalogic/pricing/sync/snapshots/",
+				) {
+					autoDecompressed = response.Uncompressed
+				}
+				return response, err
+			},
+		)
+		if _, err := client.fetchSnapshot(context.Background(), build, revision); !errors.Is(
+			err, errExcelPricingRemoteSnapshotProtocol,
+		) {
+			t.Fatalf("compressed representation payload error = %v", err)
+		}
+		if !autoDecompressed {
+			t.Fatal("control payload was not transparently decompressed")
+		}
+
+		client = fixture.Client(t)
+		if _, err := client.fetchSnapshot(context.Background(), build, revision); err != nil {
+			t.Fatalf("identity payload error = %v", err)
+		}
+		fixture.assertRepresentationCalls(t, 1, 0, 1, 1)
+	})
+
+	t.Run("collector keeps start and terminal semantics", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cdn_rewritten_etag")
+		defer fixture.Close()
+
+		result, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		if err != nil {
+			t.Fatalf("Collect() error = %v", err)
+		}
+		if result.CompositeStateRevision != fixture.revision.StateRevision ||
+			result.SnapshotRevision != fixture.payload.SnapshotRevision {
+			t.Fatalf("collector identity = %+v", result)
+		}
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		fixture.assertRepresentationCalls(t, 1, 0, 1, 0)
+	})
 }
 
 func TestExcelPricingSnapshotProductionCollectorUsesBulkAndPreservesCompositeIdentity(t *testing.T) {
@@ -1309,6 +1419,17 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		if fixture.mode == "revision_wrong_content_type" {
 			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 		}
+		if fixture.mode == "cdn_rewritten_etag" {
+			body, err := json.Marshal(fixture.revision)
+			if err != nil {
+				http.Error(w, "revision fixture", http.StatusInternalServerError)
+				return
+			}
+			fixture.writeIdentityBoundRepresentation(
+				w, r, body, fixture.revision.StateRevision, "revision",
+			)
+			return
+		}
 		w.Header().Set("ETag", `"`+fixture.revision.StateRevision+`"`)
 		if fixture.mode == "revision_empty_body" {
 			return
@@ -1321,6 +1442,10 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 	case r.Method == http.MethodPost && r.URL.Path == "/wp-json/digitalogic/pricing/sync/snapshots":
 		fixture.mu.Lock()
 		fixture.startCalls++
+		if fixture.mode == "cdn_rewritten_etag" &&
+			r.Header.Get("Accept-Encoding") == excelPricingRemoteIdentityEncoding {
+			fixture.headerFailure = "snapshot start unexpectedly forced identity encoding"
+		}
 		fixture.mu.Unlock()
 		var request excelPricingRemoteSnapshotStartRequest
 		if json.NewDecoder(r.Body).Decode(&request) != nil || request.RequestID == "" ||
@@ -1343,7 +1468,8 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			return
 		}
 		build := fixture.buildResponse()
-		if fixture.mode == "ready" || fixture.mode == "payload_wrong_content_type" ||
+		if fixture.mode == "ready" || fixture.mode == "cdn_rewritten_etag" ||
+			fixture.mode == "payload_wrong_content_type" ||
 			fixture.mode == "payload_empty_body" || fixture.mode == "payload_oversized_body" {
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(build)
@@ -1403,6 +1529,12 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		fixture.mu.Lock()
 		fixture.bulkCalls++
 		fixture.mu.Unlock()
+		if fixture.mode == "cdn_rewritten_etag" {
+			fixture.writeIdentityBoundRepresentation(
+				w, r, fixture.payloadBody, fixture.payload.Digest, "payload",
+			)
+			return
+		}
 		if fixture.badETag {
 			w.Header().Set("ETag", `W/"`+fixture.payload.Digest+`"`)
 		} else {
@@ -1427,6 +1559,42 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) writeIdentityBoundRepresentation(
+	w http.ResponseWriter,
+	r *http.Request,
+	body []byte,
+	originRevision string,
+	kind string,
+) {
+	encoding := r.Header.Get("Accept-Encoding")
+	fixture.mu.Lock()
+	switch {
+	case kind == "revision" && encoding == excelPricingRemoteIdentityEncoding:
+		fixture.revisionIdentityCalls++
+	case kind == "revision" && strings.Contains(encoding, "gzip"):
+		fixture.revisionCompressedCalls++
+	case kind == "payload" && encoding == excelPricingRemoteIdentityEncoding:
+		fixture.payloadIdentityCalls++
+	case kind == "payload" && strings.Contains(encoding, "gzip"):
+		fixture.payloadCompressedCalls++
+	default:
+		fixture.headerFailure = "identity-bound response received an unexpected content encoding"
+	}
+	fixture.mu.Unlock()
+
+	if encoding == excelPricingRemoteIdentityEncoding {
+		w.Header().Set("ETag", `"`+originRevision+`"`)
+		_, _ = w.Write(body)
+		return
+	}
+
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("ETag", `"cdn-gzip-representation"`)
+	compressed := gzip.NewWriter(w)
+	_, _ = compressed.Write(body)
+	_ = compressed.Close()
 }
 
 func (fixture *excelPricingRemoteSnapshotFixture) validSourceQuery(query url.Values) bool {
@@ -1736,6 +1904,30 @@ func (fixture *excelPricingRemoteSnapshotFixture) assertCalls(
 		t.Fatalf("calls = revision:%d start:%d bulk:%d status:%d cancel:%d",
 			fixture.revisionCalls, fixture.startCalls, fixture.bulkCalls,
 			fixture.statusCalls, fixture.cancelCalls)
+	}
+	if fixture.headerFailure != "" {
+		t.Fatal(fixture.headerFailure)
+	}
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) assertRepresentationCalls(
+	t *testing.T,
+	revisionIdentity, revisionCompressed, payloadIdentity, payloadCompressed int,
+) {
+	t.Helper()
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	if fixture.revisionIdentityCalls != revisionIdentity ||
+		fixture.revisionCompressedCalls != revisionCompressed ||
+		fixture.payloadIdentityCalls != payloadIdentity ||
+		fixture.payloadCompressedCalls != payloadCompressed {
+		t.Fatalf(
+			"representation calls = revision identity:%d compressed:%d payload identity:%d compressed:%d",
+			fixture.revisionIdentityCalls,
+			fixture.revisionCompressedCalls,
+			fixture.payloadIdentityCalls,
+			fixture.payloadCompressedCalls,
+		)
 	}
 	if fixture.headerFailure != "" {
 		t.Fatal(fixture.headerFailure)


### PR DESCRIPTION
## Outcome

Preserve origin identity validators across the authenticated remote snapshot path without weakening any fail-closed checks.

Closes #261.

## Changes

- request `Accept-Encoding: identity` for both revision-validation GET paths and the immutable snapshot-payload GET;
- retain exact strong SHA-256 ETag equality, response-body digest, source, schema, revision, and redirect checks;
- leave snapshot-start POST and terminal subscription/wait semantics unchanged;
- document why compressed representation validators are rejected;
- add an HTTP regression fixture that serves CDN-style gzip with a rewritten quoted ETag when identity is not requested.

The regression proves the stripped-header control is transparently decompressed but rejected, while production identity revision/payload reads accept the origin SHA validators. An integrated collector assertion retains one start POST, one bulk fetch, zero status polls, and zero cancellations.

## Verification

- focused identity/event tests: PASS
- full `pkg/server`: PASS (8.823s with the supported native runtime path)
- focused race x10: PASS (1.671s)
- `go vet ./...`: PASS
- canonical Windows `test-cgo.cmd` full repository: PASS
- web tests: 75/75 PASS
- JavaScript host tests: 29/29 PASS
- `gofmt` / `git diff --check`: clean
- independent source-stable review: no P0/P1

No snapshot retry, source delivery, live cutover, credential change, or WordPress mutation was performed.

Integration context: #230, #257, #260, atomicdeploy/digitalogic-wp#203, atomicdeploy/digitalogic-wp#207.