### PR TITLE
fix(pricing): preserve source event continuity

### DIFF
--- a/pkg/server/excel_pricing_events_bridge.go
+++ b/pkg/server/excel_pricing_events_bridge.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -25,6 +26,7 @@ type excelPricingRemoteBridgeConfig struct {
 type excelPricingRemoteBridgeDependencies struct {
 	config      func() appconfig.Config
 	resolve     func(appconfig.Config) excelPricingRemoteBridgeConfig
+	fenceConfig func()
 	materialize func(context.Context) (canonical.Source, error)
 	run         func(
 		context.Context,
@@ -33,10 +35,12 @@ type excelPricingRemoteBridgeDependencies struct {
 		uint64,
 		func(uint64),
 		func(excelPricingRemoteRevision) error,
+		func(excelPricingRemoteSourceLifecycle) error,
 		func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error
-	apply func(excelPricingRemoteRevision) error
-	logf  func(string, ...interface{})
+	apply     func(excelPricingRemoteRevision) error
+	lifecycle func(excelPricingRemoteSourceLifecycle) error
+	logf      func(string, ...interface{})
 }
 
 // excelPricingRemoteEventsBridge owns the production lifecycle around the
@@ -53,13 +57,19 @@ type excelPricingRemoteEventsBridge struct {
 	lifecycleWG  *sync.WaitGroup
 	managerLive  bool
 
-	mu                sync.Mutex
-	epoch             uint64
-	configInitialized bool
-	desired           excelPricingRemoteBridgeConfig
-	cursor            uint64
-	acknowledged      bool
-	verifiedRevision  atomic.Pointer[excelPricingRemoteRevision]
+	mu                  sync.Mutex
+	epoch               uint64
+	configInitialized   bool
+	desired             excelPricingRemoteBridgeConfig
+	cursor              uint64
+	acknowledged        bool
+	streamSource        canonical.Source
+	streamPresent       bool
+	acceptedSources     map[string]struct{}
+	acceptedSourceOrder []string
+	lifecycleSeen       map[string]string
+	lifecycleOrder      []string
+	verifiedRevision    atomic.Pointer[excelPricingRemoteRevision]
 }
 
 func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEventsBridge {
@@ -87,6 +97,7 @@ func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEvents
 			initialCursor uint64,
 			onCursor func(uint64),
 			onRevision func(excelPricingRemoteRevision) error,
+			onSourceLifecycle func(excelPricingRemoteSourceLifecycle) error,
 			onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 		) error {
 			return runExcelPricingRemoteEvents(
@@ -96,11 +107,14 @@ func newExcelPricingRemoteEventsBridge(server *Server) *excelPricingRemoteEvents
 				initialCursor,
 				onCursor,
 				onRevision,
+				onSourceLifecycle,
 				onTerminal,
 			)
 		},
-		apply: server.notifyExcelPricingRemoteRevisionChanged,
-		logf:  log.Printf,
+		fenceConfig: server.fenceExcelPricingRemoteConfiguration,
+		apply:       server.notifyExcelPricingRemoteRevisionChanged,
+		lifecycle:   server.notifyExcelPricingRemoteSourceLifecycle,
+		logf:        log.Printf,
 	})
 }
 
@@ -111,9 +125,11 @@ func newExcelPricingRemoteEventsBridgeWithDependencies(
 		dependencies.logf = func(string, ...interface{}) {}
 	}
 	return &excelPricingRemoteEventsBridge{
-		dependencies: dependencies,
-		wake:         make(chan struct{}, 1),
-		terminals:    newExcelPricingRemoteSnapshotTerminalHub(),
+		dependencies:    dependencies,
+		wake:            make(chan struct{}, 1),
+		terminals:       newExcelPricingRemoteSnapshotTerminalHub(),
+		acceptedSources: make(map[string]struct{}),
+		lifecycleSeen:   make(map[string]string),
 	}
 }
 
@@ -202,6 +218,7 @@ func (bridge *excelPricingRemoteEventsBridge) reconcile(
 	}
 	desired := bridge.dependencies.resolve(cfg)
 	bridge.mu.Lock()
+	initialized := bridge.configInitialized
 	configChanged := !bridge.configInitialized ||
 		bridge.desired.valid != desired.valid ||
 		bridge.desired.key != desired.key
@@ -210,13 +227,25 @@ func (bridge *excelPricingRemoteEventsBridge) reconcile(
 		bridge.mu.Unlock()
 		return epoch
 	}
+	if initialized && configChanged && !sourceChanged && bridge.dependencies.fenceConfig != nil {
+		bridge.dependencies.fenceConfig()
+	}
 	bridge.configInitialized = true
 	bridge.desired = desired
 	bridge.epoch++
 	epoch := bridge.epoch
 	bridge.cursor = 0
 	bridge.acknowledged = false
+	bridge.streamSource = canonical.Source{}
+	bridge.streamPresent = false
+	bridge.acceptedSources = make(map[string]struct{})
+	bridge.acceptedSourceOrder = nil
+	bridge.lifecycleSeen = make(map[string]string)
+	bridge.lifecycleOrder = nil
 	bridge.verifiedRevision.Store(nil)
