### PR TITLE
Verify edge-stripped snapshot ETag conditionally

### DIFF
--- a/docs/PRICING-SYNC-EVENTS.md
+++ b/docs/PRICING-SYNC-EVENTS.md
@@ -43,6 +43,15 @@ snapshots by paging the legacy remote `/state` route, and it does not poll a
 remote build-status route. A terminal-event cursor is acknowledged only after
 the generation-fenced local terminal hub retains the event for its waiter.
 
+Remote revision and immutable-payload reads explicitly request the identity
+representation. If an intermediary removes the payload `ETag` header entirely,
+the companion sends exactly one conditional identity `GET` with the
+authenticated terminal digest and accepts that exceptional path only for an
+exact `304` with zero response bytes. A present empty, weak, malformed, or
+mismatched validator fails closed; this verification is neither polling nor a
+retry loop. All payload schema, source, revision, expiry, row, reconciliation,
+and canonical digest checks still run before the local snapshot is committed.
+
 `max_age_seconds: 0` without `expected_state_revision` deliberately requests a
 new verification/build. Exact-revision reuse is allowed only when the requested
 composite revision matches the cached snapshot and the authenticated upstream

--- a/pkg/server/excel_pricing_remote_snapshot.go
+++ b/pkg/server/excel_pricing_remote_snapshot.go
@@ -851,9 +851,21 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 	if json.Unmarshal(body, &payload) != nil {
 		return nil, errExcelPricingRemoteSnapshotProtocol
 	}
+	etagValues := response.Header.Values("ETag")
 	etag := strings.TrimSpace(response.Header.Get("ETag"))
+	missingETag := len(etagValues) == 0
+	if missingETag {
+		etag = `"` + build.Digest + `"`
+	} else if len(etagValues) != 1 {
+		return nil, errExcelPricingRemoteSnapshotProtocol
+	}
 	if err := validateExcelPricingRemoteSnapshotPayload(payload, build, revision, client.source, etag); err != nil {
 		return nil, err
+	}
+	if missingETag {
+		if err := client.confirmSnapshotValidator(ctx, requestURL, build.Digest); err != nil {
+			return nil, err
+		}
 	}
 	projected, fields, err := projectExcelPricingSnapshotRows(payload.Catalog.Rows, excelPricingSnapshotProjectionExcelV1)
 	if err != nil {
@@ -874,6 +886,52 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 		ProjectedRowFields:     fields,
 		RawPayload:             append([]byte(nil), body...),
 	}, nil
+}
+
+// confirmSnapshotValidator handles intermediaries that remove an ETag header
+// from an otherwise intact immutable payload. The terminal build digest is
+// already authenticated. Requiring one exact conditional 304 with no response
+// bytes proves that the origin still binds that digest as its strong validator.
+// Present malformed or mismatched validators never enter this fallback.
+func (client *excelPricingRemoteSnapshotClient) confirmSnapshotValidator(
+	ctx context.Context,
+	requestURL *url.URL,
+	digest string,
+) error {
+	expectedETag := `"` + digest + `"`
+	if !isStrongExcelPricingRevisionETag(expectedETag, digest) {
+		return errExcelPricingRemoteSnapshotProtocol
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return errExcelPricingRemoteSnapshotConfiguration
+	}
+	client.setRemoteHeaders(request, false)
+	request.Header.Set("Accept-Encoding", excelPricingRemoteIdentityEncoding)
+	request.Header.Set("If-None-Match", expectedETag)
+	response, err := client.client.Do(request)
+	if err != nil {
+		return errExcelPricingRemoteSnapshotUnavailable
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNotModified {
+		return errExcelPricingRemoteSnapshotProtocol
+	}
+	confirmationETagValues := response.Header.Values("ETag")
+	confirmationETag := strings.TrimSpace(response.Header.Get("ETag"))
+	if len(confirmationETagValues) > 1 ||
+		(len(confirmationETagValues) == 1 &&
+			!isStrongExcelPricingRevisionETag(confirmationETag, digest)) {
+		return errExcelPricingRemoteSnapshotProtocol
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1))
+	if err != nil {
+		return errExcelPricingRemoteSnapshotUnavailable
+	}
+	if len(body) != 0 {
+		return errExcelPricingRemoteSnapshotProtocol
+	}
+	return nil
 }
 
 func readExcelPricingRemoteSnapshotBody(reader io.Reader, limit int64) ([]byte, error) {

--- a/pkg/server/excel_pricing_remote_snapshot_test.go
+++ b/pkg/server/excel_pricing_remote_snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -54,6 +55,7 @@ type excelPricingRemoteSnapshotFixture struct {
 	revisionCompressedCalls int
 	payloadIdentityCalls    int
 	payloadCompressedCalls  int
+	payloadConditionalCalls int
 }
 
 type rejectingExcelPricingRemoteTerminalSource struct{}
@@ -653,7 +655,68 @@ func TestExcelPricingRemoteSnapshotCollectAnnotatesEveryRemoteStage(t *testing.T
 		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
 		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
 			"snapshot_payload_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
 	})
