### PR TITLE
fix(excel): preserve source saved state on macro-free export

### DIFF
--- a/docs/examples/vba/ProductCatalogSync.bas
+++ b/docs/examples/vba/ProductCatalogSync.bas
@@ -470,6 +470,10 @@ Private Sub ExportMacroFreeCopy(ByVal outputPath As String)
     Set copyBook = ActiveWorkbook
     If syncVisibilityChanged Then
         syncSheetValue.Visible = originalSyncVisibility
+        If syncSheetValue.Visible <> originalSyncVisibility Then
+            Err.Raise vbObjectError + 2182, "ExportMacroFreeCopy", _
+                      "SyncData visibility could not be restored."
+        End If
         syncVisibilityChanged = False
     End If
     copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility
@@ -482,7 +486,8 @@ CleanExit:
     Application.DisplayAlerts = previousAlerts
     Application.EnableEvents = previousEvents
     Application.ScreenUpdating = previousScreenUpdating
-    If sourceWasSaved Then ThisWorkbook.Saved = True
+    If sourceWasSaved And Not syncVisibilityChanged Then _
+        ThisWorkbook.Saved = True
     If savedErrorNumber <> 0 Then
         Err.Raise savedErrorNumber, "ExportMacroFreeCopy", _
                   savedErrorDescription
@@ -495,7 +500,8 @@ Failed:
     On Error Resume Next
     If syncVisibilityChanged And Not syncSheetValue Is Nothing Then
         syncSheetValue.Visible = originalSyncVisibility
-        syncVisibilityChanged = False
+        If syncSheetValue.Visible = originalSyncVisibility Then _
+            syncVisibilityChanged = False
     End If
     If Not copyBook Is Nothing Then copyBook.Close SaveChanges:=False
     Set copyBook = Nothing

--- a/docs/examples/vba/ProductCatalogSync.bas
+++ b/docs/examples/vba/ProductCatalogSync.bas
@@ -440,6 +440,7 @@ Private Sub ExportMacroFreeCopy(ByVal outputPath As String)
     Dim syncSheetName As String
     Dim originalSyncVisibility As XlSheetVisibility
     Dim syncVisibilityChanged As Boolean
+    Dim sourceWasSaved As Boolean
     Dim previousAlerts As Boolean
     Dim previousEvents As Boolean
     Dim previousScreenUpdating As Boolean
@@ -457,6 +458,7 @@ Private Sub ExportMacroFreeCopy(ByVal outputPath As String)
     Set syncSheetValue = SyncSheet()
     syncSheetName = syncSheetValue.Name
     originalSyncVisibility = syncSheetValue.Visible
+    sourceWasSaved = ThisWorkbook.Saved
     If originalSyncVisibility <> xlSheetVisible Then
         syncSheetValue.Visible = xlSheetVisible
         syncVisibilityChanged = True
@@ -480,6 +482,7 @@ CleanExit:
     Application.DisplayAlerts = previousAlerts
     Application.EnableEvents = previousEvents
     Application.ScreenUpdating = previousScreenUpdating
+    If sourceWasSaved Then ThisWorkbook.Saved = True
     If savedErrorNumber <> 0 Then
         Err.Raise savedErrorNumber, "ExportMacroFreeCopy", _
                   savedErrorDescription
@@ -492,6 +495,7 @@ Failed:
     On Error Resume Next
     If syncVisibilityChanged And Not syncSheetValue Is Nothing Then
         syncSheetValue.Visible = originalSyncVisibility
+        syncVisibilityChanged = False
     End If
     If Not copyBook Is Nothing Then copyBook.Close SaveChanges:=False
     Set copyBook = Nothing

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -1072,8 +1072,10 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	showSync := strings.Index(macroFreeExport, "syncSheetValue.Visible = xlSheetVisible")
 	copySheets := strings.Index(macroFreeExport, "ThisWorkbook.Worksheets.Copy")
 	restoreSource := strings.Index(macroFreeExport, "syncSheetValue.Visible = originalSyncVisibility")
