### PR TITLE
Preserve hidden SyncData in macro-free Excel exports

### DIFF
--- a/docs/examples/vba/ProductCatalogSync.bas
+++ b/docs/examples/vba/ProductCatalogSync.bas
@@ -436,6 +436,10 @@ End Sub
 
 Private Sub ExportMacroFreeCopy(ByVal outputPath As String)
     Dim copyBook As Workbook
+    Dim syncSheetValue As Worksheet
+    Dim syncSheetName As String
+    Dim originalSyncVisibility As XlSheetVisibility
+    Dim syncVisibilityChanged As Boolean
     Dim previousAlerts As Boolean
     Dim previousEvents As Boolean
     Dim previousScreenUpdating As Boolean
@@ -450,8 +454,23 @@ Private Sub ExportMacroFreeCopy(ByVal outputPath As String)
     Application.EnableEvents = False
     Application.ScreenUpdating = False
 
+    Set syncSheetValue = SyncSheet()
+    syncSheetName = syncSheetValue.Name
+    originalSyncVisibility = syncSheetValue.Visible
+    If originalSyncVisibility <> xlSheetVisible Then
+        syncSheetValue.Visible = xlSheetVisible
+        syncVisibilityChanged = True
+    End If
+
+    ' Excel omits xlSheetVeryHidden worksheets when copying the collection.
+    ' Briefly expose SyncData for the copy, then restore both source and copy.
     ThisWorkbook.Worksheets.Copy
     Set copyBook = ActiveWorkbook
+    If syncVisibilityChanged Then
+        syncSheetValue.Visible = originalSyncVisibility
+        syncVisibilityChanged = False
+    End If
+    copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility
     RemoveMacroOnlyUI copyBook
     copyBook.SaveAs Filename:=outputPath, FileFormat:=xlOpenXMLWorkbook
     copyBook.Close SaveChanges:=False
@@ -471,8 +490,12 @@ Failed:
     savedErrorNumber = Err.Number
     savedErrorDescription = Err.Description
     On Error Resume Next
+    If syncVisibilityChanged And Not syncSheetValue Is Nothing Then
+        syncSheetValue.Visible = originalSyncVisibility
+    End If
     If Not copyBook Is Nothing Then copyBook.Close SaveChanges:=False
     Set copyBook = Nothing
+    Set syncSheetValue = Nothing
     On Error GoTo 0
     Resume CleanExit
 End Sub

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -1054,6 +1054,26 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	if strings.Contains(kickHandler, "DispatchAsyncRequest") {
 		t.Fatal("safe dispatch kick must not run a WinHTTP state transition directly")
 	}
+	macroFreeExport := section("Private Sub ExportMacroFreeCopy", "Private Sub RemoveMacroOnlyUI")
+	for _, required := range []string{
+		"Set syncSheetValue = SyncSheet()",
+		"originalSyncVisibility = syncSheetValue.Visible",
+		"syncSheetValue.Visible = xlSheetVisible",
+		"ThisWorkbook.Worksheets.Copy",
+		"copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility",
+		"If syncVisibilityChanged And Not syncSheetValue Is Nothing Then",
+	} {
+		if !strings.Contains(macroFreeExport, required) {
+			t.Fatalf("macro-free export can omit or expose SyncData: %s", required)
+		}
+	}
+	showSync := strings.Index(macroFreeExport, "syncSheetValue.Visible = xlSheetVisible")
+	copySheets := strings.Index(macroFreeExport, "ThisWorkbook.Worksheets.Copy")
+	restoreSource := strings.Index(macroFreeExport, "syncSheetValue.Visible = originalSyncVisibility")
+	restoreCopy := strings.Index(macroFreeExport, "copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility")
+	if showSync < 0 || copySheets <= showSync || restoreSource <= copySheets || restoreCopy <= restoreSource {
+		t.Fatal("macro-free export must expose SyncData only for the collection copy and restore both workbooks afterward")
+	}
 	saveResume := section("Private Sub ResumeQualifiedSchedulesAfterSaveAs", "Public Sub RefreshAllData")
 	for _, required := range []string{
 		"mAsyncDispatchPending.Count > 0",


### PR DESCRIPTION
## Outcome

Preserves the `SyncData` worksheet and table in macro-free Excel exports without exposing the sheet or changing the macro-free/UI stripping contract.

## Root cause

Native hidden acceptance showed that Excel omits an `xlSheetVeryHidden` worksheet from `ThisWorkbook.Worksheets.Copy`. The old helper therefore produced a three-sheet `.xlsx` while dashboard formulas still referenced `SyncData[...]`.

## Change

- Temporarily make the source `SyncData` worksheet visible only for the collection copy.
- Restore source visibility immediately after the copy and again on the error path.
- Restore the copied `SyncData` worksheet to its original `xlSheetVeryHidden` state before saving.
- Add source guards that require the expose/copy/restore ordering and failure restoration.

## Validation

- `go test ./pkg/recordsink -run '^TestDynamicCalculator' -count=1` — PASS after rebase onto exact main `15c8df2`.
- `go test ./pkg/recordsink -count=1` — PASS.
- `node --check scripts/windows/Validate-ExcelPriceCalculator.cjs` — PASS.
- `git diff --check` — PASS.
- Hidden Excel build on Office 16.0.20326.20100 — PASS, 11 VBA components.
- Hidden native macro-free export — PASS:
  - source `.xltm` SHA-256 unchanged before/after (`DD1D0E37...98E13`);
  - `.xlsx` FileFormat 51, no VBA project/package or macro-enabled content type;
  - 4 worksheets; `SyncData` table present and worksheet visibility `xlSheetVeryHidden`;
  - no macro-bound shapes or macro-only defined names;
  - FaNum toggle/name removed, zero formula errors;
  - selling-price font `Yekan Bakh FaNum`; technical font `Segoe UI`.

The native pass intentionally did not perform live synchronization, Desktop promotion, or visible Excel/UI capture; those remain gated on the final Patris live cutover.

Closes #265

Related: #230

Desktop integration: atomicdeploy/digitalogic-desktop#9