+
+	t.Run("snapshot payload missing ETag verified once", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_missing_etag_verified")
+		defer fixture.Close()
+		result, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		if err != nil {
+			t.Fatalf("Collect() error = %v", err)
+		}
+		if result.ETag != `"`+fixture.payload.Digest+`"` {
+			t.Fatalf("result ETag = %q", result.ETag)
+		}
+		fixture.assertCalls(t, 1, 1, 2, 0, 0)
+		fixture.assertConditionalPayloadCalls(t, 1)
+	})
+
+	t.Run("snapshot payload present empty ETag does not fall back", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_present_empty_etag")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		fixture.assertConditionalPayloadCalls(t, 0)
+	})
+
+	t.Run("snapshot payload duplicate ETag does not fall back", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_duplicate_etag")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		fixture.assertConditionalPayloadCalls(t, 0)
+	})
+
+	t.Run("snapshot payload wrong strong ETag does not fall back", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_wrong_strong_etag")
+		defer fixture.Close()
+		_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+		assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+			"snapshot_payload_protocol_failed")
+		fixture.assertCalls(t, 1, 1, 1, 0, 0)
+		fixture.assertConditionalPayloadCalls(t, 0)
+	})
+
+	for name, mode := range map[string]string{
+		"snapshot payload missing ETag conditional non-304":                 "payload_missing_etag_non304",
+		"snapshot payload missing ETag conditional wrong present validator": "payload_missing_etag_wrong_confirmation_etag",
+		"snapshot payload missing ETag conditional duplicate validator":     "payload_missing_etag_duplicate_confirmation_etag",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newExcelPricingRemoteSnapshotFixture(t, mode)
+			defer fixture.Close()
+			_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+			assertStage(t, err, excelPricingRemoteSnapshotStageSnapshotPayload,
+				"snapshot_payload_protocol_failed")
+			fixture.assertCalls(t, 1, 1, 2, 0, 0)
+			fixture.assertConditionalPayloadCalls(t, 1)
+		})
+	}
 
 	t.Run("snapshot payload wrong content type", func(t *testing.T) {
 		fixture := newExcelPricingRemoteSnapshotFixture(t, "payload_wrong_content_type")
@@ -758,6 +821,49 @@ func TestExcelPricingRemoteSnapshotStageCodeCoversConfigurationAndTransportClass
 				t.Fatalf("body error=%v, want protocol", err)
 			}
 		})
+	}
+}
+
+func TestExcelPricingRemoteSnapshotMissingETagConfirmationRejectsNonempty304(t *testing.T) {
+	digest := testExcelPricingRevision('a')
+	requestURL, err := url.Parse("https://example.test/wp-json/digitalogic/pricing/sync/snapshots/snap_00000000000000000000000000000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	client := &excelPricingRemoteSnapshotClient{
+		source: canonical.Source{
+			ID:       "patris-office",
+			Dataset:  "kala.db",
+			Revision: testExcelPricingRevision('1'),
+		},
+		secret: "test-remote-snapshot-secret-value",
+		client: &http.Client{Transport: excelPricingRemoteSnapshotRoundTripFunc(
+			func(request *http.Request) (*http.Response, error) {
+				calls++
+				if request.Method != http.MethodGet ||
+					request.Header.Get("Accept-Encoding") != excelPricingRemoteIdentityEncoding ||
+					request.Header.Get("If-None-Match") != `"`+digest+`"` ||
+					request.Header.Get(excelPricingRemoteSecretHeader) != "test-remote-snapshot-secret-value" {
+					t.Fatal("conditional validator request headers are invalid")
+				}
+				return &http.Response{
+					StatusCode: http.StatusNotModified,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("unexpected")),
+					Request:    request,
+				}, nil
+			},
+		)},
+	}
+	if err := client.confirmSnapshotValidator(context.Background(), requestURL, digest); !errors.Is(
+		err,
+		errExcelPricingRemoteSnapshotProtocol,
+	) {
+		t.Fatalf("confirmation error = %v, want protocol", err)
+	}
+	if calls != 1 {
+		t.Fatalf("conditional calls = %d, want 1", calls)
 	}
 }
 