+	verifySuccessRestore := strings.Index(macroFreeExport, "If syncSheetValue.Visible <> originalSyncVisibility Then")
 	restoreCopy := strings.Index(macroFreeExport, "copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility")
-	if showSync < 0 || copySheets <= showSync || restoreSource <= copySheets || restoreCopy <= restoreSource {
+	if showSync < 0 || copySheets <= showSync || restoreSource <= copySheets ||
+		verifySuccessRestore <= restoreSource || restoreCopy <= verifySuccessRestore {
 		t.Fatal("macro-free export must expose SyncData only for the collection copy and restore both workbooks afterward")
 	}
 	captureSaved := strings.Index(macroFreeExport, "sourceWasSaved = ThisWorkbook.Saved")

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -1056,8 +1056,10 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	}
 	macroFreeExport := section("Private Sub ExportMacroFreeCopy", "Private Sub RemoveMacroOnlyUI")
 	for _, required := range []string{
+		"Dim sourceWasSaved As Boolean",
 		"Set syncSheetValue = SyncSheet()",
 		"originalSyncVisibility = syncSheetValue.Visible",
+		"sourceWasSaved = ThisWorkbook.Saved",
 		"syncSheetValue.Visible = xlSheetVisible",
 		"ThisWorkbook.Worksheets.Copy",
 		"copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility",
@@ -1073,6 +1075,18 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	restoreCopy := strings.Index(macroFreeExport, "copyBook.Worksheets(syncSheetName).Visible = originalSyncVisibility")
 	if showSync < 0 || copySheets <= showSync || restoreSource <= copySheets || restoreCopy <= restoreSource {
 		t.Fatal("macro-free export must expose SyncData only for the collection copy and restore both workbooks afterward")
+	}
+	captureSaved := strings.Index(macroFreeExport, "sourceWasSaved = ThisWorkbook.Saved")
+	cleanExit := strings.Index(macroFreeExport, "CleanExit:")
+	failedHandler := strings.Index(macroFreeExport, "Failed:")
+	savedRestores := strings.Count(macroFreeExport, "If sourceWasSaved Then ThisWorkbook.Saved = True")
+	savedRestore := strings.Index(macroFreeExport, "If sourceWasSaved Then ThisWorkbook.Saved = True")
+	lastVisibilityRestore := strings.LastIndex(macroFreeExport, "syncSheetValue.Visible = originalSyncVisibility")
+	resumeCleanExit := strings.LastIndex(macroFreeExport, "Resume CleanExit")
+	if captureSaved < 0 || captureSaved >= showSync || cleanExit <= restoreCopy || failedHandler <= cleanExit ||
+		savedRestores != 1 || savedRestore <= cleanExit || savedRestore >= failedHandler ||
+		lastVisibilityRestore <= failedHandler || resumeCleanExit <= lastVisibilityRestore {
+		t.Fatal("macro-free export must preserve the source workbook's original Saved state on success and failure")
 	}
 	saveResume := section("Private Sub ResumeQualifiedSchedulesAfterSaveAs", "Public Sub RefreshAllData")
 	for _, required := range []string{

--- a/pkg/recordsink/xlsx_test.go
+++ b/pkg/recordsink/xlsx_test.go
@@ -1079,13 +1079,15 @@ func TestDynamicCalculatorVBASourceGuardsLivePricingBeforeMutation(t *testing.T)
 	captureSaved := strings.Index(macroFreeExport, "sourceWasSaved = ThisWorkbook.Saved")
 	cleanExit := strings.Index(macroFreeExport, "CleanExit:")
 	failedHandler := strings.Index(macroFreeExport, "Failed:")
-	savedRestores := strings.Count(macroFreeExport, "If sourceWasSaved Then ThisWorkbook.Saved = True")
-	savedRestore := strings.Index(macroFreeExport, "If sourceWasSaved Then ThisWorkbook.Saved = True")
-	lastVisibilityRestore := strings.LastIndex(macroFreeExport, "syncSheetValue.Visible = originalSyncVisibility")
+	savedRestores := strings.Count(macroFreeExport, "If sourceWasSaved And Not syncVisibilityChanged Then")
+	savedRestore := strings.Index(macroFreeExport, "If sourceWasSaved And Not syncVisibilityChanged Then")
+	lastVisibilityRestore := strings.LastIndex(macroFreeExport, "        syncSheetValue.Visible = originalSyncVisibility")
+	verifiedVisibilityRestore := strings.LastIndex(macroFreeExport, "If syncSheetValue.Visible = originalSyncVisibility Then")
 	resumeCleanExit := strings.LastIndex(macroFreeExport, "Resume CleanExit")
 	if captureSaved < 0 || captureSaved >= showSync || cleanExit <= restoreCopy || failedHandler <= cleanExit ||
 		savedRestores != 1 || savedRestore <= cleanExit || savedRestore >= failedHandler ||
-		lastVisibilityRestore <= failedHandler || resumeCleanExit <= lastVisibilityRestore {
+		lastVisibilityRestore <= failedHandler || verifiedVisibilityRestore <= lastVisibilityRestore ||
+		resumeCleanExit <= verifiedVisibilityRestore {
 		t.Fatal("macro-free export must preserve the source workbook's original Saved state on success and failure")
 	}
 	saveResume := section("Private Sub ResumeQualifiedSchedulesAfterSaveAs", "Public Sub RefreshAllData")


### PR DESCRIPTION
## Summary

- preserve the source workbook's original `Saved` state across macro-free export
- restore `Saved = True` only when the source was already saved before the temporary `SyncData` visibility change and the original visibility was verifiably restored
- perform that restoration at the final cleanup point shared by successful and failed exports
- add source-order guards covering capture, both visibility restorations, and the shared saved-state cleanup

Closes #267.
Related acceptance tracking: #230 and atomicdeploy/digitalogic-desktop#9.

## Why

Excel marks the source workbook dirty when `SyncData` is temporarily changed from `xlSheetVeryHidden` to visible. Restoring its visibility alone does not restore `ThisWorkbook.Saved`, so the prior fix could cause a close/save prompt or persist an unrelated source change.

## Validation

- `go test ./pkg/recordsink -run '^TestDynamicCalculator' -count=1` — PASS
- `go test ./pkg/recordsink -count=1` — PASS
- CI-equivalent prerequisites (`web` clean install/test/build and local pxlib runtime on `PATH`) followed by `go vet ./...` and `go test ./... -count=1` — PASS
- web tests — 75/75 PASS; dependency audit — 0 vulnerabilities
- delivery adapter tests — 13/13 PASS
- JavaScript host checks/tests — 29/29 PASS
- validator `node --check` and `git diff --check` — PASS
- hidden native branch candidate SHA-256 `91BE7F361E804FEE704B4ED3CBFF4B8843B34B4682C3B9079005FCACACDC3930`
- hidden native successful export: source `Saved` `True -> True`
- hidden native forced SaveAs error 1004: source `Saved` `True -> True`
- hidden native pre-existing-dirty successful export: source `Saved` `False -> False`
- hidden native pre-existing-dirty forced SaveAs error 1004: source `Saved` `False -> False`
- source `SyncData` visibility remained `xlSheetVeryHidden` (`2 -> 2`) on all four paths
- candidate hash unchanged before/after export
- macro-free `.xlsx` SHA-256 `E24564056FD2F899A7ECC9989A62CE779733D6AB177C6AE00936BC528F860F39`
- macro-free checks: four worksheets; `SyncData` retained and very hidden; no VBA/macro content; no macro-only names/UI; no formula errors; price font `Yekan Bakh FaNum`; technical font `Segoe UI`

The first forced-failure harness attempt propagated the expected VBA error through `Application.Run`, which caused a hidden VBA error dialog. The scoped helper Excel process was terminated, and the harness was corrected to catch and return the expected error inside VBA. No source workbook, Desktop canonical workbook, or live service was modified by that failed test attempt.

## Boundaries

- no live pricing sync in this PR validation
- no Desktop canonical workbook promotion
- no visible Excel session
- no API/event contract changes, so no WordPress counterpart change is required