+	if bridge.terminals != nil {
+		bridge.terminals.resetAuthenticatedEpoch()
+	}
 	bridge.mu.Unlock()
 	if wake {
 		bridge.signal()
@@ -324,7 +353,7 @@ func (bridge *excelPricingRemoteEventsBridge) runGeneration(
 ) {
 	defer bridge.clearVerifiedRevision(epoch)
 	if bridge.dependencies.materialize == nil || bridge.dependencies.run == nil ||
-		bridge.dependencies.apply == nil {
+		bridge.dependencies.apply == nil || bridge.dependencies.lifecycle == nil {
 		bridge.dependencies.logf("Pricing event subscriber is inactive: lifecycle dependencies are unavailable")
 		return
 	}
@@ -336,6 +365,9 @@ func (bridge *excelPricingRemoteEventsBridge) runGeneration(
 		}
 		return
 	}
+	if !bridge.initializeStreamSource(epoch, source) {
+		return
+	}
 	initialCursor := bridge.cursorForGeneration(epoch)
 	err = bridge.dependencies.run(
 		ctx,
@@ -345,6 +377,9 @@ func (bridge *excelPricingRemoteEventsBridge) runGeneration(
 		func(cursor uint64) { bridge.persistCursor(epoch, cursor) },
 		func(revision excelPricingRemoteRevision) error {
 			return bridge.acceptRevision(epoch, source, revision)
+		},
+		func(lifecycle excelPricingRemoteSourceLifecycle) error {
+			return bridge.acceptSourceLifecycle(epoch, source, lifecycle)
 		},
 		func(event excelPricingRemoteSnapshotTerminalEvent) error {
 			return bridge.acceptSnapshotTerminal(epoch, source, event)
@@ -372,6 +407,21 @@ func (bridge *excelPricingRemoteEventsBridge) cursorForGeneration(epoch uint64) 
 	return bridge.cursor
 }
 
+func (bridge *excelPricingRemoteEventsBridge) initializeStreamSource(
+	epoch uint64,
+	source canonical.Source,
+) bool {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if epoch == 0 || bridge.epoch != epoch || !validExcelPricingRemoteSource(source) {
+		return false
+	}
+	bridge.streamSource = source
+	bridge.streamPresent = true
+	bridge.rememberAcceptedSourceLocked(source)
+	return true
+}
+
 func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 	epoch uint64,
 	source canonical.Source,
@@ -379,7 +429,9 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 ) error {
 	bridge.mu.Lock()
 	defer bridge.mu.Unlock()
-	if epoch == 0 || bridge.epoch != epoch || revision.Source != source {
+	if epoch == 0 || bridge.epoch != epoch ||
+		!sameExcelPricingRemoteSourceScope(revision.Source, source) ||
+		!bridge.streamPresent || revision.Source != bridge.streamSource {
 		return errExcelPricingRemoteBridgeStale
 	}
 	// A reconnect validates the authoritative composite before replaying queued
@@ -388,6 +440,7 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 	// cancel a snapshot that already fetched the same revision.
 	if sameExcelPricingRemoteCompositeRevision(bridge.verifiedRevision.Load(), revision) {
 		bridge.acknowledged = true
+		bridge.rememberAcceptedSourceLocked(revision.Source)
 		return nil
 	}
 	bridge.verifiedRevision.Store(nil)
@@ -395,9 +448,223 @@ func (bridge *excelPricingRemoteEventsBridge) acceptRevision(
 		return err
 	}
 	bridge.acknowledged = true
+	bridge.rememberAcceptedSourceLocked(revision.Source)
 	verified := revision
 	bridge.verifiedRevision.Store(&verified)
 	return nil
+}
+
+func (bridge *excelPricingRemoteEventsBridge) acceptSourceLifecycle(
+	epoch uint64,
+	fixedScope canonical.Source,
+	lifecycle excelPricingRemoteSourceLifecycle,
+) error {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	if epoch == 0 || bridge.epoch != epoch ||
+		!validExcelPricingRemoteSource(lifecycle.Source) ||
+		!sameExcelPricingRemoteSourceScope(lifecycle.Source, fixedScope) {
+		return errExcelPricingRemoteBridgeStale
+	}
+	key, fingerprint := excelPricingRemoteBridgeLifecycleIdentity(lifecycle)
+	if key != "" {
+		if stored, seen := bridge.lifecycleSeen[key]; seen {
+			if stored != fingerprint {
+				return errExcelPricingRemoteBridgeStale
+			}
+			bridge.acknowledged = true
+			return nil
+		}
+	}
+	if !bridge.validSourceLifecycleLocked(lifecycle) {
+		return errExcelPricingRemoteBridgeStale
+	}
+	if bridge.dependencies.lifecycle == nil {
+		return errExcelPricingRemoteConfiguration
+	}
+	// Fence the previously verified composite before any lifecycle side effect.
+	// A failing callback therefore leaves readers fail-closed and the durable
+	// cursor/state transition remains available for replay.
+	bridge.verifiedRevision.Store(nil)
+	if err := bridge.dependencies.lifecycle(lifecycle); err != nil {
+		return err
+	}
+
+	bridge.acknowledged = true
+	switch lifecycle.Mode {
+	case "ordered":
+		bridge.streamSource = lifecycle.Source
+		bridge.streamPresent = lifecycle.Change != "removed"
+		bridge.rememberAcceptedSourceLocked(lifecycle.Source)
+		bridge.rememberLifecycleLocked(key, fingerprint)
+	case "reconcile_present":
+		bridge.streamSource = lifecycle.Source
+		bridge.streamPresent = true
+		bridge.rememberAcceptedSourceLocked(lifecycle.Source)
+	case "reconcile_absent":
+		bridge.streamSource = lifecycle.Source
+		bridge.streamPresent = false
+	case "validation_gap":
+		bridge.verifiedRevision.Store(nil)
+		return nil
+	default:
+		return errExcelPricingRemoteBridgeStale
+	}
+	if lifecycle.Revision == nil || !bridge.streamPresent {
+		bridge.verifiedRevision.Store(nil)
+		return nil
+	}
+	verified := *lifecycle.Revision
+	bridge.verifiedRevision.Store(&verified)
+	return nil
+}
+
+func (bridge *excelPricingRemoteEventsBridge) validSourceLifecycleLocked(
+	lifecycle excelPricingRemoteSourceLifecycle,
+) bool {
+	if !validExcelPricingRemoteSource(lifecycle.Source) ||
+		!validExcelPricingRemoteLifecycleValidation(lifecycle) {
+		return false
+	}
+	if lifecycle.Revision != nil &&
+		(lifecycle.Revision.Source != lifecycle.Source ||
+			!validExcelPricingRemoteRevisionParts(
+				lifecycle.Revision.StateRevision,
+				lifecycle.Revision.CatalogRevision,
+				lifecycle.Revision.PricingStateRevision,
+				lifecycle.Revision.PricingPolicyRevision,
+			) || !isStrongExcelPricingRevisionETag(
+			lifecycle.Revision.ETag,
+			lifecycle.Revision.StateRevision,
+		)) {
+		return false
+	}
+	switch lifecycle.Mode {
+	case "ordered":
+		if lifecycle.EventID == 0 || !isSHA256Revision(lifecycle.IdempotencyKey) ||
+			lifecycle.ValidationOrigin != "source_event" ||
+			!validExcelPricingRemoteSourceTransition(
+				lifecycle.Name,
+				lifecycle.Change,
+				lifecycle.Source,
+				lifecycle.PreviousSourceRevision,
+				bridge.streamSource,
+				bridge.streamPresent,
+			) {
+			return false
+		}
+		if lifecycle.Change == "removed" {
+			return lifecycle.Revision == nil
+		}
+		return (lifecycle.ValidationOutcome == excelPricingRemoteSourceCurrent) ==
+			(lifecycle.Revision != nil)
+	case "validation_gap":
+		return lifecycle.Revision == nil && lifecycle.IdempotencyKey == "" &&
+			lifecycle.Source == bridge.streamSource &&
+			(lifecycle.ValidationOutcome == excelPricingRemoteSourceSuperseded ||
+				lifecycle.ValidationOutcome == excelPricingRemoteSourceAbsent ||
+				(lifecycle.ValidationOutcome == excelPricingRemoteSourceCurrent &&
+					!bridge.streamPresent))
+	case "reconcile_present":
+		return lifecycle.Name == "pricing.source.changed" && lifecycle.Change == "reconciled" &&
+			lifecycle.IdempotencyKey == "" && lifecycle.Revision != nil &&
+			lifecycle.ValidationOutcome == excelPricingRemoteSourceCurrent
+	case "reconcile_absent":
+		return lifecycle.Name == "pricing.source.removed" && lifecycle.Change == "removed" &&
+			lifecycle.IdempotencyKey == "" && lifecycle.Revision == nil &&
+			lifecycle.Source == bridge.streamSource && bridge.streamPresent &&
+			lifecycle.ValidationOutcome == excelPricingRemoteSourceAbsent
+	default:
+		return false
+	}
+}
+
+func validExcelPricingRemoteLifecycleValidation(lifecycle excelPricingRemoteSourceLifecycle) bool {
+	switch lifecycle.ValidationOutcome {
+	case excelPricingRemoteSourceCurrent:
+		return lifecycle.CurrentSourceRevision == ""
+	case excelPricingRemoteSourceSuperseded:
+		return lifecycle.Revision == nil &&
+			isSHA256Revision(lifecycle.CurrentSourceRevision) &&
+			lifecycle.CurrentSourceRevision != lifecycle.Source.Revision
+	case excelPricingRemoteSourceAbsent:
+		return lifecycle.Revision == nil && lifecycle.CurrentSourceRevision == ""
+	default:
+		return false
+	}
+}
+
+func excelPricingRemoteBridgeLifecycleIdentity(
+	lifecycle excelPricingRemoteSourceLifecycle,
+) (string, string) {
+	if lifecycle.Mode != "ordered" {
+		return "", ""
+	}
+	return excelPricingRemoteSourceEventDedupeKey(lifecycle.Name, lifecycle.IdempotencyKey),
+		strings.Join([]string{
+			lifecycle.Name,
+			lifecycle.Change,
+			lifecycle.Source.ID,
+			lifecycle.Source.Dataset,
+			lifecycle.Source.Revision,
+			lifecycle.PreviousSourceRevision,
+		}, "\x00")
+}
+
+func (bridge *excelPricingRemoteEventsBridge) rememberAcceptedSourceLocked(source canonical.Source) {
+	if bridge.acceptedSources == nil {
+		bridge.acceptedSources = make(map[string]struct{})
+	}
+	key := source.Revision
+	if _, exists := bridge.acceptedSources[key]; exists {
+		for index, accepted := range bridge.acceptedSourceOrder {
+			if accepted != key {
+				continue
+			}
+			copy(bridge.acceptedSourceOrder[index:], bridge.acceptedSourceOrder[index+1:])
+			bridge.acceptedSourceOrder = bridge.acceptedSourceOrder[:len(bridge.acceptedSourceOrder)-1]
+			break
+		}
+	} else {
+		bridge.acceptedSources[key] = struct{}{}
+	}
+	bridge.acceptedSourceOrder = append(bridge.acceptedSourceOrder, key)
+	if len(bridge.acceptedSourceOrder) > excelPricingSnapshotEventHistory {
+		delete(bridge.acceptedSources, bridge.acceptedSourceOrder[0])
+		bridge.acceptedSourceOrder = bridge.acceptedSourceOrder[1:]
+	}
+}
+
+func (bridge *excelPricingRemoteEventsBridge) rememberLifecycleLocked(key, fingerprint string) {
+	if key == "" {
+		return
+	}
+	if bridge.lifecycleSeen == nil {
+		bridge.lifecycleSeen = make(map[string]string)
+	}
+	if _, exists := bridge.lifecycleSeen[key]; exists {
+		return
+	}
+	bridge.lifecycleSeen[key] = fingerprint
+	bridge.lifecycleOrder = append(bridge.lifecycleOrder, key)
+	if len(bridge.lifecycleOrder) > excelPricingSnapshotEventHistory {
+		delete(bridge.lifecycleSeen, bridge.lifecycleOrder[0])
+		bridge.lifecycleOrder = bridge.lifecycleOrder[1:]
+	}
+}
+
+func (bridge *excelPricingRemoteEventsBridge) sourceAcceptedLocked(source canonical.Source) bool {
+	if !sameExcelPricingRemoteSourceScope(source, bridge.streamSource) {
+		return false
+	}
+	_, accepted := bridge.acceptedSources[source.Revision]
+	return accepted
+}
+
+func (bridge *excelPricingRemoteEventsBridge) sourceAbsent() bool {
+	bridge.mu.Lock()
+	defer bridge.mu.Unlock()
+	return !bridge.streamPresent
 }
 
 func sameExcelPricingRemoteCompositeRevision(
@@ -423,7 +690,9 @@ func (bridge *excelPricingRemoteEventsBridge) acceptSnapshotTerminal(
 	}
 	bridge.mu.Lock()
 	defer bridge.mu.Unlock()
-	if epoch == 0 || bridge.epoch != epoch || event.Source != source {
+	if epoch == 0 || bridge.epoch != epoch ||
+		!sameExcelPricingRemoteSourceScope(event.Source, source) ||
+		!bridge.sourceAcceptedLocked(event.Source) {
 		return errExcelPricingRemoteBridgeStale
 	}
 	return bridge.terminals.publishAuthenticated(event)
@@ -441,10 +710,10 @@ func (bridge *excelPricingRemoteEventsBridge) clearVerifiedRevision(epoch uint64
 }
 
 func (bridge *excelPricingRemoteEventsBridge) snapshotTerminals() excelPricingRemoteSnapshotTerminalSource {
-	if bridge == nil {
+	if bridge == nil || bridge.terminals == nil {
 		return nil
 	}
-	return bridge.terminals
+	return bridge.terminals.authenticatedLease()
 }
 
 func (bridge *excelPricingRemoteEventsBridge) revisionCurrent(

--- a/pkg/server/excel_pricing_events_bridge_test.go
+++ b/pkg/server/excel_pricing_events_bridge_test.go
@@ -23,6 +23,7 @@ type excelPricingRemoteBridgeTestRun struct {
 	initialCursor uint64
 	onCursor      func(uint64)
 	onRevision    func(excelPricingRemoteRevision) error
+	onLifecycle   func(excelPricingRemoteSourceLifecycle) error
 	onTerminal    func(excelPricingRemoteSnapshotTerminalEvent) error
 	stopped       chan struct{}
 }
@@ -57,6 +58,7 @@ func excelPricingRemoteBridgeTestRunner(
 	uint64,
 	func(uint64),
 	func(excelPricingRemoteRevision) error,
+	func(excelPricingRemoteSourceLifecycle) error,
 	func(excelPricingRemoteSnapshotTerminalEvent) error,
 ) error {
 	return func(
@@ -66,6 +68,7 @@ func excelPricingRemoteBridgeTestRunner(
 		initialCursor uint64,
 		onCursor func(uint64),
 		onRevision func(excelPricingRemoteRevision) error,
+		onLifecycle func(excelPricingRemoteSourceLifecycle) error,
 		onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error {
 		call := &excelPricingRemoteBridgeTestRun{
@@ -74,6 +77,7 @@ func excelPricingRemoteBridgeTestRunner(
 			initialCursor: initialCursor,
 			onCursor:      onCursor,
 			onRevision:    onRevision,
+			onLifecycle:   onLifecycle,
 			onTerminal:    onTerminal,
 			stopped:       make(chan struct{}),
 		}
@@ -89,6 +93,63 @@ func excelPricingRemoteBridgeTestRunner(
 	}
 }
 
+func excelPricingRemoteBridgeTestLifecycle(excelPricingRemoteSourceLifecycle) error {
+	return nil
+}
+
+func excelPricingRemoteBridgeTestInitialize(
+	t *testing.T,
+	bridge *excelPricingRemoteEventsBridge,
+	epoch uint64,
+	source canonical.Source,
+) {
+	t.Helper()
+	bridge.mu.Lock()
+	bridge.epoch = epoch
+	bridge.mu.Unlock()
+	if !bridge.initializeStreamSource(epoch, source) {
+		t.Fatal("bridge source initialization failed")
+	}
+}
+
+func excelPricingRemoteBridgeTestRevision(
+	source canonical.Source,
+	stateCharacter string,
+) excelPricingRemoteRevision {
+	stateRevision := excelPricingRemoteTestRevision(stateCharacter)
+	return excelPricingRemoteRevision{
+		Source:                source,
+		StateRevision:         stateRevision,
+		CatalogRevision:       excelPricingRemoteTestRevision("c"),
+		PricingStateRevision:  excelPricingRemoteTestRevision("d"),
+		PricingPolicyRevision: excelPricingRemoteTestRevision("e"),
+		ETag:                  `"` + stateRevision + `"`,
+		ValidationOrigin:      "source_event",
+	}
+}
+
+func excelPricingRemoteBridgeTestTerminal(
+	source canonical.Source,
+	eventID uint64,
+	requestID string,
+) excelPricingRemoteSnapshotTerminalEvent {
+	return excelPricingRemoteSnapshotTerminalEvent{
+		Schema:               excelPricingRemoteSnapshotEventSchema,
+		SchemaVersion:        1,
+		BuildID:              "build_" + requestID,
+		RequestID:            requestID,
+		Status:               "failed",
+		Source:               source,
+		StateRevision:        excelPricingRemoteTestRevision("1"),
+		PricingStateRevision: excelPricingRemoteTestRevision("2"),
+		CatalogRevision:      excelPricingRemoteTestRevision("3"),
+		Code:                 "test_failure",
+		Retryable:            false,
+		IdempotencyKey:       excelPricingRemoteTestRevision("4"),
+		EventID:              eventID,
+	}
+}
+
 func TestExcelPricingRemoteEventsBridgeServerCloseCancelsAndJoins(t *testing.T) {
 	cfg := excelPricingRemoteBridgeTestConfig("generation-a")
 	source := excelPricingRemoteTestSource()
@@ -99,8 +160,9 @@ func TestExcelPricingRemoteEventsBridgeServerCloseCancelsAndJoins(t *testing.T) 
 		materialize: func(context.Context) (canonical.Source, error) {
 			return source, nil
 		},
-		run:   excelPricingRemoteBridgeTestRunner(runs),
-		apply: func(excelPricingRemoteRevision) error { return nil },
+		run:       excelPricingRemoteBridgeTestRunner(runs),
+		apply:     func(excelPricingRemoteRevision) error { return nil },
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 	})
 	backgroundCtx, backgroundCancel := context.WithCancel(context.Background())
 	server := &Server{
@@ -140,6 +202,7 @@ func TestExcelPricingRemoteEventsBridgeCoalescesRestartToNewestGeneration(t *tes
 		initialCursor uint64,
 		onCursor func(uint64),
 		onRevision func(excelPricingRemoteRevision) error,
+		onLifecycle func(excelPricingRemoteSourceLifecycle) error,
 		onTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 	) error {
 		call := &excelPricingRemoteBridgeTestRun{
@@ -148,6 +211,7 @@ func TestExcelPricingRemoteEventsBridgeCoalescesRestartToNewestGeneration(t *tes
 			initialCursor: initialCursor,
 			onCursor:      onCursor,
 			onRevision:    onRevision,
+			onLifecycle:   onLifecycle,
 			onTerminal:    onTerminal,
 			stopped:       make(chan struct{}),
 		}
@@ -174,8 +238,9 @@ func TestExcelPricingRemoteEventsBridgeCoalescesRestartToNewestGeneration(t *tes
 		materialize: func(context.Context) (canonical.Source, error) {
 			return source, nil
 		},
-		run:   runner,
-		apply: func(excelPricingRemoteRevision) error { return nil },
+		run:       runner,
+		apply:     func(excelPricingRemoteRevision) error { return nil },
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -275,6 +340,7 @@ func TestExcelPricingRemoteEventsBridgeStartsOnlyAfterConfigAndSourceResolve(t *
 		apply: func(excelPricingRemoteRevision) error {
 			return nil
 		},
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -348,6 +414,7 @@ func TestExcelPricingRemoteEventsBridgeConfigRestartAndCursorOrdering(t *testing
 			applyMu.Unlock()
 			return nil
 		},
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -422,6 +489,50 @@ func TestExcelPricingRemoteEventsBridgeConfigRestartAndCursorOrdering(t *testing
 	waitExcelPricingRemoteBridgeTestSignal(t, callTwo.stopped, "replacement generation cancellation")
 }
 
+func TestExcelPricingRemoteEventsBridgeFencesOnlyActualConfigurationReplacementBeforeEpochReset(
+	t *testing.T,
+) {
+	source := excelPricingRemoteTestSource()
+	stateRevision := excelPricingRemoteTestRevision("1")
+	var (
+		bridge             *excelPricingRemoteEventsBridge
+		oldLease           excelPricingRemoteSnapshotTerminalSource
+		fenceCalls         int
+		fenceObservedLease bool
+	)
+	bridge = newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		resolve: excelPricingRemoteBridgeTestResolve,
+		fenceConfig: func() {
+			fenceCalls++
+			subscription, err := oldLease.Subscribe("request_config_fence", source, stateRevision)
+			if err == nil {
+				fenceObservedLease = true
+				subscription.Close()
+			}
+		},
+	})
+	configA := excelPricingRemoteBridgeTestConfig("generation-a")
+	bridge.reconcile(configA, false, false)
+	oldLease = bridge.snapshotTerminals()
+
+	bridge.configChanged(configA)
+	if fenceCalls != 0 {
+		t.Fatalf("equivalent config fence calls=%d", fenceCalls)
+	}
+	bridge.configChanged(excelPricingRemoteBridgeTestConfig("generation-b"))
+	if fenceCalls != 1 || !fenceObservedLease {
+		t.Fatalf("replacement fence calls=%d observed pre-reset lease=%v", fenceCalls, fenceObservedLease)
+	}
+	if _, err := oldLease.Subscribe("request_stale_config", source, stateRevision); !errors.Is(err, errExcelPricingRemoteSnapshotUnavailable) {
+		t.Fatalf("old config lease error=%v", err)
+	}
+
+	bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-c"), true, false)
+	if fenceCalls != 1 {
+		t.Fatalf("combined source/config change duplicated config fence: calls=%d", fenceCalls)
+	}
+}
+
 func TestExcelPricingRemoteEventsBridgeRetainsSnapshotTerminalBeforeCursorAck(t *testing.T) {
 	cfg := excelPricingRemoteBridgeTestConfig("generation-terminal")
 	source := excelPricingRemoteTestSource()
@@ -432,6 +543,7 @@ func TestExcelPricingRemoteEventsBridgeRetainsSnapshotTerminalBeforeCursorAck(t 
 		materialize: func(context.Context) (canonical.Source, error) { return source, nil },
 		run:         excelPricingRemoteBridgeTestRunner(runs),
 		apply:       func(excelPricingRemoteRevision) error { return nil },
+		lifecycle:   excelPricingRemoteBridgeTestLifecycle,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	var waitGroup sync.WaitGroup
@@ -525,6 +637,7 @@ func TestExcelPricingRemoteEventsBridgeSourceFenceRemovalAndReset(t *testing.T) 
 		apply: func(excelPricingRemoteRevision) error {
 			return nil
 		},
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -632,9 +745,7 @@ func TestExcelPricingRemoteEventsBridgeCursorRequiresSuccessfulApplyAndAllowsRes
 			return applyErr
 		},
 	})
-	bridge.mu.Lock()
-	bridge.epoch = 1
-	bridge.mu.Unlock()
+	excelPricingRemoteBridgeTestInitialize(t, bridge, 1, source)
 
 	revision := excelPricingRemoteRevision{Source: source}
 	if err := bridge.acceptRevision(1, source, revision); !errors.Is(err, applyErr) {
@@ -655,6 +766,272 @@ func TestExcelPricingRemoteEventsBridgeCursorRequiresSuccessfulApplyAndAllowsRes
 	_, cursor, acknowledged = excelPricingRemoteBridgeState(bridge)
 	if cursor != 0 || !acknowledged {
 		t.Fatalf("validated replay reset was not persisted: cursor=%d acknowledged=%v", cursor, acknowledged)
+	}
+}
+
+func TestExcelPricingRemoteEventsBridgeSourceLifecycleMustCommitBeforeCursor(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	lifecycleErr := errors.New("source-lifecycle journal failed")
+	lifecycleCalls := 0
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		lifecycle: func(excelPricingRemoteSourceLifecycle) error {
+			lifecycleCalls++
+			return lifecycleErr
+		},
+	})
+	excelPricingRemoteBridgeTestInitialize(t, bridge, 1, source)
+	lifecycle := excelPricingRemoteSourceLifecycle{
+		Mode:                   "ordered",
+		Name:                   "pricing.source.removed",
+		Change:                 "removed",
+		Source:                 source,
+		PreviousSourceRevision: source.Revision,
+		IdempotencyKey:         excelPricingRemoteTestRevision("9"),
+		EventID:                9,
+		ValidationOrigin:       "source_event",
+		ValidationOutcome:      excelPricingRemoteSourceAbsent,
+	}
+	if err := bridge.acceptSourceLifecycle(1, source, lifecycle); !errors.Is(err, lifecycleErr) {
+		t.Fatalf("lifecycle failure=%v", err)
+	}
+	bridge.persistCursor(1, lifecycle.EventID)
+	_, cursor, acknowledged := excelPricingRemoteBridgeState(bridge)
+	if cursor != 0 || acknowledged || lifecycleCalls != 1 || bridge.sourceAbsent() {
+		t.Fatalf("failed lifecycle cursor=%d acknowledged=%v calls=%d absent=%v",
+			cursor, acknowledged, lifecycleCalls, bridge.sourceAbsent())
+	}
+
+	bridge.dependencies.lifecycle = func(candidate excelPricingRemoteSourceLifecycle) error {
+		lifecycleCalls++
+		if candidate.Name != lifecycle.Name || candidate.Source != lifecycle.Source ||
+			candidate.IdempotencyKey != lifecycle.IdempotencyKey {
+			return errors.New("wrong lifecycle")
+		}
+		return nil
+	}
+	if err := bridge.acceptSourceLifecycle(1, source, lifecycle); err != nil {
+		t.Fatalf("accept lifecycle: %v", err)
+	}
+	bridge.persistCursor(1, lifecycle.EventID)
+	_, cursor, acknowledged = excelPricingRemoteBridgeState(bridge)
+	if cursor != lifecycle.EventID || !acknowledged || !bridge.sourceAbsent() || lifecycleCalls != 2 {
+		t.Fatalf("accepted lifecycle cursor=%d acknowledged=%v absent=%v calls=%d",
+			cursor, acknowledged, bridge.sourceAbsent(), lifecycleCalls)
+	}
+
+	replay := lifecycle
+	replay.EventID++
+	if err := bridge.acceptSourceLifecycle(1, source, replay); err != nil {
+		t.Fatalf("accept lifecycle replay: %v", err)
+	}
+	bridge.persistCursor(1, replay.EventID)
+	_, cursor, acknowledged = excelPricingRemoteBridgeState(bridge)
+	if cursor != replay.EventID || !acknowledged || lifecycleCalls != 2 {
+		t.Fatalf("lifecycle replay cursor=%d acknowledged=%v calls=%d", cursor, acknowledged, lifecycleCalls)
+	}
+}
+
+func TestExcelPricingRemoteEventsBridgeTracksMutableSourceAndAcceptedTerminalLineage(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	revisionB := excelPricingRemoteBridgeTestRevision(sourceB, "5")
+	lifecycleCalls := 0
+	applyCalls := 0
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		apply: func(excelPricingRemoteRevision) error {
+			applyCalls++
+			return nil
+		},
+		lifecycle: func(excelPricingRemoteSourceLifecycle) error {
+			lifecycleCalls++
+			return nil
+		},
+	})
+	excelPricingRemoteBridgeTestInitialize(t, bridge, 1, sourceA)
+
+	key := excelPricingRemoteTestRevision("6")
+	changed := excelPricingRemoteSourceLifecycle{
+		Mode:                   "ordered",
+		Name:                   "pricing.source.changed",
+		Change:                 "changed",
+		Source:                 sourceB,
+		PreviousSourceRevision: sourceA.Revision,
+		IdempotencyKey:         key,
+		EventID:                1,
+		ValidationOrigin:       "source_event",
+		ValidationOutcome:      excelPricingRemoteSourceCurrent,
+		Revision:               &revisionB,
+	}
+	if err := bridge.acceptSourceLifecycle(1, sourceA, changed); err != nil {
+		t.Fatalf("accept A->B lifecycle: %v", err)
+	}
+	if !bridge.revisionCurrent(sourceB, revisionB.StateRevision, revisionB.CatalogRevision) {
+		t.Fatal("source lifecycle did not atomically establish the verified B composite")
+	}
+	if err := bridge.acceptRevision(1, sourceA, revisionB); err != nil {
+		t.Fatalf("accept matching B state: %v", err)
+	}
+	if applyCalls != 0 || lifecycleCalls != 1 {
+		t.Fatalf("matching state reapplied lifecycle: apply=%d lifecycle=%d", applyCalls, lifecycleCalls)
+	}
+
+	replay := changed
+	replay.EventID = 2
+	if err := bridge.acceptSourceLifecycle(1, sourceA, replay); err != nil {
+		t.Fatalf("accept exact lifecycle replay: %v", err)
+	}
+	conflict := changed
+	conflict.Source = sourceC
+	conflict.PreviousSourceRevision = sourceB.Revision
+	conflict.EventID = 3
+	if err := bridge.acceptSourceLifecycle(1, sourceA, conflict); !errors.Is(err, errExcelPricingRemoteBridgeStale) {
+		t.Fatalf("conflicting idempotency reuse error=%v", err)
+	}
+	if lifecycleCalls != 1 {
+		t.Fatalf("dedupe replay/conflict invoked lifecycle %d times", lifecycleCalls)
+	}
+
+	removed := excelPricingRemoteSourceLifecycle{
+		Mode:                   "ordered",
+		Name:                   "pricing.source.removed",
+		Change:                 "removed",
+		Source:                 sourceB,
+		PreviousSourceRevision: sourceB.Revision,
+		IdempotencyKey:         excelPricingRemoteTestRevision("7"),
+		EventID:                4,
+		ValidationOrigin:       "source_event",
+		ValidationOutcome:      excelPricingRemoteSourceAbsent,
+	}
+	if err := bridge.acceptSourceLifecycle(1, sourceA, removed); err != nil {
+		t.Fatalf("accept final removal: %v", err)
+	}
+	if !bridge.sourceAbsent() || bridge.revisionCurrent(sourceB, revisionB.StateRevision, revisionB.CatalogRevision) {
+		t.Fatal("final removal did not clear the verified composite")
+	}
+	gap := excelPricingRemoteSourceLifecycle{
+		Mode:              "validation_gap",
+		Source:            sourceB,
+		EventID:           4,
+		ValidationOrigin:  "connection_validation",
+		ValidationOutcome: excelPricingRemoteSourceCurrent,
+	}
+	if err := bridge.acceptSourceLifecycle(1, sourceA, gap); err != nil {
+		t.Fatalf("accept absent/current replay gap: %v", err)
+	}
+	if !bridge.sourceAbsent() {
+		t.Fatal("current validation jumped across the queued re-add transition")
+	}
+
+	if err := bridge.acceptSnapshotTerminal(
+		1, sourceA, excelPricingRemoteBridgeTestTerminal(sourceA, 5, "request_source_a"),
+	); err != nil {
+		t.Fatalf("accepted lineage terminal A: %v", err)
+	}
+	if err := bridge.acceptSnapshotTerminal(
+		1, sourceA, excelPricingRemoteBridgeTestTerminal(sourceB, 6, "request_source_b"),
+	); err != nil {
+		t.Fatalf("accepted lineage terminal B: %v", err)
+	}
+	if err := bridge.acceptSnapshotTerminal(
+		1, sourceA, excelPricingRemoteBridgeTestTerminal(sourceC, 7, "request_source_c"),
+	); !errors.Is(err, errExcelPricingRemoteBridgeStale) {
+		t.Fatalf("unaccepted lineage terminal error=%v", err)
+	}
+}
+
+func TestExcelPricingRemoteEventsBridgeRefreshesAcceptedSourceLineageRecency(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceA.Revision = excelPricingRemoteTestIndexedRevision(1)
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		apply:     func(excelPricingRemoteRevision) error { return nil },
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
+	})
+	excelPricingRemoteBridgeTestInitialize(t, bridge, 1, sourceA)
+	current := sourceA
+	var eventID uint64
+	transition := func(next canonical.Source) {
+		t.Helper()
+		eventID++
+		revision := excelPricingRemoteBridgeTestRevision(next, "5")
+		lifecycle := excelPricingRemoteSourceLifecycle{
+			Mode:                   "ordered",
+			Name:                   "pricing.source.changed",
+			Change:                 "changed",
+			Source:                 next,
+			PreviousSourceRevision: current.Revision,
+			IdempotencyKey:         excelPricingRemoteTestIndexedRevision(1000 + int(eventID)),
+			EventID:                eventID,
+			ValidationOrigin:       "source_event",
+			ValidationOutcome:      excelPricingRemoteSourceCurrent,
+			Revision:               &revision,
+		}
+		if err := bridge.acceptSourceLifecycle(1, sourceA, lifecycle); err != nil {
+			t.Fatalf("accept %s -> %s: %v", current.Revision, next.Revision, err)
+		}
+		current = next
+	}
+	for index := 2; index <= excelPricingSnapshotEventHistory; index++ {
+		next := sourceA
+		next.Revision = excelPricingRemoteTestIndexedRevision(index)
+		transition(next)
+	}
+	transition(sourceA)
+	next := sourceA
+	next.Revision = excelPricingRemoteTestIndexedRevision(excelPricingSnapshotEventHistory + 1)
+	transition(next)
+	if err := bridge.acceptSnapshotTerminal(
+		1, sourceA, excelPricingRemoteBridgeTestTerminal(sourceA, eventID+1, "request_recent_source"),
+	); err != nil {
+		t.Fatalf("recently reaccepted source terminal: %v", err)
+	}
+}
+
+func TestExcelPricingRemoteEventsBridgeResetsTerminalHubAcrossEpochs(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		resolve:   excelPricingRemoteBridgeTestResolve,
+		apply:     func(excelPricingRemoteRevision) error { return nil },
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
+	})
+	epochA := bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-a"), false, false)
+	excelPricingRemoteBridgeTestInitialize(t, bridge, epochA, sourceA)
+	oldTerminal := excelPricingRemoteBridgeTestTerminal(sourceA, 100, "request_epoch")
+	if err := bridge.acceptSnapshotTerminal(epochA, sourceA, oldTerminal); err != nil {
+		t.Fatalf("accept old epoch terminal: %v", err)
+	}
+	pending, err := bridge.terminals.Subscribe(
+		"request_pending", sourceA, oldTerminal.StateRevision,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pending.Close()
+
+	epochB := bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-b"), false, false)
+	if epochB == epochA {
+		t.Fatal("config change did not advance bridge epoch")
+	}
+	if _, waitErr := pending.Wait(t.Context()); !errors.Is(waitErr, errExcelPricingRemoteSnapshotUnavailable) {
+		t.Fatalf("old epoch waiter error = %v", waitErr)
+	}
+	excelPricingRemoteBridgeTestInitialize(t, bridge, epochB, sourceB)
+	current, err := bridge.terminals.Subscribe("request_epoch", sourceB, oldTerminal.StateRevision)
+	if err != nil {
+		t.Fatalf("new epoch subscription inherited old history: %v", err)
+	}
+	defer current.Close()
+	newTerminal := excelPricingRemoteBridgeTestTerminal(sourceB, 1, "request_epoch")
+	if err := bridge.acceptSnapshotTerminal(epochB, sourceB, newTerminal); err != nil {
+		t.Fatalf("lower-ID new epoch terminal: %v", err)
+	}
+	accepted, err := current.Wait(t.Context())
+	if err != nil || accepted != newTerminal {
+		t.Fatalf("accepted=%+v err=%v", accepted, err)
 	}
 }
 
@@ -681,9 +1058,7 @@ func TestExcelPricingRemoteEventsBridgeIdenticalCompositeDoesNotCancelActiveSnap
 			return server.notifyExcelPricingRemoteRevisionChanged(candidate)
 		},
 	})
-	bridge.mu.Lock()
-	bridge.epoch = 1
-	bridge.mu.Unlock()
+	excelPricingRemoteBridgeTestInitialize(t, bridge, 1, source)
 
 	store.mu.Lock()
 	initialGeneration := store.generation
@@ -828,11 +1203,13 @@ func TestExcelPricingRemoteEventsBridgeLogsAreSecretSafe(t *testing.T) {
 			uint64,
 			func(uint64),
 			func(excelPricingRemoteRevision) error,
+			func(excelPricingRemoteSourceLifecycle) error,
 			func(excelPricingRemoteSnapshotTerminalEvent) error,
 		) error {
 			return fmt.Errorf("transport rejected %s with %s", privateEndpoint, privateSecret)
 		},
-		apply: func(excelPricingRemoteRevision) error { return nil },
+		apply:     func(excelPricingRemoteRevision) error { return nil },
+		lifecycle: excelPricingRemoteBridgeTestLifecycle,
 		logf: func(format string, args ...interface{}) {
 			logMu.Lock()
 			logs = append(logs, fmt.Sprintf(format, args...))

--- a/pkg/server/excel_pricing_events_client.go
+++ b/pkg/server/excel_pricing_events_client.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -20,6 +21,7 @@ import (
 
 const (
 	excelPricingRemoteWebSocketProtocol = "digitalogic.pricing.v1"
+	excelPricingRemoteSourceEventSchema = "digitalogic.pricing-source-change/v1"
 	excelPricingRemoteStateEventSchema  = "digitalogic.pricing-state-change/v1"
 	excelPricingRemoteStreamResetSchema = "digitalogic.pricing-stream-reset/v1"
 	excelPricingRemoteRevisionSchema    = "digitalogic.pricing-sync-revision/v1"
@@ -64,10 +66,37 @@ type excelPricingRemoteRevision struct {
 	ValidationOrigin      string
 }
 
+type excelPricingRemoteSourceValidationOutcome string
+
+const (
+	excelPricingRemoteSourceCurrent    excelPricingRemoteSourceValidationOutcome = "current"
+	excelPricingRemoteSourceSuperseded excelPricingRemoteSourceValidationOutcome = "superseded"
+	excelPricingRemoteSourceAbsent     excelPricingRemoteSourceValidationOutcome = "absent"
+)
+
+// excelPricingRemoteSourceLifecycle is the only source-identity transition
+// allowed to cross from the authenticated WordPress stream into the local
+// snapshot store. Synthetic modes reconcile a connection/reset without
+// inventing a durable producer idempotency key.
+type excelPricingRemoteSourceLifecycle struct {
+	Mode                   string
+	Name                   string
+	Change                 string
+	Source                 canonical.Source
+	PreviousSourceRevision string
+	IdempotencyKey         string
+	EventID                uint64
+	ValidationOrigin       string
+	ValidationOutcome      excelPricingRemoteSourceValidationOutcome
+	CurrentSourceRevision  string
+	Revision               *excelPricingRemoteRevision
+}
+
 type excelPricingRemoteEventsOptions struct {
 	InitialCursor       uint64
 	InitialETag         string
 	OnRevision          func(excelPricingRemoteRevision) error
+	OnSourceLifecycle   func(excelPricingRemoteSourceLifecycle) error
 	OnSnapshotTerminal  func(excelPricingRemoteSnapshotTerminalEvent) error
 	OnCursor            func(uint64)
 	WebSocketDialer     *websocket.Dialer
@@ -86,6 +115,7 @@ type excelPricingRemoteEventsClient struct {
 	dialer       *websocket.Dialer
 	httpClient   *http.Client
 	onRevision   func(excelPricingRemoteRevision) error
+	onLifecycle  func(excelPricingRemoteSourceLifecycle) error
 	onTerminal   func(excelPricingRemoteSnapshotTerminalEvent) error
 	onCursor     func(uint64)
 	minBackoff   time.Duration
@@ -95,7 +125,9 @@ type excelPricingRemoteEventsClient struct {
 	cursor        uint64
 	etag          string
 	stateRevision string
-	seen          map[string]struct{}
+	streamSource  canonical.Source
+	streamPresent bool
+	seen          map[string]string
 	seenOrder     []string
 }
 
@@ -144,6 +176,44 @@ type excelPricingRemoteStateEventData struct {
 	RevisionPath          string           `json:"revision_path"`
 }
 
+type excelPricingRemoteSourceAudience struct {
+	Services []string `json:"services"`
+}
+
+type excelPricingRemoteSourceEventData struct {
+	Schema                     string                           `json:"schema"`
+	SchemaVersion              int                              `json:"schema_version"`
+	Projection                 string                           `json:"projection"`
+	Change                     string                           `json:"change"`
+	Source                     canonical.Source                 `json:"source"`
+	PreviousSourceRevision     json.RawMessage                  `json:"previous_source_revision"`
+	IdempotencyKey             string                           `json:"idempotency_key"`
+	RevisionValidationRequired bool                             `json:"revision_validation_required"`
+	RevisionPath               string                           `json:"revision_path"`
+	Audience                   excelPricingRemoteSourceAudience `json:"audience"`
+}
+
+type excelPricingRemoteErrorSource struct {
+	ID       *string `json:"id"`
+	Dataset  *string `json:"dataset"`
+	Revision *string `json:"revision"`
+}
+
+type excelPricingRemoteErrorDetails struct {
+	CurrentSource           *excelPricingRemoteErrorSource `json:"current_source"`
+	SubmittedSourceRevision *string                        `json:"submitted_source_revision"`
+	CurrentSourceRevision   *string                        `json:"current_source_revision"`
+	Retryable               *bool                          `json:"retryable"`
+}
+
+type excelPricingRemoteErrorResponse struct {
+	Success   *bool                          `json:"success"`
+	Code      string                         `json:"code"`
+	Message   string                         `json:"message"`
+	Retryable *bool                          `json:"retryable"`
+	Details   excelPricingRemoteErrorDetails `json:"details"`
+}
+
 type excelPricingRemoteRevisionResponse struct {
 	Schema                string           `json:"schema"`
 	SchemaVersion         int              `json:"schema_version"`
@@ -158,13 +228,21 @@ type excelPricingRemoteRevisionResponse struct {
 	PageSize              int              `json:"page_size"`
 }
 
+type excelPricingRemoteRevisionValidation struct {
+	Outcome               excelPricingRemoteSourceValidationOutcome
+	Revision              *excelPricingRemoteRevision
+	CurrentSourceRevision string
+	NotModified           bool
+}
+
 func newExcelPricingRemoteEventsClient(
 	cfg updateout.Config,
 	source canonical.Source,
 	options excelPricingRemoteEventsOptions,
 ) (*excelPricingRemoteEventsClient, error) {
 	cfg, secret, _, err := resolveExcelPricingRemote(cfg, "state")
-	if err != nil || !validExcelPricingRemoteSource(source) || options.OnRevision == nil {
+	if err != nil || !validExcelPricingRemoteSource(source) || options.OnRevision == nil ||
+		options.OnSourceLifecycle == nil {
 		return nil, errExcelPricingRemoteConfiguration
 	}
 	webSocketURL, revisionURL, revisionPath, err := excelPricingRemoteEventEndpoints(cfg.URL)
@@ -209,23 +287,31 @@ func newExcelPricingRemoteEventsClient(
 	if initialETag != "" && !isStrongExcelPricingRevisionETag(initialETag, "") {
 		return nil, errExcelPricingRemoteConfiguration
 	}
+	initialStateRevision := ""
+	if initialETag != "" {
+		initialStateRevision = initialETag[1 : len(initialETag)-1]
+	}
 	return &excelPricingRemoteEventsClient{
-		cfg:          cfg,
-		source:       source,
-		secret:       secret,
-		webSocketURL: webSocketURL,
-		revisionURL:  revisionURL,
-		revisionPath: revisionPath,
-		dialer:       dialer,
-		httpClient:   httpClient,
-		onRevision:   options.OnRevision,
-		onTerminal:   options.OnSnapshotTerminal,
-		onCursor:     options.OnCursor,
-		minBackoff:   minBackoff,
-		maxBackoff:   maxBackoff,
-		cursor:       options.InitialCursor,
-		etag:         initialETag,
-		seen:         make(map[string]struct{}),
+		cfg:           cfg,
+		source:        source,
+		secret:        secret,
+		webSocketURL:  webSocketURL,
+		revisionURL:   revisionURL,
+		revisionPath:  revisionPath,
+		dialer:        dialer,
+		httpClient:    httpClient,
+		onRevision:    options.OnRevision,
+		onLifecycle:   options.OnSourceLifecycle,
+		onTerminal:    options.OnSnapshotTerminal,
+		onCursor:      options.OnCursor,
+		minBackoff:    minBackoff,
+		maxBackoff:    maxBackoff,
+		cursor:        options.InitialCursor,
+		etag:          initialETag,
+		stateRevision: initialStateRevision,
+		streamSource:  source,
+		streamPresent: true,
+		seen:          make(map[string]string),
 	}, nil
 }
 
@@ -432,11 +518,21 @@ func (client *excelPricingRemoteEventsClient) handleExcelPricingRemoteFrame(
 			!validExcelPricingRemoteWindow(data.Cursor, data.OldestEventID, data.LatestEventID) {
 			return false, errExcelPricingRemoteProtocol
 		}
-		if err := client.validateExcelPricingRemoteRevision(ctx, "connection_validation", data.Cursor); err != nil {
+		requestedCursor := client.currentCursor()
+		if !data.CursorResetRequired &&
+			((requestedCursor > 0 && data.Cursor != requestedCursor) ||
+				(requestedCursor == 0 && data.Cursor != data.LatestEventID)) {
+			return false, errExcelPricingRemoteProtocol
+		}
+		replayPending := requestedCursor > 0 && !data.CursorResetRequired &&
+			data.Cursor == requestedCursor && data.Cursor < data.LatestEventID
+		if err := client.reconcileExcelPricingRemoteRevision(
+			ctx, "connection_validation", data.Cursor, replayPending,
+		); err != nil {
 			return false, err
 		}
 		if data.CursorResetRequired {
-			client.replaceCursor(data.Cursor)
+			client.replaceCursor(data.LatestEventID)
 		} else {
 			client.advanceCursor(data.Cursor)
 		}
@@ -447,13 +543,74 @@ func (client *excelPricingRemoteEventsClient) handleExcelPricingRemoteFrame(
 			data.Schema != excelPricingRemoteStreamResetSchema || data.SchemaVersion != 1 ||
 			data.Reason != "cursor_gap" || !data.RevisionValidationRequired ||
 			data.RevisionPath != client.revisionPath ||
-			!validExcelPricingRemoteWindow(data.Cursor, data.OldestEventID, data.LatestEventID) {
+			!validExcelPricingRemoteWindow(data.Cursor, data.OldestEventID, data.LatestEventID) ||
+			data.Cursor != data.LatestEventID {
 			return false, errExcelPricingRemoteProtocol
 		}
-		if err := client.validateExcelPricingRemoteRevision(ctx, "cursor_reset", data.Cursor); err != nil {
+		if err := client.reconcileExcelPricingRemoteRevision(ctx, "cursor_reset", data.Cursor, false); err != nil {
 			return false, err
 		}
-		client.replaceCursor(data.Cursor)
+		client.replaceCursor(data.LatestEventID)
+		return false, nil
+	case "pricing.source.changed", "pricing.source.removed":
+		if frame.ID == 0 {
+			return false, errExcelPricingRemoteProtocol
+		}
+		if frame.ID <= client.currentCursor() {
+			return false, nil
+		}
+		var data excelPricingRemoteSourceEventData
+		if !decodeExactExcelPricingRemoteJSON(frame.Data, &data) ||
+			!validExcelPricingRemoteSourceEventShape(eventName, data, client.source, client.revisionPath) {
+			return false, errExcelPricingRemoteProtocol
+		}
+		previous, ok := excelPricingRemoteSourceEventPrevious(data.PreviousSourceRevision)
+		if !ok {
+			return false, errExcelPricingRemoteProtocol
+		}
+		dedupeKey := excelPricingRemoteSourceEventDedupeKey(eventName, data.IdempotencyKey)
+		fingerprint := excelPricingRemoteSourceEventFingerprint(eventName, data, previous)
+		seen, conflict := client.seenEvent(dedupeKey, fingerprint)
+		if conflict {
+			return false, errExcelPricingRemoteProtocol
+		}
+		if seen {
+			client.advanceCursor(frame.ID)
+			return false, nil
+		}
+		streamSource, streamPresent := client.currentStreamSource()
+		if !validExcelPricingRemoteSourceTransition(
+			eventName, data.Change, data.Source, previous, streamSource, streamPresent,
+		) {
+			return false, errExcelPricingRemoteProtocol
+		}
+		validation, err := client.probeExcelPricingRemoteRevision(
+			ctx, data.Source, false, "source_event", frame.ID,
+		)
+		if err != nil {
+			return false, err
+		}
+		lifecycle := excelPricingRemoteSourceLifecycle{
+			Mode:                   "ordered",
+			Name:                   eventName,
+			Change:                 data.Change,
+			Source:                 data.Source,
+			PreviousSourceRevision: previous,
+			IdempotencyKey:         data.IdempotencyKey,
+			EventID:                frame.ID,
+			ValidationOrigin:       "source_event",
+			ValidationOutcome:      validation.Outcome,
+			CurrentSourceRevision:  validation.CurrentSourceRevision,
+		}
+		if eventName != "pricing.source.removed" && validation.Outcome == excelPricingRemoteSourceCurrent {
+			lifecycle.Revision = validation.Revision
+		}
+		if err := client.deliverSourceLifecycle(lifecycle); err != nil {
+			return false, err
+		}
+		client.applySourceLifecycle(lifecycle)
+		client.rememberEvent(dedupeKey, fingerprint)
+		client.advanceCursor(frame.ID)
 		return false, nil
 	case "pricing.state.changed":
 		if frame.ID == 0 {
@@ -462,10 +619,14 @@ func (client *excelPricingRemoteEventsClient) handleExcelPricingRemoteFrame(
 		if frame.ID <= client.currentCursor() {
 			return false, nil
 		}
+		streamSource, streamPresent := client.currentStreamSource()
+		if !streamPresent {
+			return false, errExcelPricingRemoteRevision
+		}
 		var data excelPricingRemoteStateEventData
 		if json.Unmarshal(frame.Data, &data) != nil ||
 			data.Schema != excelPricingRemoteStateEventSchema || data.SchemaVersion != 1 ||
-			data.Projection != excelPricingRemoteProjection || data.Source != client.source ||
+			data.Projection != excelPricingRemoteProjection || data.Source != streamSource ||
 			!validExcelPricingRemoteRevisionParts(data.StateRevision, data.CatalogRevision,
 				data.PricingStateRevision, data.PricingPolicyRevision) ||
 			!isStrongExcelPricingRevisionETag(data.ETag, data.StateRevision) ||
@@ -485,13 +646,17 @@ func (client *excelPricingRemoteEventsClient) handleExcelPricingRemoteFrame(
 			EventID:               frame.ID,
 			ValidationOrigin:      "stream_event",
 		}
-		if !client.seenRevision(revision) {
+		seen, conflict := client.seenRevision(revision)
+		if conflict {
+			return false, errExcelPricingRemoteProtocol
+		}
+		if !seen {
 			if err := client.deliverRevision(revision); err != nil {
 				return false, err
 			}
 			client.rememberRevision(revision)
 		}
-		client.setValidatedRevision(revision.StateRevision, revision.ETag)
+		client.setValidatedRevision(revision)
 		client.advanceCursor(frame.ID)
 		return false, nil
 	case "pricing.snapshot.build.terminal":
@@ -506,7 +671,8 @@ func (client *excelPricingRemoteEventsClient) handleExcelPricingRemoteFrame(
 			return false, errExcelPricingRemoteProtocol
 		}
 		event.EventID = frame.ID
-		if event.Source != client.source || validateExcelPricingRemoteSnapshotTerminalEvent(event) != nil {
+		if !sameExcelPricingRemoteSourceScope(event.Source, client.source) ||
+			validateExcelPricingRemoteSnapshotTerminalEvent(event) != nil {
 			return false, errExcelPricingRemoteProtocol
 		}
 		if err := client.onTerminal(event); err != nil {
@@ -527,6 +693,10 @@ func normalizedExcelPricingRemoteEventName(event, name string) (string, bool) {
 		return event, true
 	case event == "pricing.stream.reset" && name == "":
 		return event, true
+	case event == "pricing.source.changed" && (name == "" || name == event):
+		return event, true
+	case event == "pricing.source.removed" && (name == "" || name == event):
+		return event, true
 	case event == "pricing.state.changed" && (name == "" || name == event):
 		return event, true
 	case event == "pricing.snapshot.build.terminal" && (name == "" || name == event):
@@ -540,6 +710,96 @@ func normalizedExcelPricingRemoteEventName(event, name string) (string, bool) {
 	}
 }
 
+func decodeExactExcelPricingRemoteJSON(data []byte, target interface{}) bool {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(target) != nil {
+		return false
+	}
+	return decoder.Decode(&struct{}{}) == io.EOF
+}
+
+func validExcelPricingRemoteSourceEventShape(
+	name string,
+	data excelPricingRemoteSourceEventData,
+	fixedScope canonical.Source,
+	revisionPath string,
+) bool {
+	if data.Schema != excelPricingRemoteSourceEventSchema || data.SchemaVersion != 1 ||
+		data.Projection != excelPricingRemoteProjection || !validExcelPricingRemoteSource(data.Source) ||
+		!sameExcelPricingRemoteSourceScope(data.Source, fixedScope) || !isSHA256Revision(data.IdempotencyKey) ||
+		!data.RevisionValidationRequired || data.RevisionPath != revisionPath ||
+		len(data.Audience.Services) != 1 || data.Audience.Services[0] != "patris_pricing" ||
+		len(data.PreviousSourceRevision) == 0 {
+		return false
+	}
+	switch data.Change {
+	case "added":
+		return name == "pricing.source.changed"
+	case "changed":
+		return name == "pricing.source.changed"
+	case "removed":
+		return name == "pricing.source.removed"
+	default:
+		return false
+	}
+}
+
+func excelPricingRemoteSourceEventPrevious(raw json.RawMessage) (string, bool) {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return "", true
+	}
+	var previous string
+	if json.Unmarshal(raw, &previous) != nil || !isSHA256Revision(previous) {
+		return "", false
+	}
+	return previous, true
+}
+
+func validExcelPricingRemoteSourceTransition(
+	name string,
+	change string,
+	source canonical.Source,
+	previous string,
+	current canonical.Source,
+	present bool,
+) bool {
+	switch change {
+	case "added":
+		return name == "pricing.source.changed" && !present && previous == ""
+	case "changed":
+		return name == "pricing.source.changed" && present && previous == current.Revision &&
+			sameExcelPricingRemoteSourceScope(source, current) && source.Revision != current.Revision
+	case "removed":
+		return name == "pricing.source.removed" && present && source == current && previous == current.Revision
+	default:
+		return false
+	}
+}
+
+func sameExcelPricingRemoteSourceScope(left, right canonical.Source) bool {
+	return left.ID == right.ID && left.Dataset == right.Dataset
+}
+
+func excelPricingRemoteSourceEventDedupeKey(_ string, idempotencyKey string) string {
+	return "source\x00" + idempotencyKey
+}
+
+func excelPricingRemoteSourceEventFingerprint(
+	name string,
+	data excelPricingRemoteSourceEventData,
+	previous string,
+) string {
+	return strings.Join([]string{
+		name,
+		data.Change,
+		data.Source.ID,
+		data.Source.Dataset,
+		data.Source.Revision,
+		previous,
+	}, "\x00")
+}
+
 func validExcelPricingRemoteWindow(cursor, oldest, latest uint64) bool {
 	if oldest > latest || cursor > latest {
 		return false
@@ -547,19 +807,144 @@ func validExcelPricingRemoteWindow(cursor, oldest, latest uint64) bool {
 	return oldest == 0 || cursor >= oldest-1
 }
 
-func (client *excelPricingRemoteEventsClient) validateExcelPricingRemoteRevision(
+func (client *excelPricingRemoteEventsClient) reconcileExcelPricingRemoteRevision(
 	ctx context.Context,
 	origin string,
 	eventID uint64,
+	replayPending bool,
 ) error {
-	requestURL, err := url.Parse(client.revisionURL)
+	streamSource, streamPresent := client.currentStreamSource()
+	validation, err := client.probeExcelPricingRemoteRevision(
+		ctx, streamSource, client.canConditionallyValidate(streamSource), origin, eventID,
+	)
 	if err != nil {
+		return err
+	}
+	if replayPending {
+		if validation.Outcome == excelPricingRemoteSourceCurrent && streamPresent {
+			if validation.Revision != nil {
+				if err := client.deliverRevision(*validation.Revision); err != nil {
+					return err
+				}
+				client.setValidatedRevision(*validation.Revision)
+			}
+			return nil
+		}
+		gap := excelPricingRemoteSourceLifecycle{
+			Mode:                  "validation_gap",
+			Source:                streamSource,
+			EventID:               eventID,
+			ValidationOrigin:      origin,
+			ValidationOutcome:     validation.Outcome,
+			CurrentSourceRevision: validation.CurrentSourceRevision,
+		}
+		if err := client.deliverSourceLifecycle(gap); err != nil {
+			return err
+		}
+		client.clearValidatedRevision()
+		return nil
+	}
+
+	switch validation.Outcome {
+	case excelPricingRemoteSourceCurrent:
+		if streamPresent {
+			if validation.Revision != nil {
+				if err := client.deliverRevision(*validation.Revision); err != nil {
+					return err
+				}
+				client.setValidatedRevision(*validation.Revision)
+			}
+			return nil
+		}
+		if validation.Revision == nil {
+			return errExcelPricingRemoteRevision
+		}
+		return client.reconcileExcelPricingRemoteSource(
+			origin, eventID, streamSource, *validation.Revision,
+		)
+	case excelPricingRemoteSourceSuperseded:
+		currentSource := canonical.Source{
+			ID:       streamSource.ID,
+			Dataset:  streamSource.Dataset,
+			Revision: validation.CurrentSourceRevision,
+		}
+		current, probeErr := client.probeExcelPricingRemoteRevision(
+			ctx, currentSource, false, origin, eventID,
+		)
+		if probeErr != nil || current.Outcome != excelPricingRemoteSourceCurrent || current.Revision == nil {
+			return errExcelPricingRemoteRevision
+		}
+		return client.reconcileExcelPricingRemoteSource(
+			origin, eventID, streamSource, *current.Revision,
+		)
+	case excelPricingRemoteSourceAbsent:
+		if !streamPresent {
+			client.clearValidatedRevision()
+			return nil
+		}
+		lifecycle := excelPricingRemoteSourceLifecycle{
+			Mode:                   "reconcile_absent",
+			Name:                   "pricing.source.removed",
+			Change:                 "removed",
+			Source:                 streamSource,
+			PreviousSourceRevision: streamSource.Revision,
+			EventID:                eventID,
+			ValidationOrigin:       origin,
+			ValidationOutcome:      validation.Outcome,
+		}
+		if err := client.deliverSourceLifecycle(lifecycle); err != nil {
+			return err
+		}
+		client.applySourceLifecycle(lifecycle)
+		return nil
+	default:
 		return errExcelPricingRemoteRevision
 	}
+}
+
+func (client *excelPricingRemoteEventsClient) reconcileExcelPricingRemoteSource(
+	origin string,
+	eventID uint64,
+	previous canonical.Source,
+	revision excelPricingRemoteRevision,
+) error {
+	lifecycle := excelPricingRemoteSourceLifecycle{
+		Mode:                   "reconcile_present",
+		Name:                   "pricing.source.changed",
+		Change:                 "reconciled",
+		Source:                 revision.Source,
+		PreviousSourceRevision: previous.Revision,
+		EventID:                eventID,
+		ValidationOrigin:       origin,
+		ValidationOutcome:      excelPricingRemoteSourceCurrent,
+		Revision:               &revision,
+	}
+	if err := client.deliverSourceLifecycle(lifecycle); err != nil {
+		return err
+	}
+	client.applySourceLifecycle(lifecycle)
+	return nil
+}
+
+func (client *excelPricingRemoteEventsClient) probeExcelPricingRemoteRevision(
+	ctx context.Context,
+	source canonical.Source,
+	conditional bool,
+	origin string,
+	eventID uint64,
+) (excelPricingRemoteRevisionValidation, error) {
+	invalid := excelPricingRemoteRevisionValidation{}
+	if !validExcelPricingRemoteSource(source) || !sameExcelPricingRemoteSourceScope(source, client.source) {
+		return invalid, errExcelPricingRemoteRevision
+	}
+	requestURL, err := url.Parse(client.revisionURL)
+	if err != nil {
+		return invalid, errExcelPricingRemoteRevision
+	}
 	query := requestURL.Query()
-	query.Set("source_id", client.source.ID)
-	query.Set("source_dataset", client.source.Dataset)
-	query.Set("source_revision", client.source.Revision)
+	query.Set("source_id", source.ID)
+	query.Set("source_dataset", source.Dataset)
+	query.Set("source_revision", source.Revision)
 	query.Set("locale", "fa")
 	query.Set("page_size", strconv.Itoa(excelPricingSnapshotPageSize))
 	query.Set("schema_version", "1")
@@ -567,7 +952,7 @@ func (client *excelPricingRemoteEventsClient) validateExcelPricingRemoteRevision
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
-		return errExcelPricingRemoteRevision
+		return invalid, errExcelPricingRemoteRevision
 	}
 	request.Header.Set("Accept", "application/json")
 	// Revision ETags bind the identity JSON bytes to state_revision. Selecting
@@ -575,42 +960,71 @@ func (client *excelPricingRemoteEventsClient) validateExcelPricingRemoteRevision
 	// validator with a gzip-representation ETag before the fail-closed check.
 	request.Header.Set("Accept-Encoding", excelPricingRemoteIdentityEncoding)
 	request.Header.Set(excelPricingRemoteSecretHeader, client.secret)
-	request.Header.Set(excelPricingRemoteSourceIDHeader, client.source.ID)
-	request.Header.Set(excelPricingRemoteDatasetHeader, client.source.Dataset)
-	if etag := client.currentETag(); etag != "" {
+	request.Header.Set(excelPricingRemoteSourceIDHeader, source.ID)
+	request.Header.Set(excelPricingRemoteDatasetHeader, source.Dataset)
+	if conditional {
+		streamSource, present := client.currentStreamSource()
+		stateRevision, etag := client.currentValidatedRevision()
+		if !present || streamSource != source || stateRevision == "" || etag == "" {
+			return invalid, errExcelPricingRemoteRevision
+		}
 		request.Header.Set("If-None-Match", etag)
 	}
 
 	response, err := client.httpClient.Do(request)
 	if err != nil {
-		return errExcelPricingRemoteRevision
+		return invalid, errExcelPricingRemoteRevision
 	}
 	defer response.Body.Close()
-	responseETag := strings.TrimSpace(response.Header.Get("ETag"))
-	if response.StatusCode == http.StatusNotModified {
-		if client.currentETag() == "" || responseETag != client.currentETag() {
-			return errExcelPricingRemoteRevision
-		}
-		return nil
+	if !excelPricingRemoteIdentityResponseEncoding(response.Header) {
+		return invalid, errExcelPricingRemoteRevision
 	}
-	if response.StatusCode != http.StatusOK || !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
-		return errExcelPricingRemoteRevision
+	responseETag, singleResponseETag := excelPricingRemoteSingleETag(response.Header)
+	if response.StatusCode == http.StatusNotModified {
+		stateRevision, currentETag := client.currentValidatedRevision()
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, 1))
+		if !singleResponseETag || !conditional || readErr != nil || len(body) != 0 || stateRevision == "" || currentETag == "" ||
+			responseETag != currentETag || !isStrongExcelPricingRevisionETag(responseETag, stateRevision) {
+			return invalid, errExcelPricingRemoteRevision
+		}
+		return excelPricingRemoteRevisionValidation{
+			Outcome:     excelPricingRemoteSourceCurrent,
+			NotModified: true,
+		}, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		if !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) ||
+			len(response.Header.Values("ETag")) != 0 {
+			return invalid, errExcelPricingRemoteRevision
+		}
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, excelPricingRemoteRevisionMaxBytes+1))
+		if readErr != nil || len(body) == 0 || len(body) > excelPricingRemoteRevisionMaxBytes {
+			return invalid, errExcelPricingRemoteRevision
+		}
+		validation, ok := excelPricingRemoteRevisionConflict(response.StatusCode, body, source)
+		if !ok {
+			return invalid, errExcelPricingRemoteRevision
+		}
+		return validation, nil
+	}
+	if !singleResponseETag || !excelPricingRemoteJSONContentType(response.Header.Get("Content-Type")) {
+		return invalid, errExcelPricingRemoteRevision
 	}
 	body, err := io.ReadAll(io.LimitReader(response.Body, excelPricingRemoteRevisionMaxBytes+1))
 	if err != nil || len(body) == 0 || len(body) > excelPricingRemoteRevisionMaxBytes {
-		return errExcelPricingRemoteRevision
+		return invalid, errExcelPricingRemoteRevision
 	}
 	var payload excelPricingRemoteRevisionResponse
-	if json.Unmarshal(body, &payload) != nil ||
+	if !decodeExactExcelPricingRemoteJSON(body, &payload) ||
 		payload.Schema != excelPricingRemoteRevisionSchema || payload.SchemaVersion != 1 ||
 		payload.Projection != excelPricingRemoteProjection ||
 		payload.ProjectionSchema != excelPricingRemoteProjectionSchema ||
-		payload.Source != client.source || payload.Locale != "fa" ||
+		payload.Source != source || payload.Locale != "fa" ||
 		payload.PageSize != excelPricingSnapshotPageSize ||
 		!validExcelPricingRemoteRevisionParts(payload.StateRevision, payload.CatalogRevision,
 			payload.PricingStateRevision, payload.PricingPolicyRevision) ||
 		!isStrongExcelPricingRevisionETag(responseETag, payload.StateRevision) {
-		return errExcelPricingRemoteRevision
+		return invalid, errExcelPricingRemoteRevision
 	}
 	revision := excelPricingRemoteRevision{
 		Source:                payload.Source,
@@ -622,16 +1036,73 @@ func (client *excelPricingRemoteEventsClient) validateExcelPricingRemoteRevision
 		EventID:               eventID,
 		ValidationOrigin:      origin,
 	}
-	if err := client.deliverRevision(revision); err != nil {
-		return err
+	return excelPricingRemoteRevisionValidation{
+		Outcome:  excelPricingRemoteSourceCurrent,
+		Revision: &revision,
+	}, nil
+}
+
+func excelPricingRemoteRevisionConflict(
+	status int,
+	body []byte,
+	requested canonical.Source,
+) (excelPricingRemoteRevisionValidation, bool) {
+	invalid := excelPricingRemoteRevisionValidation{}
+	if status != http.StatusConflict {
+		return invalid, false
 	}
-	client.setValidatedRevision(revision.StateRevision, revision.ETag)
-	return nil
+	var payload excelPricingRemoteErrorResponse
+	if !decodeExactExcelPricingRemoteJSON(body, &payload) || payload.Success == nil || *payload.Success ||
+		payload.Retryable == nil || *payload.Retryable ||
+		strings.TrimSpace(payload.Message) == "" {
+		return invalid, false
+	}
+	switch payload.Code {
+	case "digitalogic_excel_sync_source_scope_conflict":
+		if payload.Details.CurrentSource == nil ||
+			payload.Details.CurrentSource.ID == nil || *payload.Details.CurrentSource.ID != "" ||
+			payload.Details.CurrentSource.Dataset == nil || *payload.Details.CurrentSource.Dataset != "" ||
+			payload.Details.CurrentSource.Revision == nil || *payload.Details.CurrentSource.Revision != "" ||
+			payload.Details.SubmittedSourceRevision != nil ||
+			payload.Details.CurrentSourceRevision != nil || payload.Details.Retryable != nil {
+			return invalid, false
+		}
+		return excelPricingRemoteRevisionValidation{Outcome: excelPricingRemoteSourceAbsent}, true
+	case "digitalogic_pricing_snapshot_source_revision_conflict":
+		if payload.Details.CurrentSource != nil || payload.Details.SubmittedSourceRevision == nil ||
+			payload.Details.CurrentSourceRevision == nil || payload.Details.Retryable == nil ||
+			*payload.Details.Retryable || *payload.Details.SubmittedSourceRevision != requested.Revision ||
+			!isSHA256Revision(*payload.Details.CurrentSourceRevision) ||
+			*payload.Details.CurrentSourceRevision == requested.Revision {
+			return invalid, false
+		}
+		return excelPricingRemoteRevisionValidation{
+			Outcome:               excelPricingRemoteSourceSuperseded,
+			CurrentSourceRevision: *payload.Details.CurrentSourceRevision,
+		}, true
+	default:
+		return invalid, false
+	}
 }
 
 func excelPricingRemoteJSONContentType(value string) bool {
 	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(value))
 	return err == nil && mediaType == "application/json"
+}
+
+func excelPricingRemoteSingleETag(header http.Header) (string, bool) {
+	values := header.Values("ETag")
+	if len(values) != 1 {
+		return "", false
+	}
+	etag := strings.TrimSpace(values[0])
+	return etag, etag != ""
+}
+
+func excelPricingRemoteIdentityResponseEncoding(header http.Header) bool {
+	values := header.Values("Content-Encoding")
+	return len(values) == 0 ||
+		(len(values) == 1 && strings.EqualFold(strings.TrimSpace(values[0]), excelPricingRemoteIdentityEncoding))
 }
 
 func validExcelPricingRemoteRevisionParts(revisions ...string) bool {
@@ -659,6 +1130,18 @@ func (client *excelPricingRemoteEventsClient) deliverRevision(revision excelPric
 		return errExcelPricingRemoteConfiguration
 	}
 	if err := client.onRevision(revision); err != nil {
+		return errExcelPricingRemoteRevision
+	}
+	return nil
+}
+
+func (client *excelPricingRemoteEventsClient) deliverSourceLifecycle(
+	lifecycle excelPricingRemoteSourceLifecycle,
+) error {
+	if client.onLifecycle == nil {
+		return errExcelPricingRemoteConfiguration
+	}
+	if err := client.onLifecycle(lifecycle); err != nil {
 		return errExcelPricingRemoteRevision
 	}
 	return nil
@@ -700,29 +1183,115 @@ func (client *excelPricingRemoteEventsClient) currentETag() string {
 	return client.etag
 }
 
-func (client *excelPricingRemoteEventsClient) setValidatedRevision(stateRevision, etag string) {
+func (client *excelPricingRemoteEventsClient) currentStreamSource() (canonical.Source, bool) {
 	client.stateMu.Lock()
-	client.stateRevision = stateRevision
-	client.etag = etag
+	defer client.stateMu.Unlock()
+	return client.streamSource, client.streamPresent
+}
+
+func (client *excelPricingRemoteEventsClient) currentValidatedRevision() (string, string) {
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	return client.stateRevision, client.etag
+}
+
+func (client *excelPricingRemoteEventsClient) canConditionallyValidate(source canonical.Source) bool {
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	return client.streamPresent && client.streamSource == source &&
+		client.stateRevision != "" && client.etag != ""
+}
+
+func (client *excelPricingRemoteEventsClient) setValidatedRevision(revision excelPricingRemoteRevision) {
+	client.stateMu.Lock()
+	client.streamSource = revision.Source
+	client.streamPresent = true
+	client.stateRevision = revision.StateRevision
+	client.etag = revision.ETag
 	client.stateMu.Unlock()
 }
 
-func (client *excelPricingRemoteEventsClient) seenRevision(revision excelPricingRemoteRevision) bool {
-	key := revision.IdempotencyKey + "\x00" + revision.StateRevision
+func (client *excelPricingRemoteEventsClient) clearValidatedRevision() {
+	client.stateMu.Lock()
+	client.stateRevision = ""
+	client.etag = ""
+	client.stateMu.Unlock()
+}
+
+func (client *excelPricingRemoteEventsClient) applySourceLifecycle(
+	lifecycle excelPricingRemoteSourceLifecycle,
+) {
 	client.stateMu.Lock()
 	defer client.stateMu.Unlock()
-	_, seen := client.seen[key]
-	return seen
+	switch lifecycle.Mode {
+	case "ordered":
+		client.streamSource = lifecycle.Source
+		client.streamPresent = lifecycle.Change != "removed"
+	case "reconcile_present":
+		client.streamSource = lifecycle.Source
+		client.streamPresent = true
+	case "reconcile_absent":
+		client.streamSource = lifecycle.Source
+		client.streamPresent = false
+	default:
+		return
+	}
+	if lifecycle.Revision != nil && client.streamPresent {
+		client.stateRevision = lifecycle.Revision.StateRevision
+		client.etag = lifecycle.Revision.ETag
+		return
+	}
+	client.stateRevision = ""
+	client.etag = ""
+}
+
+func (client *excelPricingRemoteEventsClient) seenRevision(
+	revision excelPricingRemoteRevision,
+) (bool, bool) {
+	return client.seenEvent(
+		"revision\x00"+revision.IdempotencyKey,
+		excelPricingRemoteRevisionFingerprint(revision),
+	)
+}
+
+func excelPricingRemoteRevisionFingerprint(revision excelPricingRemoteRevision) string {
+	return strings.Join([]string{
+		revision.Source.ID,
+		revision.Source.Dataset,
+		revision.Source.Revision,
+		revision.StateRevision,
+		revision.CatalogRevision,
+		revision.PricingStateRevision,
+		revision.PricingPolicyRevision,
+		revision.ETag,
+		revision.Cause,
+	}, "\x00")
+}
+
+func (client *excelPricingRemoteEventsClient) seenEvent(key, fingerprint string) (bool, bool) {
+	client.stateMu.Lock()
+	defer client.stateMu.Unlock()
+	stored, seen := client.seen[key]
+	if !seen {
+		return false, false
+	}
+	return stored == fingerprint, stored != fingerprint
 }
 
 func (client *excelPricingRemoteEventsClient) rememberRevision(revision excelPricingRemoteRevision) {
-	key := revision.IdempotencyKey + "\x00" + revision.StateRevision
+	client.rememberEvent(
+		"revision\x00"+revision.IdempotencyKey,
+		excelPricingRemoteRevisionFingerprint(revision),
+	)
+}
+
+func (client *excelPricingRemoteEventsClient) rememberEvent(key, fingerprint string) {
 	client.stateMu.Lock()
 	defer client.stateMu.Unlock()
 	if _, exists := client.seen[key]; exists {
 		return
 	}
-	client.seen[key] = struct{}{}
+	client.seen[key] = fingerprint
 	client.seenOrder = append(client.seenOrder, key)
 	if len(client.seenOrder) > excelPricingSnapshotEventHistory {
 		delete(client.seen, client.seenOrder[0])
@@ -744,12 +1313,14 @@ func runExcelPricingRemoteEvents(
 	initialCursor uint64,
 	onCursor func(uint64),
 	onRevision func(excelPricingRemoteRevision) error,
+	onSourceLifecycle func(excelPricingRemoteSourceLifecycle) error,
 	onSnapshotTerminal func(excelPricingRemoteSnapshotTerminalEvent) error,
 ) error {
 	client, err := newExcelPricingRemoteEventsClient(cfg, source, excelPricingRemoteEventsOptions{
 		InitialCursor:      initialCursor,
 		OnCursor:           onCursor,
 		OnRevision:         onRevision,
+		OnSourceLifecycle:  onSourceLifecycle,
 		OnSnapshotTerminal: onSnapshotTerminal,
 	})
 	if err != nil {

--- a/pkg/server/excel_pricing_events_client_test.go
+++ b/pkg/server/excel_pricing_events_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,12 +26,20 @@ func excelPricingRemoteTestRevision(character string) string {
 	return "sha256:" + strings.Repeat(character, 64)
 }
 
+func excelPricingRemoteTestIndexedRevision(index int) string {
+	return fmt.Sprintf("sha256:%064x", index)
+}
+
 func excelPricingRemoteTestSource() canonical.Source {
 	return canonical.Source{
 		ID:       "patris-office",
 		Dataset:  "kala.db",
 		Revision: excelPricingRemoteTestRevision("a"),
 	}
+}
+
+func excelPricingRemoteTestLifecycle(excelPricingRemoteSourceLifecycle) error {
+	return nil
 }
 
 func excelPricingRemoteTestConfig(t *testing.T, baseURL string) updateout.Config {
@@ -62,6 +71,57 @@ func excelPricingRemoteTestRevisionPayload(source canonical.Source, stateRevisio
 	}
 }
 
+func excelPricingRemoteWriteCurrentRevision(
+	w http.ResponseWriter,
+	source canonical.Source,
+	stateRevision string,
+) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("ETag", `"`+stateRevision+`"`)
+	_ = json.NewEncoder(w).Encode(excelPricingRemoteTestRevisionPayload(source, stateRevision))
+}
+
+func excelPricingRemoteWriteSupersededRevision(
+	w http.ResponseWriter,
+	requested canonical.Source,
+	currentRevision string,
+) {
+	success := false
+	retryable := false
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	_ = json.NewEncoder(w).Encode(excelPricingRemoteErrorResponse{
+		Success:   &success,
+		Code:      "digitalogic_pricing_snapshot_source_revision_conflict",
+		Message:   "requested source revision is no longer current",
+		Retryable: &retryable,
+		Details: excelPricingRemoteErrorDetails{
+			SubmittedSourceRevision: &requested.Revision,
+			CurrentSourceRevision:   &currentRevision,
+			Retryable:               &retryable,
+		},
+	})
+}
+
+func excelPricingRemoteWriteAbsentRevision(w http.ResponseWriter) {
+	empty := ""
+	success := false
+	retryable := false
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	_ = json.NewEncoder(w).Encode(excelPricingRemoteErrorResponse{
+		Success:   &success,
+		Code:      "digitalogic_excel_sync_source_scope_conflict",
+		Message:   "source is no longer materialized",
+		Retryable: &retryable,
+		Details: excelPricingRemoteErrorDetails{
+			CurrentSource: &excelPricingRemoteErrorSource{
+				ID: &empty, Dataset: &empty, Revision: &empty,
+			},
+		},
+	})
+}
+
 func excelPricingRemoteTestStateFrame(source canonical.Source, eventID uint64, stateRevision string) map[string]interface{} {
 	return map[string]interface{}{
 		// This deliberately mirrors the WordPress PHP bridge fixture: the
@@ -87,6 +147,86 @@ func excelPricingRemoteTestStateFrame(source canonical.Source, eventID uint64, s
 			"audience": map[string]interface{}{
 				"services": []string{"patris_pricing"},
 			},
+		},
+	}
+}
+
+func excelPricingRemoteTestSourceFrame(
+	source canonical.Source,
+	eventID uint64,
+	name string,
+	change string,
+	previous interface{},
+	idempotencyKey string,
+) map[string]interface{} {
+	return map[string]interface{}{
+		"event":   name,
+		"name":    name,
+		"success": true,
+		"time":    "2026-08-26T00:00:00Z",
+		"id":      eventID,
+		"data": map[string]interface{}{
+			"schema":                       excelPricingRemoteSourceEventSchema,
+			"schema_version":               1,
+			"projection":                   excelPricingRemoteProjection,
+			"change":                       change,
+			"source":                       source,
+			"previous_source_revision":     previous,
+			"idempotency_key":              idempotencyKey,
+			"revision_validation_required": true,
+			"revision_path":                "/wp-json/digitalogic/pricing/sync/revision",
+			"audience": map[string]interface{}{
+				"services": []string{"patris_pricing"},
+			},
+		},
+	}
+}
+
+func excelPricingRemoteTestTerminalFrame(
+	source canonical.Source,
+	eventID uint64,
+	stateRevision string,
+) map[string]interface{} {
+	return map[string]interface{}{
+		"event":   "pricing.snapshot.build.terminal",
+		"name":    "pricing.snapshot.build.terminal",
+		"success": true,
+		"time":    "2026-08-26T00:00:01Z",
+		"id":      eventID,
+		"data": map[string]interface{}{
+			"schema":                 excelPricingRemoteSnapshotEventSchema,
+			"schema_version":         1,
+			"build_id":               "build_source_event_continuity",
+			"request_id":             "request_source_event_continuity",
+			"status":                 "failed",
+			"source":                 source,
+			"state_revision":         stateRevision,
+			"pricing_state_revision": excelPricingRemoteTestRevision("d"),
+			"catalog_revision":       excelPricingRemoteTestRevision("c"),
+			"code":                   "source_event_fixture_failure",
+			"retryable":              false,
+			"idempotency_key":        excelPricingRemoteTestRevision("1"),
+		},
+	}
+}
+
+func excelPricingRemoteTestConnectedFrame(
+	cursor uint64,
+	oldest uint64,
+	latest uint64,
+	reset bool,
+) map[string]interface{} {
+	return map[string]interface{}{
+		"event":   "connected",
+		"success": true,
+		"data": map[string]interface{}{
+			"principal":                    "patris_pricing",
+			"cursor":                       cursor,
+			"oldest_event_id":              oldest,
+			"latest_event_id":              latest,
+			"cursor_reset_required":        reset,
+			"revision_validation_required": true,
+			"revision_path":                "/wp-json/digitalogic/pricing/sync/revision",
 		},
 	}
 }
@@ -195,6 +335,7 @@ func TestExcelPricingRemoteEventsConnectValidateAndConsumePHPFrame(t *testing.T)
 		excelPricingRemoteEventsOptions{
 			MinReconnectBackoff: 5 * time.Millisecond,
 			MaxReconnectBackoff: 10 * time.Millisecond,
+			OnSourceLifecycle:   excelPricingRemoteTestLifecycle,
 			OnRevision: func(revision excelPricingRemoteRevision) error {
 				revisions <- revision
 				return nil
@@ -312,6 +453,7 @@ func TestExcelPricingRemoteEventsReconnectUsesCursorAndConditionalRevisionGETWit
 		excelPricingRemoteEventsOptions{
 			MinReconnectBackoff: 2 * time.Millisecond,
 			MaxReconnectBackoff: 5 * time.Millisecond,
+			OnSourceLifecycle:   excelPricingRemoteTestLifecycle,
 			OnRevision: func(excelPricingRemoteRevision) error {
 				accepted.Add(1)
 				return nil
@@ -407,6 +549,7 @@ func TestExcelPricingRemoteEventsStreamResetTriggersOneConditionalValidation(t *
 			MinReconnectBackoff: 2 * time.Millisecond,
 			MaxReconnectBackoff: 5 * time.Millisecond,
 			OnRevision:          func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle:   excelPricingRemoteTestLifecycle,
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -444,8 +587,9 @@ func TestExcelPricingRemoteConnectedCursorResetMayClampAHighPersistedCursor(t *t
 	defer server.Close()
 	client, err := newExcelPricingRemoteEventsClient(excelPricingRemoteTestConfig(t, server.URL), source,
 		excelPricingRemoteEventsOptions{
-			InitialCursor: 99,
-			OnRevision:    func(excelPricingRemoteRevision) error { return nil },
+			InitialCursor:     99,
+			OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -475,12 +619,78 @@ func TestExcelPricingRemoteConnectedCursorResetMayClampAHighPersistedCursor(t *t
 	}
 }
 
+func TestExcelPricingRemoteConnectedLowCursorResetSkipsRetainedStaleFrames(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	stateC := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("cursor-reset reconciliation used If-None-Match")
+		}
+		requested := sourceA
+		requested.Revision = r.URL.Query().Get("source_revision")
+		if requested == sourceC {
+			excelPricingRemoteWriteCurrentRevision(w, sourceC, stateC)
+			return
+		}
+		excelPricingRemoteWriteSupersededRevision(w, requested, sourceC.Revision)
+	}))
+	defer server.Close()
+	var lifecycles []excelPricingRemoteSourceLifecycle
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			InitialCursor: 2,
+			OnRevision:    func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(lifecycle excelPricingRemoteSourceLifecycle) error {
+				lifecycles = append(lifecycles, lifecycle)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := func(frame map[string]interface{}, connected bool) (bool, error) {
+		body, marshalErr := json.Marshal(frame)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		return client.handleExcelPricingRemoteFrame(t.Context(), body, connected)
+	}
+	connected, err := handle(excelPricingRemoteTestConnectedFrame(5, 6, 10, true), false)
+	current, present := client.currentStreamSource()
+	if err != nil || !connected || current != sourceC || !present || client.currentCursor() != 10 ||
+		requests.Load() != 2 || len(lifecycles) != 1 || lifecycles[0].Mode != "reconcile_present" {
+		t.Fatalf("connected=%v err=%v source=%+v present=%v cursor=%d requests=%d lifecycles=%+v",
+			connected, err, current, present, client.currentCursor(), requests.Load(), lifecycles)
+	}
+	if _, err := handle(excelPricingRemoteTestSourceFrame(
+		sourceB, 6, "pricing.source.changed", "changed", sourceA.Revision,
+		excelPricingRemoteTestRevision("1"),
+	), true); err != nil {
+		t.Fatalf("retained stale lifecycle frame: %v", err)
+	}
+	current, present = client.currentStreamSource()
+	if current != sourceC || !present || client.currentCursor() != 10 ||
+		requests.Load() != 2 || len(lifecycles) != 1 {
+		t.Fatalf("source=%+v present=%v cursor=%d requests=%d lifecycles=%+v",
+			current, present, client.currentCursor(), requests.Load(), lifecycles)
+	}
+}
+
 func TestExcelPricingRemoteEventCursorAdvancesOnlyAfterAtomicAcceptance(t *testing.T) {
 	source := excelPricingRemoteTestSource()
 	state := excelPricingRemoteTestRevision("5")
 	cfg := excelPricingRemoteTestConfig(t, "http://127.0.0.1:18080")
 	client, err := newExcelPricingRemoteEventsClient(cfg, source, excelPricingRemoteEventsOptions{
-		InitialCursor: 5,
+		InitialCursor:     5,
+		OnSourceLifecycle: excelPricingRemoteTestLifecycle,
 		OnRevision: func(excelPricingRemoteRevision) error {
 			return errors.New("local generation was not invalidated")
 		},
@@ -507,11 +717,690 @@ func TestExcelPricingRemoteEventCursorAdvancesOnlyAfterAtomicAcceptance(t *testi
 	}
 }
 
+func TestExcelPricingRemoteSourceChangeStateAndTerminalPreserveOrder(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	stateB := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	var conditional atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		conditional.Store(conditional.Load() || r.Header.Get("If-None-Match") != "")
+		excelPricingRemoteWriteCurrentRevision(w, sourceB, stateB)
+	}))
+	defer server.Close()
+
+	var lifecycleCalls atomic.Int32
+	var revisionCalls atomic.Int32
+	var terminalCalls atomic.Int32
+	var client *excelPricingRemoteEventsClient
+	var err error
+	client, err = newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(revision excelPricingRemoteRevision) error {
+				if revision.Source != sourceB {
+					return errors.New("state crossed before source transition")
+				}
+				revisionCalls.Add(1)
+				return nil
+			},
+			OnSourceLifecycle: func(lifecycle excelPricingRemoteSourceLifecycle) error {
+				current, present := client.currentStreamSource()
+				if current != sourceA || !present || lifecycle.Source != sourceB || lifecycle.Revision == nil {
+					return errors.New("source lifecycle was not delivered before mutation")
+				}
+				lifecycleCalls.Add(1)
+				return nil
+			},
+			OnSnapshotTerminal: func(event excelPricingRemoteSnapshotTerminalEvent) error {
+				if event.Source != sourceB {
+					return errors.New("wrong terminal source")
+				}
+				terminalCalls.Add(1)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := func(frame map[string]interface{}) error {
+		body, marshalErr := json.Marshal(frame)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		_, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true)
+		return frameErr
+	}
+	if err := handle(excelPricingRemoteTestSourceFrame(
+		sourceB, 1, "pricing.source.changed", "changed", sourceA.Revision,
+		excelPricingRemoteTestRevision("6"),
+	)); err != nil {
+		t.Fatalf("source A->B: %v", err)
+	}
+	if err := handle(excelPricingRemoteTestStateFrame(sourceB, 2, stateB)); err != nil {
+		t.Fatalf("state B: %v", err)
+	}
+	if err := handle(excelPricingRemoteTestTerminalFrame(sourceB, 3, stateB)); err != nil {
+		t.Fatalf("terminal B: %v", err)
+	}
+	current, present := client.currentStreamSource()
+	if current != sourceB || !present || client.currentCursor() != 3 || requests.Load() != 1 ||
+		conditional.Load() || lifecycleCalls.Load() != 1 || revisionCalls.Load() != 1 ||
+		terminalCalls.Load() != 1 {
+		t.Fatalf("source=%+v present=%v cursor=%d requests=%d conditional=%v lifecycle=%d revision=%d terminal=%d",
+			current, present, client.currentCursor(), requests.Load(), conditional.Load(),
+			lifecycleCalls.Load(), revisionCalls.Load(), terminalCalls.Load())
+	}
+}
+
+func TestExcelPricingRemoteSourceCallbackFailureReplaysWithoutCursorOrStateAdvance(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	stateB := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("lifecycle validation unexpectedly became conditional")
+		}
+		excelPricingRemoteWriteCurrentRevision(w, sourceB, stateB)
+	}))
+	defer server.Close()
+	var callbacks atomic.Int32
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(excelPricingRemoteSourceLifecycle) error {
+				if callbacks.Add(1) == 1 {
+					return errors.New("injected lifecycle failure")
+				}
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(excelPricingRemoteTestSourceFrame(
+		sourceB, 1, "pricing.source.changed", "changed", sourceA.Revision,
+		excelPricingRemoteTestRevision("6"),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.handleExcelPricingRemoteFrame(t.Context(), body, true); !errors.Is(err, errExcelPricingRemoteRevision) {
+		t.Fatalf("first callback error=%v", err)
+	}
+	current, present := client.currentStreamSource()
+	if current != sourceA || !present || client.currentCursor() != 0 {
+		t.Fatalf("failed callback mutated source=%+v present=%v cursor=%d", current, present, client.currentCursor())
+	}
+	if _, err := client.handleExcelPricingRemoteFrame(t.Context(), body, true); err != nil {
+		t.Fatalf("replayed callback: %v", err)
+	}
+	current, present = client.currentStreamSource()
+	if current != sourceB || !present || client.currentCursor() != 1 ||
+		callbacks.Load() != 2 || requests.Load() != 2 {
+		t.Fatalf("replay source=%+v present=%v cursor=%d callbacks=%d requests=%d",
+			current, present, client.currentCursor(), callbacks.Load(), requests.Load())
+	}
+}
+
+func TestExcelPricingRemoteSupersededLifecycleAdvancesOnlyThroughQueuedTransitions(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	stateC := excelPricingRemoteTestRevision("5")
+	var requests []string
+	var requestMu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested := canonical.Source{
+			ID:       r.URL.Query().Get("source_id"),
+			Dataset:  r.URL.Query().Get("source_dataset"),
+			Revision: r.URL.Query().Get("source_revision"),
+		}
+		requestMu.Lock()
+		requests = append(requests, requested.Revision+"|"+r.Header.Get("If-None-Match"))
+		requestMu.Unlock()
+		if requested == sourceC {
+			excelPricingRemoteWriteCurrentRevision(w, sourceC, stateC)
+			return
+		}
+		excelPricingRemoteWriteSupersededRevision(w, requested, sourceC.Revision)
+	}))
+	defer server.Close()
+	var lifecycles []excelPricingRemoteSourceLifecycle
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(lifecycle excelPricingRemoteSourceLifecycle) error {
+				lifecycles = append(lifecycles, lifecycle)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := func(source canonical.Source, id uint64, previous, key string) {
+		t.Helper()
+		body, marshalErr := json.Marshal(excelPricingRemoteTestSourceFrame(
+			source, id, "pricing.source.changed", "changed", previous, key,
+		))
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); frameErr != nil {
+			t.Fatalf("source event %d: %v", id, frameErr)
+		}
+	}
+	handle(sourceB, 1, sourceA.Revision, excelPricingRemoteTestRevision("6"))
+	current, present := client.currentStreamSource()
+	if current != sourceB || !present || lifecycles[0].ValidationOutcome != excelPricingRemoteSourceSuperseded ||
+		lifecycles[0].CurrentSourceRevision != sourceC.Revision || lifecycles[0].Revision != nil {
+		t.Fatalf("superseded B lifecycle=%+v source=%+v present=%v", lifecycles[0], current, present)
+	}
+	handle(sourceC, 2, sourceB.Revision, excelPricingRemoteTestRevision("7"))
+	current, present = client.currentStreamSource()
+	if current != sourceC || !present || client.currentCursor() != 2 || len(lifecycles) != 2 ||
+		lifecycles[1].Revision == nil {
+		t.Fatalf("final lifecycle source=%+v present=%v cursor=%d lifecycles=%+v",
+			current, present, client.currentCursor(), lifecycles)
+	}
+	requestMu.Lock()
+	defer requestMu.Unlock()
+	if len(requests) != 2 || requests[0] != sourceB.Revision+"|" || requests[1] != sourceC.Revision+"|" {
+		t.Fatalf("lifecycle requests=%v", requests)
+	}
+}
+
+func TestExcelPricingRemoteProcessesMoreThanProducerHistoryWithoutJumpingToFinalSource(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	finalSource := source
+	finalSource.Revision = excelPricingRemoteTestIndexedRevision(205)
+	state := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("ordered lifecycle request used If-None-Match")
+		}
+		requested := source
+		requested.Revision = r.URL.Query().Get("source_revision")
+		if requested == finalSource {
+			excelPricingRemoteWriteCurrentRevision(w, finalSource, state)
+			return
+		}
+		excelPricingRemoteWriteSupersededRevision(w, requested, finalSource.Revision)
+	}))
+	defer server.Close()
+	var callbacks atomic.Int32
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), source,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(excelPricingRemoteSourceLifecycle) error {
+				callbacks.Add(1)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := source
+	for index := 1; index <= 205; index++ {
+		next := source
+		next.Revision = excelPricingRemoteTestIndexedRevision(index)
+		body, marshalErr := json.Marshal(excelPricingRemoteTestSourceFrame(
+			next, uint64(index), "pricing.source.changed", "changed", previous.Revision,
+			excelPricingRemoteTestIndexedRevision(1000+index),
+		))
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); frameErr != nil {
+			t.Fatalf("transition %d: %v", index, frameErr)
+		}
+		current, present := client.currentStreamSource()
+		if current != next || !present {
+			t.Fatalf("transition %d jumped to source=%+v present=%v", index, current, present)
+		}
+		previous = next
+	}
+	if client.currentCursor() != 205 || callbacks.Load() != 205 || requests.Load() != 205 {
+		t.Fatalf("cursor=%d callbacks=%d requests=%d",
+			client.currentCursor(), callbacks.Load(), requests.Load())
+	}
+}
+
+func TestExcelPricingRemoteSameRevisionRemoveAddRemoveAndOldTerminal(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		excelPricingRemoteWriteAbsentRevision(w)
+	}))
+	defer server.Close()
+	var lifecycles atomic.Int32
+	var terminals atomic.Int32
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), source,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(excelPricingRemoteSourceLifecycle) error {
+				lifecycles.Add(1)
+				return nil
+			},
+			OnSnapshotTerminal: func(excelPricingRemoteSnapshotTerminalEvent) error {
+				terminals.Add(1)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := []map[string]interface{}{
+		excelPricingRemoteTestSourceFrame(source, 1, "pricing.source.removed", "removed", source.Revision, excelPricingRemoteTestRevision("1")),
+		excelPricingRemoteTestSourceFrame(source, 2, "pricing.source.changed", "added", nil, excelPricingRemoteTestRevision("2")),
+		excelPricingRemoteTestSourceFrame(source, 3, "pricing.source.removed", "removed", source.Revision, excelPricingRemoteTestRevision("3")),
+		excelPricingRemoteTestTerminalFrame(source, 4, excelPricingRemoteTestRevision("5")),
+	}
+	for index, frame := range frames {
+		body, marshalErr := json.Marshal(frame)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); frameErr != nil {
+			t.Fatalf("frame %d: %v", index+1, frameErr)
+		}
+	}
+	current, present := client.currentStreamSource()
+	if current != source || present || client.currentCursor() != 4 ||
+		lifecycles.Load() != 3 || terminals.Load() != 1 {
+		t.Fatalf("source=%+v present=%v cursor=%d lifecycles=%d terminals=%d",
+			current, present, client.currentCursor(), lifecycles.Load(), terminals.Load())
+	}
+}
+
+func TestExcelPricingRemoteSourceIdempotencyRejectsConflictingPayload(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceB := sourceA
+	sourceB.Revision = excelPricingRemoteTestRevision("b")
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	stateB := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		excelPricingRemoteWriteCurrentRevision(w, sourceB, stateB)
+	}))
+	defer server.Close()
+	var callbacks atomic.Int32
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(excelPricingRemoteSourceLifecycle) error {
+				callbacks.Add(1)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := excelPricingRemoteTestRevision("6")
+	first := excelPricingRemoteTestSourceFrame(
+		sourceB, 1, "pricing.source.changed", "changed", sourceA.Revision, key,
+	)
+	for _, frame := range []map[string]interface{}{first, excelPricingRemoteTestSourceFrame(
+		sourceB, 2, "pricing.source.changed", "changed", sourceA.Revision, key,
+	)} {
+		body, marshalErr := json.Marshal(frame)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); frameErr != nil {
+			t.Fatalf("exact lifecycle/replay: %v", frameErr)
+		}
+	}
+	conflict, err := json.Marshal(excelPricingRemoteTestSourceFrame(
+		sourceC, 3, "pricing.source.changed", "changed", sourceB.Revision, key,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.handleExcelPricingRemoteFrame(t.Context(), conflict, true); !errors.Is(err, errExcelPricingRemoteProtocol) {
+		t.Fatalf("idempotency conflict error=%v", err)
+	}
+	if client.currentCursor() != 2 || callbacks.Load() != 1 || requests.Load() != 1 {
+		t.Fatalf("cursor=%d callbacks=%d requests=%d",
+			client.currentCursor(), callbacks.Load(), requests.Load())
+	}
+}
+
+func TestExcelPricingRemoteConnectedReplayGapPreservesOrderedSource(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested := sourceA
+		requested.Revision = r.URL.Query().Get("source_revision")
+		excelPricingRemoteWriteSupersededRevision(w, requested, sourceC.Revision)
+	}))
+	defer server.Close()
+	var lifecycle excelPricingRemoteSourceLifecycle
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			InitialCursor: 5,
+			OnRevision:    func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(candidate excelPricingRemoteSourceLifecycle) error {
+				lifecycle = candidate
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"event": "connected", "success": true,
+		"data": map[string]interface{}{
+			"principal": "patris_pricing", "cursor": 5, "oldest_event_id": 1, "latest_event_id": 7,
+			"cursor_reset_required": false, "revision_validation_required": true,
+			"revision_path": "/wp-json/digitalogic/pricing/sync/revision",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	connected, err := client.handleExcelPricingRemoteFrame(t.Context(), body, false)
+	current, present := client.currentStreamSource()
+	if err != nil || !connected || current != sourceA || !present ||
+		lifecycle.Mode != "validation_gap" || lifecycle.CurrentSourceRevision != sourceC.Revision {
+		t.Fatalf("connected=%v err=%v source=%+v present=%v lifecycle=%+v",
+			connected, err, current, present, lifecycle)
+	}
+}
+
+func TestExcelPricingRemoteConnectedWithoutReplayReconcilesCurrentSource(t *testing.T) {
+	sourceA := excelPricingRemoteTestSource()
+	sourceC := sourceA
+	sourceC.Revision = excelPricingRemoteTestRevision("c")
+	stateC := excelPricingRemoteTestRevision("5")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		requested := sourceA
+		requested.Revision = r.URL.Query().Get("source_revision")
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("reconciliation request used If-None-Match")
+		}
+		if requested == sourceC {
+			excelPricingRemoteWriteCurrentRevision(w, sourceC, stateC)
+			return
+		}
+		excelPricingRemoteWriteSupersededRevision(w, requested, sourceC.Revision)
+	}))
+	defer server.Close()
+	var lifecycle excelPricingRemoteSourceLifecycle
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), sourceA,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(candidate excelPricingRemoteSourceLifecycle) error {
+				lifecycle = candidate
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"event": "connected", "success": true,
+		"data": map[string]interface{}{
+			"principal": "patris_pricing", "cursor": 0, "oldest_event_id": 0, "latest_event_id": 0,
+			"cursor_reset_required": false, "revision_validation_required": true,
+			"revision_path": "/wp-json/digitalogic/pricing/sync/revision",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	connected, err := client.handleExcelPricingRemoteFrame(t.Context(), body, false)
+	current, present := client.currentStreamSource()
+	if err != nil || !connected || current != sourceC || !present || requests.Load() != 2 ||
+		lifecycle.Mode != "reconcile_present" || lifecycle.Revision == nil {
+		t.Fatalf("connected=%v err=%v source=%+v present=%v requests=%d lifecycle=%+v",
+			connected, err, current, present, requests.Load(), lifecycle)
+	}
+}
+
+func TestExcelPricingRemoteConnectedRejectsCursorDiscontinuityBeforeValidation(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	for name, fixture := range map[string]struct {
+		initial uint64
+		cursor  uint64
+		oldest  uint64
+		latest  uint64
+	}{
+		"persisted cursor changed without reset": {initial: 5, cursor: 6, oldest: 1, latest: 7},
+		"new subscriber placed before latest":    {initial: 0, cursor: 0, oldest: 1, latest: 7},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests.Add(1)
+			}))
+			defer server.Close()
+			client, err := newExcelPricingRemoteEventsClient(
+				excelPricingRemoteTestConfig(t, server.URL), source,
+				excelPricingRemoteEventsOptions{
+					InitialCursor:     fixture.initial,
+					OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+					OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := json.Marshal(excelPricingRemoteTestConnectedFrame(
+				fixture.cursor, fixture.oldest, fixture.latest, false,
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.handleExcelPricingRemoteFrame(t.Context(), body, false); !errors.Is(err, errExcelPricingRemoteProtocol) {
+				t.Fatalf("cursor discontinuity error=%v", err)
+			}
+			if requests.Load() != 0 || client.currentCursor() != fixture.initial {
+				t.Fatalf("requests=%d cursor=%d", requests.Load(), client.currentCursor())
+			}
+		})
+	}
+}
+
+func TestExcelPricingRemoteStreamResetRejectsNonLatestCursorBeforeValidation(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), source,
+		excelPricingRemoteEventsOptions{
+			InitialCursor:     5,
+			OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"event": "pricing.stream.reset", "success": true,
+		"data": map[string]interface{}{
+			"schema": excelPricingRemoteStreamResetSchema, "schema_version": 1,
+			"reason": "cursor_gap", "cursor": 5, "oldest_event_id": 6, "latest_event_id": 10,
+			"revision_validation_required": true,
+			"revision_path":                "/wp-json/digitalogic/pricing/sync/revision",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); !errors.Is(frameErr, errExcelPricingRemoteProtocol) {
+		t.Fatalf("stream reset error = %v", frameErr)
+	}
+	if requests.Load() != 0 || client.currentCursor() != 5 {
+		t.Fatalf("requests=%d cursor=%d", requests.Load(), client.currentCursor())
+	}
+}
+
+func TestExcelPricingRemoteReplayPreservesAbsenceWhenSameRevisionWasReadded(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	state := excelPricingRemoteTestRevision("5")
+	var absent atomic.Bool
+	absent.Store(true)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("absent replay reconciliation used If-None-Match")
+		}
+		if absent.Load() {
+			excelPricingRemoteWriteAbsentRevision(w)
+			return
+		}
+		excelPricingRemoteWriteCurrentRevision(w, source, state)
+	}))
+	defer server.Close()
+	var modes []string
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), source,
+		excelPricingRemoteEventsOptions{
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: func(lifecycle excelPricingRemoteSourceLifecycle) error {
+				modes = append(modes, lifecycle.Mode)
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle := func(frame map[string]interface{}, connected bool) (bool, error) {
+		body, marshalErr := json.Marshal(frame)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		return client.handleExcelPricingRemoteFrame(t.Context(), body, connected)
+	}
+	if _, err := handle(excelPricingRemoteTestSourceFrame(
+		source, 1, "pricing.source.removed", "removed", source.Revision,
+		excelPricingRemoteTestRevision("1"),
+	), true); err != nil {
+		t.Fatalf("initial removal: %v", err)
+	}
+	absent.Store(false)
+	connected, err := handle(excelPricingRemoteTestConnectedFrame(1, 1, 2, false), false)
+	current, present := client.currentStreamSource()
+	if err != nil || !connected || current != source || present || client.currentCursor() != 1 {
+		t.Fatalf("replay connection=%v err=%v source=%+v present=%v cursor=%d",
+			connected, err, current, present, client.currentCursor())
+	}
+	if _, err := handle(excelPricingRemoteTestSourceFrame(
+		source, 2, "pricing.source.changed", "added", nil,
+		excelPricingRemoteTestRevision("2"),
+	), true); err != nil {
+		t.Fatalf("queued re-add: %v", err)
+	}
+	current, present = client.currentStreamSource()
+	if current != source || !present || client.currentCursor() != 2 || requests.Load() != 3 ||
+		strings.Join(modes, ",") != "ordered,validation_gap,ordered" {
+		t.Fatalf("source=%+v present=%v cursor=%d requests=%d modes=%v",
+			current, present, client.currentCursor(), requests.Load(), modes)
+	}
+}
+
+func TestExcelPricingRemoteSourceEventsRejectMalformedLifecycleProofs(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	next := source
+	next.Revision = excelPricingRemoteTestRevision("b")
+	for name, mutate := range map[string]func(map[string]interface{}){
+		"wrong exact source": func(frame map[string]interface{}) {
+			data := frame["data"].(map[string]interface{})
+			wrong := next
+			wrong.Dataset = "other.db"
+			data["source"] = wrong
+		},
+		"missing previous changed revision": func(frame map[string]interface{}) {
+			data := frame["data"].(map[string]interface{})
+			data["change"] = "changed"
+			data["previous_source_revision"] = nil
+		},
+		"removal name mismatch": func(frame map[string]interface{}) {
+			data := frame["data"].(map[string]interface{})
+			data["change"] = "removed"
+			data["previous_source_revision"] = source.Revision
+		},
+		"validation flag disabled": func(frame map[string]interface{}) {
+			data := frame["data"].(map[string]interface{})
+			data["revision_validation_required"] = false
+		},
+		"unexpected public field": func(frame map[string]interface{}) {
+			data := frame["data"].(map[string]interface{})
+			data["credential"] = "must-not-be-accepted"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, err := newExcelPricingRemoteEventsClient(
+				excelPricingRemoteTestConfig(t, "http://127.0.0.1:18080"), source,
+				excelPricingRemoteEventsOptions{
+					OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+					OnSourceLifecycle: func(excelPricingRemoteSourceLifecycle) error { return nil },
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			frame := excelPricingRemoteTestSourceFrame(
+				next, 1, "pricing.source.changed", "changed", source.Revision, excelPricingRemoteTestRevision("6"),
+			)
+			mutate(frame)
+			body, err := json.Marshal(frame)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, frameErr := client.handleExcelPricingRemoteFrame(t.Context(), body, true); !errors.Is(frameErr, errExcelPricingRemoteProtocol) {
+				t.Fatalf("frame error=%v", frameErr)
+			}
+			if client.currentCursor() != 0 {
+				t.Fatalf("malformed source event advanced cursor to %d", client.currentCursor())
+			}
+		})
+	}
+}
+
 func TestExcelPricingRemoteEventsRejectWrongSourceWeakETagAndUnmappedAlias(t *testing.T) {
 	source := excelPricingRemoteTestSource()
 	client, err := newExcelPricingRemoteEventsClient(
 		excelPricingRemoteTestConfig(t, "http://127.0.0.1:18080"), source,
-		excelPricingRemoteEventsOptions{OnRevision: func(excelPricingRemoteRevision) error { return nil }},
+		excelPricingRemoteEventsOptions{
+			OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -555,12 +1444,137 @@ func TestExcelPricingRemoteRevisionRejectsWeakValidator(t *testing.T) {
 	}))
 	defer server.Close()
 	client, err := newExcelPricingRemoteEventsClient(excelPricingRemoteTestConfig(t, server.URL), source,
-		excelPricingRemoteEventsOptions{OnRevision: func(excelPricingRemoteRevision) error { return nil }})
+		excelPricingRemoteEventsOptions{
+			OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+		})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := client.validateExcelPricingRemoteRevision(t.Context(), "connection_validation", 0); !errors.Is(err, errExcelPricingRemoteRevision) {
+	if err := client.reconcileExcelPricingRemoteRevision(t.Context(), "connection_validation", 0, false); !errors.Is(err, errExcelPricingRemoteRevision) {
 		t.Fatalf("revision error = %v", err)
+	}
+}
+
+func TestExcelPricingRemoteRevisionRejectsConflictingDuplicateETags(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	state := excelPricingRemoteTestRevision("7")
+	validETag := `"` + state + `"`
+	conflictingETag := `"` + excelPricingRemoteTestRevision("8") + `"`
+	for _, status := range []int{http.StatusOK, http.StatusNotModified} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("ETag", validETag)
+				w.Header().Add("ETag", conflictingETag)
+				if status == http.StatusNotModified {
+					w.WriteHeader(status)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(excelPricingRemoteTestRevisionPayload(source, state))
+			}))
+			defer server.Close()
+			client, err := newExcelPricingRemoteEventsClient(
+				excelPricingRemoteTestConfig(t, server.URL), source,
+				excelPricingRemoteEventsOptions{
+					OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+					OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conditional := status == http.StatusNotModified
+			if conditional {
+				client.setValidatedRevision(excelPricingRemoteRevision{
+					Source: source, StateRevision: state, ETag: validETag,
+				})
+			}
+			if _, probeErr := client.probeExcelPricingRemoteRevision(
+				t.Context(), source, conditional, "test", 0,
+			); !errors.Is(probeErr, errExcelPricingRemoteRevision) {
+				t.Fatalf("duplicate ETag error = %v", probeErr)
+			}
+		})
+	}
+}
+
+func TestExcelPricingRemoteRevisionRejectsNonIdentityResponseEncoding(t *testing.T) {
+	source := excelPricingRemoteTestSource()
+	state := excelPricingRemoteTestRevision("7")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("ETag", `"`+state+`"`)
+		_ = json.NewEncoder(w).Encode(excelPricingRemoteTestRevisionPayload(source, state))
+	}))
+	defer server.Close()
+	client, err := newExcelPricingRemoteEventsClient(
+		excelPricingRemoteTestConfig(t, server.URL), source,
+		excelPricingRemoteEventsOptions{
+			OnRevision:        func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, probeErr := client.probeExcelPricingRemoteRevision(
+		t.Context(), source, false, "test", 0,
+	); !errors.Is(probeErr, errExcelPricingRemoteRevision) {
+		t.Fatalf("content encoding error = %v", probeErr)
+	}
+}
+
+func TestExcelPricingRemoteRevisionConflictRequiresExplicitEnvelopeBooleans(t *testing.T) {
+	requested := excelPricingRemoteTestSource()
+	currentRevision := excelPricingRemoteTestRevision("b")
+	for _, code := range []string{
+		"digitalogic_pricing_snapshot_source_revision_conflict",
+		"digitalogic_excel_sync_source_scope_conflict",
+	} {
+		for _, missing := range []string{"success", "retryable"} {
+			t.Run(code+"/missing "+missing, func(t *testing.T) {
+				details := map[string]interface{}{"current_source": canonical.Source{}}
+				if code == "digitalogic_pricing_snapshot_source_revision_conflict" {
+					details = map[string]interface{}{
+						"submitted_source_revision": requested.Revision,
+						"current_source_revision":   currentRevision,
+						"retryable":                 false,
+					}
+				}
+				payload := map[string]interface{}{
+					"success": false, "code": code, "message": "conflict",
+					"retryable": false, "details": details,
+				}
+				delete(payload, missing)
+				body, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := excelPricingRemoteRevisionConflict(http.StatusConflict, body, requested); ok {
+					t.Fatalf("accepted conflict missing %q", missing)
+				}
+			})
+		}
+	}
+	for _, missing := range []string{"id", "dataset", "revision"} {
+		t.Run("empty current source missing "+missing, func(t *testing.T) {
+			currentSource := map[string]interface{}{"id": "", "dataset": "", "revision": ""}
+			delete(currentSource, missing)
+			body, err := json.Marshal(map[string]interface{}{
+				"success": false,
+				"code":    "digitalogic_excel_sync_source_scope_conflict",
+				"message": "conflict", "retryable": false,
+				"details": map[string]interface{}{"current_source": currentSource},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := excelPricingRemoteRevisionConflict(http.StatusConflict, body, requested); ok {
+				t.Fatalf("accepted current_source missing %q", missing)
+			}
+		})
 	}
 }
 
@@ -575,6 +1589,7 @@ func TestExcelPricingRemoteEventsErrorsDoNotExposeSecretOrResponse(t *testing.T)
 			MinReconnectBackoff: time.Millisecond,
 			MaxReconnectBackoff: 2 * time.Millisecond,
 			OnRevision:          func(excelPricingRemoteRevision) error { return nil },
+			OnSourceLifecycle:   excelPricingRemoteTestLifecycle,
 		},
 	)
 	if err != nil {
@@ -593,8 +1608,22 @@ func TestExcelPricingRemoteEventsErrorsDoNotExposeSecretOrResponse(t *testing.T)
 
 func TestExcelPricingRemoteEventsConstructorFailsClosedWithoutAcceptanceHook(t *testing.T) {
 	cfg := excelPricingRemoteTestConfig(t, "http://127.0.0.1:18080")
-	if _, err := newExcelPricingRemoteEventsClient(cfg, excelPricingRemoteTestSource(), excelPricingRemoteEventsOptions{}); !errors.Is(err, errExcelPricingRemoteConfiguration) {
-		t.Fatalf("constructor error = %v", err)
+	for name, options := range map[string]excelPricingRemoteEventsOptions{
+		"both hooks": {},
+		"revision hook": {
+			OnSourceLifecycle: excelPricingRemoteTestLifecycle,
+		},
+		"source lifecycle hook": {
+			OnRevision: func(excelPricingRemoteRevision) error { return nil },
+		},
+	} {
+		t.Run("missing "+name, func(t *testing.T) {
+			if _, err := newExcelPricingRemoteEventsClient(
+				cfg, excelPricingRemoteTestSource(), options,
+			); !errors.Is(err, errExcelPricingRemoteConfiguration) {
+				t.Fatalf("constructor error = %v", err)
+			}
+		})
 	}
 }
 
@@ -631,7 +1660,7 @@ func TestExcelPricingRemoteRevisionURLHasExactBoundedQuery(t *testing.T) {
 func TestExcelPricingRemoteEventDedupeRemainsBounded(t *testing.T) {
 	source := excelPricingRemoteTestSource()
 	client := &excelPricingRemoteEventsClient{
-		seen: make(map[string]struct{}),
+		seen: make(map[string]string),
 	}
 	for index := 0; index < excelPricingSnapshotEventHistory+20; index++ {
 		revision := excelPricingRemoteRevision{
@@ -653,7 +1682,7 @@ func TestExcelPricingRemoteCursorCallbackRunsAfterAcceptance(t *testing.T) {
 	accepted := false
 	callbackSawAccepted := false
 	client := &excelPricingRemoteEventsClient{
-		seen: make(map[string]struct{}),
+		seen: make(map[string]string),
 		onRevision: func(excelPricingRemoteRevision) error {
 			mu.Lock()
 			accepted = true

--- a/pkg/server/excel_pricing_remote_snapshot.go
+++ b/pkg/server/excel_pricing_remote_snapshot.go
@@ -238,6 +238,7 @@ type excelPricingRemoteSnapshotTerminalEvent struct {
 }
 
 type excelPricingRemoteSnapshotTerminalSubscription interface {
+	Valid() bool
 	Wait(context.Context) (excelPricingRemoteSnapshotTerminalEvent, error)
 	Close()
 }
@@ -256,6 +257,7 @@ type excelPricingRemoteSnapshotTerminalSource interface {
 
 type excelPricingRemoteSnapshotTerminalHub struct {
 	mu       sync.Mutex
+	epoch    uint64
 	nextID   uint64
 	waiters  map[string]map[uint64]*excelPricingRemoteSnapshotHubSubscription
 	history  map[string]excelPricingRemoteSnapshotTerminalEvent
@@ -263,8 +265,14 @@ type excelPricingRemoteSnapshotTerminalHub struct {
 	lastSeen uint64
 }
 
+type excelPricingRemoteSnapshotTerminalLease struct {
+	hub   *excelPricingRemoteSnapshotTerminalHub
+	epoch uint64
+}
+
 type excelPricingRemoteSnapshotHubSubscription struct {
 	hub       *excelPricingRemoteSnapshotTerminalHub
+	epoch     uint64
 	requestID string
 	id        uint64
 	channel   chan excelPricingRemoteSnapshotTerminalEvent
@@ -467,12 +475,70 @@ func deriveExcelPricingRemoteSnapshotEndpoints(productSyncURL string) (excelPric
 
 func newExcelPricingRemoteSnapshotTerminalHub() *excelPricingRemoteSnapshotTerminalHub {
 	return &excelPricingRemoteSnapshotTerminalHub{
+		epoch:   1,
 		waiters: make(map[string]map[uint64]*excelPricingRemoteSnapshotHubSubscription),
 		history: make(map[string]excelPricingRemoteSnapshotTerminalEvent),
 	}
 }
 
+func (hub *excelPricingRemoteSnapshotTerminalHub) authenticatedLease() excelPricingRemoteSnapshotTerminalSource {
+	if hub == nil {
+		return nil
+	}
+	hub.mu.Lock()
+	epoch := hub.epoch
+	hub.mu.Unlock()
+	return &excelPricingRemoteSnapshotTerminalLease{hub: hub, epoch: epoch}
+}
+
+func (hub *excelPricingRemoteSnapshotTerminalHub) resetAuthenticatedEpoch() {
+	if hub == nil {
+		return
+	}
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	hub.epoch++
+	if hub.epoch == 0 {
+		hub.epoch = 1
+	}
+	for _, waiters := range hub.waiters {
+		for _, subscription := range waiters {
+			close(subscription.channel)
+		}
+	}
+	hub.waiters = make(map[string]map[uint64]*excelPricingRemoteSnapshotHubSubscription)
+	hub.history = make(map[string]excelPricingRemoteSnapshotTerminalEvent)
+	hub.order = nil
+	hub.lastSeen = 0
+}
+
 func (hub *excelPricingRemoteSnapshotTerminalHub) Subscribe(
+	requestID string,
+	source canonical.Source,
+	stateRevision string,
+) (excelPricingRemoteSnapshotTerminalSubscription, error) {
+	if hub == nil {
+		return nil, errExcelPricingRemoteSnapshotConfiguration
+	}
+	hub.mu.Lock()
+	epoch := hub.epoch
+	hub.mu.Unlock()
+	return hub.subscribeAuthenticatedEpoch(epoch, requestID, source, stateRevision)
+}
+
+func (lease *excelPricingRemoteSnapshotTerminalLease) Subscribe(
+	requestID string,
+	source canonical.Source,
+	stateRevision string,
+) (excelPricingRemoteSnapshotTerminalSubscription, error) {
+	if lease == nil || lease.hub == nil || lease.epoch == 0 {
+		return nil, errExcelPricingRemoteSnapshotConfiguration
+	}
+	return lease.hub.subscribeAuthenticatedEpoch(lease.epoch, requestID, source, stateRevision)
+}
+
+func (hub *excelPricingRemoteSnapshotTerminalHub) subscribeAuthenticatedEpoch(
+	epoch uint64,
 	requestID string,
 	source canonical.Source,
 	stateRevision string,
@@ -483,9 +549,13 @@ func (hub *excelPricingRemoteSnapshotTerminalHub) Subscribe(
 	}
 	hub.mu.Lock()
 	defer hub.mu.Unlock()
+	if epoch == 0 || hub.epoch != epoch {
+		return nil, errExcelPricingRemoteSnapshotUnavailable
+	}
 	hub.nextID++
 	subscription := &excelPricingRemoteSnapshotHubSubscription{
 		hub:       hub,
+		epoch:     epoch,
 		requestID: requestID,
 		id:        hub.nextID,
 		channel:   make(chan excelPricingRemoteSnapshotTerminalEvent, 1),
@@ -548,15 +618,27 @@ func (subscription *excelPricingRemoteSnapshotHubSubscription) Wait(
 	if subscription == nil || subscription.channel == nil {
 		return excelPricingRemoteSnapshotTerminalEvent{}, errExcelPricingRemoteSnapshotConfiguration
 	}
+	if !subscription.Valid() {
+		return excelPricingRemoteSnapshotTerminalEvent{}, errExcelPricingRemoteSnapshotUnavailable
+	}
 	select {
 	case <-ctx.Done():
 		return excelPricingRemoteSnapshotTerminalEvent{}, ctx.Err()
 	case event, ok := <-subscription.channel:
-		if !ok {
+		if !ok || !subscription.Valid() {
 			return excelPricingRemoteSnapshotTerminalEvent{}, errExcelPricingRemoteSnapshotUnavailable
 		}
 		return event, nil
 	}
+}
+
+func (subscription *excelPricingRemoteSnapshotHubSubscription) Valid() bool {
+	if subscription == nil || subscription.hub == nil || subscription.epoch == 0 {
+		return false
+	}
+	subscription.hub.mu.Lock()
+	defer subscription.hub.mu.Unlock()
+	return subscription.hub.epoch == subscription.epoch
 }
 
 func (subscription *excelPricingRemoteSnapshotHubSubscription) Close() {
@@ -606,6 +688,12 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 		)
 	}
 	defer subscription.Close()
+	if !subscription.Valid() {
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageTerminalSubscription,
+			errExcelPricingRemoteSnapshotUnavailable,
+		)
+	}
 
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -624,6 +712,15 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 	}
 	build, status, err := client.startSnapshot(startContext, requestID, maxAgeSeconds, revision)
 	stopStart()
+	if !subscription.Valid() {
+		if build.BuildID != "" {
+			client.cancelSnapshot(build.CancelURL, build.BuildID)
+		}
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageTerminalWait,
+			errExcelPricingRemoteSnapshotUnavailable,
+		)
+	}
 	if err != nil {
 		if contextErr := ctx.Err(); contextErr != nil {
 			return nil, wrapExcelPricingRemoteSnapshotStage(
@@ -685,6 +782,13 @@ func (client *excelPricingRemoteSnapshotClient) Collect(
 			err,
 		)
 	}
+	if !subscription.Valid() {
+		client.cancelSnapshot(build.CancelURL, build.BuildID)
+		return nil, wrapExcelPricingRemoteSnapshotStage(
+			excelPricingRemoteSnapshotStageTerminalWait,
+			errExcelPricingRemoteSnapshotUnavailable,
+		)
+	}
 	return result, nil
 }
 
@@ -706,6 +810,9 @@ func (client *excelPricingRemoteSnapshotClient) fetchRevision(
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
 	}
 	defer response.Body.Close()
+	if !excelPricingRemoteIdentityResponseEncoding(response.Header) {
+		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotProtocol
+	}
 	if response.StatusCode != http.StatusOK {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotUnavailable
 	}
@@ -728,8 +835,8 @@ func (client *excelPricingRemoteSnapshotClient) fetchRevision(
 			payload.PricingStateRevision, payload.PricingPolicyRevision) {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotProtocol
 	}
-	etag := strings.TrimSpace(response.Header.Get("ETag"))
-	if !isStrongExcelPricingRevisionETag(etag, payload.StateRevision) {
+	etag, singleETag := excelPricingRemoteSingleETag(response.Header)
+	if !singleETag || !isStrongExcelPricingRevisionETag(etag, payload.StateRevision) {
 		return excelPricingRemoteSnapshotRevision{}, errExcelPricingRemoteSnapshotProtocol
 	}
 	return excelPricingRemoteSnapshotRevision{
@@ -834,6 +941,9 @@ func (client *excelPricingRemoteSnapshotClient) fetchSnapshot(
 		return nil, errExcelPricingRemoteSnapshotUnavailable
 	}
 	defer response.Body.Close()
+	if !excelPricingRemoteIdentityResponseEncoding(response.Header) {
+		return nil, errExcelPricingRemoteSnapshotProtocol
+	}
 	if response.StatusCode != http.StatusOK {
 		return nil, errExcelPricingRemoteSnapshotUnavailable
 	}
@@ -914,6 +1024,9 @@ func (client *excelPricingRemoteSnapshotClient) confirmSnapshotValidator(
 		return errExcelPricingRemoteSnapshotUnavailable
 	}
 	defer response.Body.Close()
+	if !excelPricingRemoteIdentityResponseEncoding(response.Header) {
+		return errExcelPricingRemoteSnapshotProtocol
+	}
 	if response.StatusCode != http.StatusNotModified {
 		return errExcelPricingRemoteSnapshotProtocol
 	}

--- a/pkg/server/excel_pricing_remote_snapshot_test.go
+++ b/pkg/server/excel_pricing_remote_snapshot_test.go
@@ -60,6 +60,13 @@ type excelPricingRemoteSnapshotFixture struct {
 
 type rejectingExcelPricingRemoteTerminalSource struct{}
 
+type pausedExcelPricingRemoteTerminalSource struct {
+	inner   excelPricingRemoteSnapshotTerminalSource
+	entered chan struct{}
+	resume  chan struct{}
+	once    sync.Once
+}
+
 type excelPricingRemoteSnapshotRoundTripFunc func(*http.Request) (*http.Response, error)
 
 type failingExcelPricingRemoteSnapshotReader struct{}
@@ -80,6 +87,30 @@ func (rejectingExcelPricingRemoteTerminalSource) Subscribe(
 	string,
 ) (excelPricingRemoteSnapshotTerminalSubscription, error) {
 	return nil, errors.New("private subscription implementation detail")
+}
+
+func (source *pausedExcelPricingRemoteTerminalSource) Subscribe(
+	requestID string,
+	snapshotSource canonical.Source,
+	stateRevision string,
+) (excelPricingRemoteSnapshotTerminalSubscription, error) {
+	source.once.Do(func() { close(source.entered) })
+	<-source.resume
+	return source.inner.Subscribe(requestID, snapshotSource, stateRevision)
+}
+
+func assertExcelPricingRemoteSnapshotStage(
+	t *testing.T,
+	err error,
+	wantStage string,
+	wantCode string,
+) {
+	t.Helper()
+	stage, code, ok := excelPricingRemoteSnapshotFailureDetails(err)
+	if !ok || stage != wantStage || code != wantCode {
+		t.Fatalf("failure details=(%q,%q,%v), want=(%q,%q,true): %v",
+			stage, code, ok, wantStage, wantCode, err)
+	}
 }
 
 func TestExcelPricingRemoteSnapshotReadyUsesOneBulkFetchWithoutStatusPolling(t *testing.T) {
@@ -249,6 +280,44 @@ func TestExcelPricingRemoteSnapshotIdentityEncodingPreservesOriginETags(t *testi
 		fixture.assertCalls(t, 1, 1, 1, 0, 0)
 		fixture.assertRepresentationCalls(t, 1, 0, 1, 0)
 	})
+}
+
+func TestExcelPricingRemoteSnapshotRejectsValidatorAndEncodingMetadataConflicts(t *testing.T) {
+	for name, fixtureCase := range map[string]struct {
+		mode        string
+		stage       string
+		code        string
+		revision    int
+		start       int
+		bulk        int
+		conditional int
+	}{
+		"duplicate revision ETag": {
+			mode: "revision_duplicate_etag", stage: excelPricingRemoteSnapshotStageRevisionFetch,
+			code: "snapshot_revision_fetch_protocol_failed", revision: 1,
+		},
+		"revision gzip metadata": {
+			mode: "revision_gzip_metadata", stage: excelPricingRemoteSnapshotStageRevisionFetch,
+			code: "snapshot_revision_fetch_protocol_failed", revision: 1,
+		},
+		"payload gzip metadata": {
+			mode: "payload_gzip_metadata", stage: excelPricingRemoteSnapshotStageSnapshotPayload,
+			code: "snapshot_payload_protocol_failed", revision: 1, start: 1, bulk: 1,
+		},
+		"fallback 304 gzip metadata": {
+			mode: "payload_missing_etag_gzip_confirmation", stage: excelPricingRemoteSnapshotStageSnapshotPayload,
+			code: "snapshot_payload_protocol_failed", revision: 1, start: 1, bulk: 2, conditional: 1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newExcelPricingRemoteSnapshotFixture(t, fixtureCase.mode)
+			defer fixture.Close()
+			_, err := fixture.Client(t).Collect(context.Background(), fixture.requestID, 60)
+			assertExcelPricingRemoteSnapshotStage(t, err, fixtureCase.stage, fixtureCase.code)
+			fixture.assertCalls(t, fixtureCase.revision, fixtureCase.start, fixtureCase.bulk, 0, 0)
+			fixture.assertConditionalPayloadCalls(t, fixtureCase.conditional)
+		})
+	}
 }
 
 func TestExcelPricingSnapshotProductionCollectorUsesBulkAndPreservesCompositeIdentity(t *testing.T) {
@@ -439,6 +508,47 @@ func TestExcelPricingSnapshotProductionCollectorColdTerminalAndCancel(t *testing
 		}
 		fixture.releaseHeldStart()
 		waitForExcelPricingSnapshotStatus(t, server, token, jobID, "cancelled")
+		fixture.assertCalls(t, 1, 1, 0, 0, 1)
+		fixture.assertNoLegacyStateCalls(t)
+	})
+
+	t.Run("configuration epoch change", func(t *testing.T) {
+		fixture := newExcelPricingRemoteSnapshotFixture(t, "cold_start_inflight")
+		defer fixture.Close()
+		fixture.acceptAnyID = true
+		server, token := newExcelPricingRemoteSnapshotProductionServer(t, fixture)
+		bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+			resolve:     excelPricingRemoteBridgeTestResolve,
+			fenceConfig: server.fenceExcelPricingRemoteConfiguration,
+		})
+		bridge.terminals = fixture.hub
+		bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-a"), false, false)
+		server.excelPricingRemote = bridge
+		server.excelPricing.snapshotRevisionCurrent = bridge.revisionCurrent
+
+		requestID := "snapshot-production-config-fence-0001"
+		request := authenticatedExcelPricingRequest(
+			http.MethodPost,
+			"/api/pricing-sync/snapshots",
+			validExcelPricingSnapshotStartBody(fixture.source, requestID, "fa", 0),
+			token,
+		)
+		request.Header.Set("Idempotency-Key", requestID)
+		response := httptest.NewRecorder()
+		server.router.ServeHTTP(response, request)
+		jobID := excelPricingSnapshotJobIDForTest(t, response.Body.Bytes())
+		select {
+		case <-fixture.startHeld:
+		case <-time.After(time.Second):
+			t.Fatal("remote cold build did not reach the in-flight response gate")
+		}
+
+		bridge.configChanged(excelPricingRemoteBridgeTestConfig("generation-b"))
+		fixture.releaseHeldStart()
+		status := waitForExcelPricingSnapshotStatus(t, server, token, jobID, "cancelled")
+		if status["code"] != "snapshot_remote_configuration_changed" {
+			t.Fatalf("configuration-fenced status=%#v", status)
+		}
 		fixture.assertCalls(t, 1, 1, 0, 0, 1)
 		fixture.assertNoLegacyStateCalls(t)
 	})
@@ -1382,6 +1492,105 @@ func TestExcelPricingRemoteSnapshotTerminalHubRejectsCursorRegressionAndConflict
 	}
 }
 
+func TestExcelPricingRemoteSnapshotTerminalHubRejectsQueuedTerminalAfterEpochReset(t *testing.T) {
+	fixture := newExcelPricingRemoteSnapshotFixture(t, "cold")
+	defer fixture.Close()
+	oldLease := fixture.hub.authenticatedLease()
+	oldSubscription, err := oldLease.Subscribe(
+		fixture.requestID, fixture.source, fixture.revision.StateRevision,
+	)
+	if err != nil {
+		t.Fatalf("old subscription: %v", err)
+	}
+	defer oldSubscription.Close()
+	oldTerminal := fixture.terminalEvent(9)
+	if err := fixture.hub.publishAuthenticated(oldTerminal); err != nil {
+		t.Fatalf("queue old terminal: %v", err)
+	}
+	fixture.hub.resetAuthenticatedEpoch()
+	if _, err := oldSubscription.Wait(t.Context()); !errors.Is(err, errExcelPricingRemoteSnapshotUnavailable) {
+		t.Fatalf("old queued terminal wait error = %v", err)
+	}
+
+	currentSubscription, err := fixture.hub.authenticatedLease().Subscribe(
+		fixture.requestID, fixture.source, fixture.revision.StateRevision,
+	)
+	if err != nil {
+		t.Fatalf("current subscription: %v", err)
+	}
+	defer currentSubscription.Close()
+	currentTerminal := fixture.terminalEvent(1)
+	if err := fixture.hub.publishAuthenticated(currentTerminal); err != nil {
+		t.Fatalf("queue current terminal: %v", err)
+	}
+	received, err := currentSubscription.Wait(t.Context())
+	if err != nil || received != currentTerminal {
+		t.Fatalf("current terminal=%+v err=%v", received, err)
+	}
+}
+
+func TestExcelPricingRemoteSnapshotCollectRejectsLeaseResetAfterRevisionFetch(t *testing.T) {
+	fixture := newExcelPricingRemoteSnapshotFixture(t, "ready")
+	defer fixture.Close()
+	bridge := newExcelPricingRemoteEventsBridgeWithDependencies(excelPricingRemoteBridgeDependencies{
+		resolve: excelPricingRemoteBridgeTestResolve,
+	})
+	bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-a"), false, false)
+	paused := &pausedExcelPricingRemoteTerminalSource{
+		inner: bridge.snapshotTerminals(), entered: make(chan struct{}), resume: make(chan struct{}),
+	}
+	client, err := newExcelPricingRemoteSnapshotClient(updateout.Config{
+		Enabled:              true,
+		URL:                  fixture.server.URL + "/wp-json/digitalogic/product-sync",
+		Method:               http.MethodPost,
+		Format:               "json",
+		Timeout:              "2s",
+		ProductSyncSecretEnv: excelPricingRemoteSnapshotTestSecretEnv,
+	}, fixture.source, excelPricingRemoteSnapshotClientOptions{
+		HTTPClient: fixture.server.Client(),
+		Terminals:  paused,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, collectErr := client.Collect(t.Context(), fixture.requestID, 60)
+		result <- collectErr
+	}()
+	select {
+	case <-paused.entered:
+	case <-time.After(excelPricingRemoteBridgeTestTimeout):
+		t.Fatal("Collect did not reach terminal subscription after revision fetch")
+	}
+	bridge.reconcile(excelPricingRemoteBridgeTestConfig("generation-b"), false, false)
+	close(paused.resume)
+	select {
+	case collectErr := <-result:
+		assertExcelPricingRemoteSnapshotStage(t, collectErr, excelPricingRemoteSnapshotStageTerminalSubscription,
+			"snapshot_terminal_subscription_failed")
+	case <-time.After(excelPricingRemoteBridgeTestTimeout):
+		t.Fatal("old-epoch Collect did not fail after terminal lease reset")
+	}
+
+	current, err := bridge.snapshotTerminals().Subscribe(
+		fixture.requestID, fixture.source, fixture.revision.StateRevision,
+	)
+	if err != nil {
+		t.Fatalf("new epoch lease subscribe: %v", err)
+	}
+	defer current.Close()
+	terminal := fixture.terminalEvent(1)
+	if err := bridge.terminals.publishAuthenticated(terminal); err != nil {
+		t.Fatalf("publish new epoch terminal: %v", err)
+	}
+	accepted, err := current.Wait(t.Context())
+	if err != nil || accepted != terminal {
+		t.Fatalf("accepted=%+v err=%v", accepted, err)
+	}
+	fixture.assertCalls(t, 1, 0, 0, 0, 0)
+}
+
 func TestExcelPricingRemoteSnapshotAuthenticatedStreamAcknowledgesOnlyAfterWaiterAccepts(t *testing.T) {
 	fixture := newExcelPricingRemoteSnapshotFixture(t, "cold")
 	defer fixture.Close()
@@ -1397,7 +1606,7 @@ func TestExcelPricingRemoteSnapshotAuthenticatedStreamAcknowledgesOnlyAfterWaite
 	client := &excelPricingRemoteEventsClient{
 		source:     fixture.source,
 		onTerminal: fixture.hub.publishAuthenticated,
-		seen:       make(map[string]struct{}),
+		seen:       make(map[string]string),
 	}
 	event := fixture.terminalEvent(0)
 	data := mustMarshalExcelPricingRemoteSnapshotTestJSON(t, event)
@@ -1425,7 +1634,7 @@ func TestExcelPricingRemoteSnapshotAuthenticatedStreamAcknowledgesOnlyAfterWaite
 		onTerminal: func(excelPricingRemoteSnapshotTerminalEvent) error {
 			return errors.New("retain failed")
 		},
-		seen: make(map[string]struct{}),
+		seen: make(map[string]string),
 	}
 	if _, err := rejecting.handleExcelPricingRemoteFrame(context.Background(), body, true); !errors.Is(err, errExcelPricingRemoteProtocol) {
 		t.Fatalf("rejected frame error = %v", err)
@@ -1536,6 +1745,18 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			)
 			return
 		}
+		if fixture.mode == "revision_duplicate_etag" {
+			w.Header().Add("ETag", `"`+fixture.revision.StateRevision+`"`)
+			w.Header().Add("ETag", `"`+testExcelPricingRevision('b')+`"`)
+			_ = json.NewEncoder(w).Encode(fixture.revision)
+			return
+		}
+		if fixture.mode == "revision_gzip_metadata" {
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("ETag", `"`+fixture.revision.StateRevision+`"`)
+			_ = json.NewEncoder(w).Encode(fixture.revision)
+			return
+		}
 		w.Header().Set("ETag", `"`+fixture.revision.StateRevision+`"`)
 		if fixture.mode == "revision_empty_body" {
 			return
@@ -1578,7 +1799,7 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			fixture.mode == "payload_wrong_content_type" ||
 			fixture.mode == "payload_empty_body" || fixture.mode == "payload_oversized_body" ||
 			fixture.mode == "payload_present_empty_etag" || fixture.mode == "payload_duplicate_etag" ||
-			fixture.mode == "payload_wrong_strong_etag" ||
+			fixture.mode == "payload_wrong_strong_etag" || fixture.mode == "payload_gzip_metadata" ||
 			strings.HasPrefix(fixture.mode, "payload_missing_etag_") {
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(build)
@@ -1663,6 +1884,9 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 				w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
 				w.Header().Add("ETag", `"`+fixture.payload.Digest+`"`)
 				w.WriteHeader(http.StatusNotModified)
+			case "payload_missing_etag_gzip_confirmation":
+				w.Header().Set("Content-Encoding", "gzip")
+				w.WriteHeader(http.StatusNotModified)
 			default:
 				http.Error(w, "unknown missing ETag mode", http.StatusInternalServerError)
 			}
@@ -1688,6 +1912,12 @@ func (fixture *excelPricingRemoteSnapshotFixture) handle(w http.ResponseWriter, 
 			fixture.writeIdentityBoundRepresentation(
 				w, r, fixture.payloadBody, fixture.payload.Digest, "payload",
 			)
+			return
+		}
+		if fixture.mode == "payload_gzip_metadata" {
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("ETag", `"`+fixture.payload.Digest+`"`)
+			_, _ = w.Write(fixture.payloadBody)
 			return
 		}
 		if fixture.badETag {

--- a/pkg/server/excel_pricing_snapshot.go
+++ b/pkg/server/excel_pricing_snapshot.go
@@ -1486,6 +1486,24 @@ func (s *Server) notifyExcelPricingSourceChanged(sourceChangeToken string) {
 	}
 }
 
+// fenceExcelPricingRemoteConfiguration synchronously makes every snapshot
+// started under the previous resolved remote configuration ineligible for
+// publication. The bridge invokes it before advancing its authenticated event
+// epoch, closing the window where a completed old-config response could become
+// ready while the replacement configuration is being installed.
+func (s *Server) fenceExcelPricingRemoteConfiguration() {
+	if s == nil || s.excelPricing == nil || s.excelPricing.snapshots == nil {
+		return
+	}
+	store := s.excelPricing.snapshots
+	store.mu.Lock()
+	cancel := store.invalidateGenerationLocked("snapshot_remote_configuration_changed")
+	store.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
 func (store *excelPricingSnapshotStore) publishPricingStateInvalidated(stateRevision string) {
 	store.mu.Lock()
 	previous := store.lastVerifiedChangeLocked()
@@ -1559,6 +1577,78 @@ func (s *Server) notifyExcelPricingRemoteRevisionChanged(
 		ETag:            revision.ETag,
 		Stale:           true,
 		Verified:        true,
+	}
+	bindExcelPricingPreviousState(&event, previous)
+	store.publishChangeLocked(event)
+	store.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+// notifyExcelPricingRemoteSourceLifecycle synchronously applies one accepted
+// source transition. It fences the old generation and publishes exactly one
+// source-change record before the subscriber may acknowledge its cursor.
+func (s *Server) notifyExcelPricingRemoteSourceLifecycle(
+	lifecycle excelPricingRemoteSourceLifecycle,
+) error {
+	if s == nil || !validExcelPricingRemoteSource(lifecycle.Source) ||
+		!validExcelPricingRemoteLifecycleValidation(lifecycle) {
+		return errExcelPricingRemoteRevision
+	}
+	if lifecycle.Revision != nil &&
+		(lifecycle.Revision.Source != lifecycle.Source ||
+			!validExcelPricingRemoteRevisionParts(
+				lifecycle.Revision.StateRevision,
+				lifecycle.Revision.CatalogRevision,
+				lifecycle.Revision.PricingStateRevision,
+				lifecycle.Revision.PricingPolicyRevision,
+			) || !isStrongExcelPricingRevisionETag(
+			lifecycle.Revision.ETag,
+			lifecycle.Revision.StateRevision,
+		)) {
+		return errExcelPricingRemoteRevision
+	}
+	reason := ""
+	switch lifecycle.Mode {
+	case "ordered":
+		switch lifecycle.Change {
+		case "added":
+			reason = "upstream_source_added"
+		case "changed":
+			reason = "upstream_source_changed"
+		case "removed":
+			reason = "upstream_source_removed"
+		}
+	case "validation_gap":
+		reason = "upstream_source_validation_gap"
+	case "reconcile_present":
+		reason = "upstream_source_reconciled"
+	case "reconcile_absent":
+		reason = "upstream_source_absence_reconciled"
+	}
+	if reason == "" {
+		return errExcelPricingRemoteRevision
+	}
+	s.invalidateCanonicalProjection(true)
+
+	store := s.excelPricing.snapshots
+	store.mu.Lock()
+	previous := store.lastVerifiedChangeLocked()
+	cancel := store.invalidateGenerationLocked("snapshot_source_changed")
+	source := lifecycle.Source
+	event := excelPricingStateChangeEvent{
+		Kind:     "source_changed",
+		Reason:   reason,
+		Source:   &source,
+		Stale:    true,
+		Verified: true,
+	}
+	if lifecycle.Revision != nil {
+		event.CatalogRevision = lifecycle.Revision.CatalogRevision
+		event.StateRevision = lifecycle.Revision.StateRevision
+		event.ETag = lifecycle.Revision.ETag
 	}
 	bindExcelPricingPreviousState(&event, previous)
 	store.publishChangeLocked(event)

--- a/pkg/server/excel_pricing_snapshot_test.go
+++ b/pkg/server/excel_pricing_snapshot_test.go
@@ -1922,6 +1922,73 @@ func TestExcelPricingSnapshotUpstreamCatalogInvalidationIsAtomic(t *testing.T) {
 	}
 }
 
+func TestExcelPricingSnapshotUpstreamSourceRemovalIsAtomic(t *testing.T) {
+	server := newExcelPricingTestServer(t, "http://127.0.0.1:1/wp-json/digitalogic/patris/product-sync")
+	store := server.excelPricing.snapshots
+	source := excelPricingStateSourceForTest()
+	previousCatalog := excelPricingRevisionForTest("removed-previous-catalog")
+	previousState := excelPricingRevisionForTest("removed-previous-state")
+	previousSnapshot := excelPricingRevisionForTest("removed-previous-snapshot")
+	previousETag := `"` + excelPricingRevisionForTest("removed-previous-payload") + `"`
+	owner := sha256.Sum256([]byte("removed-owner"))
+	cancelContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store.mu.Lock()
+	store.publishChangeLocked(excelPricingStateChangeEvent{
+		Kind:             "snapshot_ready",
+		Source:           &source,
+		CatalogRevision:  previousCatalog,
+		StateRevision:    previousState,
+		SnapshotRevision: previousSnapshot,
+		ETag:             previousETag,
+		Verified:         true,
+	})
+	store.jobs["removed-leader"] = &excelPricingSnapshotJob{
+		id:              "removed-leader",
+		owner:           owner,
+		status:          "running",
+		startGeneration: store.generation,
+		cancel:          cancel,
+	}
+	store.activeJobID = "removed-leader"
+	initialGeneration := store.generation
+	store.mu.Unlock()
+
+	if err := server.notifyExcelPricingRemoteSourceLifecycle(excelPricingRemoteSourceLifecycle{
+		Mode:                   "ordered",
+		Name:                   "pricing.source.removed",
+		Change:                 "removed",
+		Source:                 source,
+		PreviousSourceRevision: source.Revision,
+		IdempotencyKey:         excelPricingRevisionForTest("removed-idempotency"),
+		EventID:                21,
+		ValidationOrigin:       "source_event",
+		ValidationOutcome:      excelPricingRemoteSourceAbsent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-cancelContext.Done():
+	case <-time.After(time.Second):
+		t.Fatal("upstream source removal did not cancel active leader")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.generation != initialGeneration+1 || store.jobs["removed-leader"].status != "cancelling" ||
+		len(store.cache) != 0 {
+		t.Fatalf("removal generation=%d leader=%+v cache=%d",
+			store.generation, store.jobs["removed-leader"], len(store.cache))
+	}
+	change := store.events[len(store.events)-1].Change
+	if change == nil || change.Kind != "source_changed" || change.Reason != "upstream_source_removed" ||
+		change.Source == nil || *change.Source != source || !change.Stale || !change.Verified ||
+		change.PreviousCatalogRevision != previousCatalog || change.PreviousStateRevision != previousState ||
+		change.PreviousSnapshotRevision != previousSnapshot || change.PreviousETag != previousETag {
+		t.Fatalf("source-removal event=%+v", change)
+	}
+}
+
 func TestExcelPricingSnapshotWaitDisconnectCancelsRemoteWork(t *testing.T) {
 	source := excelPricingStateSourceForTest()
 	started := make(chan struct{})


### PR DESCRIPTION
Fixes #273
Related to #230

Counterpart contract: https://github.com/atomicdeploy/digitalogic-wp/pull/212

## Outcome

- accepts strict ordered `pricing.source.changed` and `pricing.source.removed` lifecycle frames before matching state events
- validates each transition with one unconditional identity revision GET and distinguishes current, superseded, and absent outcomes without conflating source revision, composite state revision, payload digest, or HTTP validator
- applies lifecycle invalidation synchronously before dedupe/cursor mutation, then tracks the current source plus bounded accepted-source lineage across cursor-preserving reconnects
- resets cursor, lineage, terminal history, and authenticated terminal leases together on explicit local/config epochs
- rejects stale subscriptions both before and after terminal delivery, including queued pre-reset events and immediate-ready snapshot responses
- synchronously cancels/fences local snapshot generations on resolved remote configuration replacement
- rejects non-identity response encoding and ambiguous/missing/weak/conflicting strong ETags on identity-bound revision and payload reads

## Verification on exact commit

- aggregate SHA-256 for the eight changed file bytes: `377da26cbcd47f931ba7115d65ab1e2f67e0720a4efcaa093d75f18abb134c53`
- focused `TestExcelPricing(Remote|Snapshot)` suite: pass
- focused race suite: pass
- full `go test ./... -count=1`: pass with dynamic, CGO, and static-CGO pxlib backends
- full `go vet ./...`: pass with dynamic, CGO, and static-CGO pxlib backends
- web: 75 tests, production build, and production dependency audit with 0 vulnerabilities
- privileged JavaScript hosts: syntax checks and 29 tests
- delivery adapters: 13 tests
- `git diff --check`: pass

## Remaining gates

- GitHub Linux/Windows/SQL/package/installer checks on this exact head
- reciprocal WordPress source review, CI, package, deployment, daemon restart, and live authenticated event/replay/ETag readback
- Patris package/cutover only after the reciprocal production contract is proven
- fresh workbook synchronization, derived-instance promotion, and native Excel/Desktop cold-open/interaction/reopen evidence

## Deployment state

Draft/source-only. No production, installed Patris executable, Desktop workbook, live sync, notification, schedule, service, or configuration was changed.