@@ -1470,7 +1576,10 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		build := fixture.buildResponse()
 		if fixture.mode == "ready" || fixture.mode == "cdn_rewritten_etag" ||
 			fixture.mode == "payload_wrong_content_type" ||
-			fixture.mode == "payload_empty_body" || fixture.mode == "payload_oversized_body" {
+			fixture.mode == "payload_empty_body" || fixture.mode == "payload_oversized_body" ||
+			fixture.mode == "payload_present_empty_etag" || fixture.mode == "payload_duplicate_etag" ||
+			fixture.mode == "payload_wrong_strong_etag" ||
+			strings.HasPrefix(fixture.mode, "payload_missing_etag_") {
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(build)
 			return
@@ -1529,6 +1638,52 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 		fixture.mu.Lock()
 		fixture.bulkCalls++
 		fixture.mu.Unlock()
+		if strings.HasPrefix(fixture.mode, "payload_missing_etag_") {
+			if r.Header.Get("If-None-Match") == "" {
+				_, _ = w.Write(fixture.payloadBody)
+				return
+			}
+			fixture.mu.Lock()
+			fixture.payloadConditionalCalls++
+			if r.Header.Get("Accept-Encoding") != excelPricingRemoteIdentityEncoding ||
+				r.Header.Get("If-None-Match") != `"`+fixture.payload.Digest+`"` {
+				fixture.headerFailure = "conditional payload validator headers are invalid"
+			}
+			fixture.mu.Unlock()
+			switch fixture.mode {
+			case "payload_missing_etag_verified":
+				w.WriteHeader(http.StatusNotModified)
+			case "payload_missing_etag_non304":
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(fixture.payloadBody)
+			case "payload_missing_etag_wrong_confirmation_etag":
+				w.Header().Set("ETag", `"`+testExcelPricingRevision('b')+`"`)
+				w.WriteHeader(http.StatusNotModified)
+			case "payload_missing_etag_duplicate_confirmation_etag":
+				w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
+				w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
+				w.WriteHeader(http.StatusNotModified)
+			default:
+				http.Error(w, "unknown missing ETag mode", http.StatusInternalServerError)
+			}
+			return
+		}
+		if fixture.mode == "payload_present_empty_etag" {
+			w.Header()["ETag"] = []string{""}
+			_, _ = w.Write(fixture.payloadBody)
+			return
+		}
+		if fixture.mode == "payload_duplicate_etag" {
+			w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
+			w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
+			_, _ = w.Write(fixture.payloadBody)
+			return
+		}
+		if fixture.mode == "payload_wrong_strong_etag" {
+			w.Header().Set("ETag", `"`+testExcelPricingRevision('b')+`"`)
+			_, _ = w.Write(fixture.payloadBody)
+			return
+		}
 		if fixture.mode == "cdn_rewritten_etag" {
 			fixture.writeIdentityBoundRepresentation(
 				w, r, fixture.payloadBody, fixture.payload.Digest, "payload",
@@ -1931,6 +2086,18 @@ func (fixture *excelPricingRemoteSnapshotFixture) assertRepresentationCalls(
 	}
 	if fixture.headerFailure != "" {
 		t.Fatal(fixture.headerFailure)
+	}
+}
+
+func (fixture *excelPricingRemoteSnapshotFixture) assertConditionalPayloadCalls(
+	t *testing.T,
+	want int,
+) {
+	t.Helper()
+	fixture.mu.Lock()
+	defer fixture.mu.Unlock()
+	if fixture.payloadConditionalCalls != want {
+		t.Fatalf("conditional payload calls = %d, want %d", fixture.payloadConditionalCalls, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing strong-ETag immutable payload path
- when and only when a 200 payload has no ETag field, validate the full payload first and issue one identity-encoded conditional GET using the authenticated terminal/build digest
- require exact HTTP 304 and zero response bytes; reject present empty, weak, malformed, wrong, or duplicate validators without fallback
- document the bounded exceptional path and keep all semantic/digest/privacy checks fail-closed

Closes #263
Supports #230
Follow-up to #261 and #262
Integration context: atomicdeploy/digitalogic-wp#203 and atomicdeploy/digitalogic-wp#207

## Verification

- `go test ./pkg/server -run '^(TestExcelPricingRemoteSnapshot|TestExcelPricingSnapshotFailure)' -count=1`
- `go test ./pkg/server -count=1`
- focused `go test -race` x20
- `go vet ./pkg/server`
- canonical Windows `test-cgo.cmd` full repository
- web Node tests: 75/75
- JavaScript host tests: 29/29
- `gofmt -d` and `git diff --check`
- independent read-only review: no P0/P1 blockers

No production process, scheduled task, credential, source delivery, snapshot retry, or live cutover was changed while preparing this PR.